### PR TITLE
Compatibility fixes with vLLM v0.24.0

### DIFF
--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from dataclasses import dataclass, fields, replace
@@ -13,7 +14,16 @@ import ttnn
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOutput
 
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.structured_output import has_structured_outputs
+
+logger = init_tt_logger(__name__)
+
+# Verbose mrope/decode-reset tracing, off by default. Enable by exporting
+# ``VLLM_TT_DEBUG_MROPE=1`` on the server process to confirm the rope-delta
+# re-application on the prefill->decode transition (see ``submit_decode``).
+_DEBUG_MROPE_ENV = os.environ.get("VLLM_TT_DEBUG_MROPE", "")
+DEBUG_MROPE = _DEBUG_MROPE_ENV not in ("", "0", "false", "False")
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -606,18 +616,44 @@ class TTAsyncDecodeController:
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
-            if any(
+            # Re-apply per-request mrope deltas whenever the decode inputs are
+            # (re)staged from host: either the batch's request set changed, or a
+            # full input reset is in effect (the first decode after a
+            # prefill->decode switch, or a slot remap). ``reset_batch`` forces
+            # the model to rebuild ``rot_mat_idxs = current_pos + rope_deltas``
+            # from host, so ``rope_setup.rope_deltas`` must already be current
+            # for THIS batch. Gating only on ``previous_req_ids`` let a reset
+            # rebuild positions with a stale (zero) delta, silently corrupting
+            # multimodal decode while text (delta == 0) looked fine.
+            new_reqs = any(
                 req_id not in runner.previous_req_ids
                 for req_id in runner.input_batch.req_ids
-            ):
-                enc_dec_kwargs = {
-                    "rope_deltas_all_users": [
-                        runner.requests[req_id].mrope_position_delta
-                        for req_id in runner.input_batch.req_ids
-                    ]
-                }
+            )
+            if new_reqs or model_input.reset_batch:
+                rope_deltas_all_users = [
+                    runner.requests[req_id].mrope_position_delta
+                    for req_id in runner.input_batch.req_ids
+                ]
+                enc_dec_kwargs = {"rope_deltas_all_users": rope_deltas_all_users}
+                if DEBUG_MROPE:
+                    logger.info(
+                        "[mrope] re-apply rope_deltas: new_reqs=%s reset_batch=%s "
+                        "req_ids=%s deltas=%s prev_req_ids=%s",
+                        new_reqs,
+                        model_input.reset_batch,
+                        list(runner.input_batch.req_ids),
+                        rope_deltas_all_users,
+                        sorted(runner.previous_req_ids),
+                    )
             else:
                 enc_dec_kwargs = {"rope_deltas_all_users": None}
+                if DEBUG_MROPE:
+                    logger.info(
+                        "[mrope] skip rope_deltas (steady decode): req_ids=%s "
+                        "reset_batch=%s",
+                        list(runner.input_batch.req_ids),
+                        model_input.reset_batch,
+                    )
             runner.previous_req_ids = set(runner.input_batch.req_ids)
 
         enable_trace = runner.trace_mode in ["all", "decode_only"]

--- a/src/vllm_tt_plugin/engine.py
+++ b/src/vllm_tt_plugin/engine.py
@@ -323,7 +323,13 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
     def _dp_negotiate_forced_mode(self) -> TTSchedulingMode:
         has_running = bool(getattr(self.scheduler, "running", []))
-        has_waiting = bool(getattr(self.scheduler, "waiting", False))
+        # ``skipped_waiting`` holds prefill requests blocked on grammar
+        # compilation; count them so a rank with only grammar-blocked
+        # structured-output work still signals prefill intent instead of
+        # letting the base scheduler promote them into a gathered decode step.
+        has_waiting = bool(getattr(self.scheduler, "waiting", False)) or bool(
+            getattr(self.scheduler, "skipped_waiting", False)
+        )
         max_running = getattr(self.scheduler, "max_num_running_reqs", 0)
         has_capacity = len(getattr(self.scheduler, "running", [])) < max_running
         local_prefill_intent = (

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -356,8 +356,14 @@ class TTLaneCoordinator(SchedulerInterface):
         A lane wants to prefill when it has queued requests and either nothing
         running (so it must prefill to make progress) or spare capacity to admit
         more alongside its running decodes.
+
+        ``skipped_waiting`` holds prefill requests blocked on grammar
+        compilation and counts as queued work: without it a lane whose only
+        pending request is a grammar-blocked structured-output request would
+        signal decode-only, and the base scheduler could then promote that
+        request into a mixed prefill+decode step.
         """
-        has_waiting = bool(sched.waiting)
+        has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)
         has_capacity = len(sched.running) < self._per_lane_max
         return int(has_waiting and ((not has_running) or has_capacity))

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -33,6 +33,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_tt_plugin.async_decode import (
+    DEBUG_MROPE,
     AsyncTTModelRunnerOutput,
     CompletedDecodeStep,
     DeferredDecodeOutput,
@@ -2373,6 +2374,13 @@ class TTModelRunner:
             # Store rope_deltas for each prefilled request
             for i, req_id in enumerate(self.input_batch.req_ids):
                 self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
+                if DEBUG_MROPE:
+                    logger.info(
+                        "[mrope] prefill stored mrope_position_delta: "
+                        "req_id=%s delta=%s",
+                        req_id,
+                        self.requests[req_id].mrope_position_delta,
+                    )
             return tt_out
         return self.model.prefill_forward(**kwargs)
 

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -114,9 +114,7 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     parallel_config.distributed_executor_backend = "uni"
 
 
-def _convert_gather_dp_to_lanes(
-    vllm_config: "VllmConfig", model_class=None
-) -> None:
+def _convert_gather_dp_to_lanes(vllm_config: "VllmConfig", model_class=None) -> None:
     """Transparently convert gathered multi-process DP into in-process TT lanes.
 
     Models that run as a single shared device execute on one mesh -- the Galaxy

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -441,6 +441,15 @@ class TTPlatform(Platform):
         pass
 
     @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        # No-op: TT device context is owned by the ttnn mesh device opened in
+        # TTWorker.init_device, not by a torch device context. torch has no "tt"
+        # backend to switch to, so the base Platform.set_device raises
+        # NotImplementedError. vLLM's multiproc executor calls this from its
+        # async-output-copy thread, which would crash that thread without this.
+        pass
+
+    @classmethod
     def is_async_output_supported(cls, enforce_eager: bool | None) -> bool:
         return True
 

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -525,6 +525,17 @@ class TTPlatform(Platform):
             )
             model_config.max_logprobs = MAX_TOP_K
 
+        # Force the grammar backends to emit compact JSON. xgrammar and guidance
+        # allow arbitrary inter-field whitespace by default; under greedy decoding
+        # the model can pick a whitespace token as the argmax indefinitely,
+        # exhausting the token budget before it emits a property name and
+        # returning truncated, unparseable JSON. Masking whitespace out of the
+        # grammar makes that loop structurally impossible for any decoding
+        # strategy. Backend stays "auto" so schemas xgrammar cannot compile still
+        # fall back to guidance (which also honors this flag); outlines and
+        # lm-format-enforcer ignore it.
+        vllm_config.structured_outputs_config.disable_any_whitespace = True
+
         # Opt into vLLM's auto-fit of max_model_len against the KV cache the TT
         # device can actually hold. The TT worker sizes the KV cache from the
         # model's total token budget (max_tokens_all_users) and pins it via

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -54,6 +54,26 @@ def _galaxy_generator_version() -> str | None:
     return None
 
 
+# GPT-OSS is served by the tt_transformers generator, which drives data
+# parallelism inside a single process -- either user-row sharding on multi-row
+# meshes or one Generator over per-DP submeshes. Gathered multi-process DP is
+# therefore unnecessary: --data_parallel_size folds into in-process TT lanes,
+# the same as the Galaxy generators.
+_GPT_OSS_ARCH = "GptOssForCausalLM"
+
+
+def _model_folds_gather_dp_into_lanes(model_class) -> bool:
+    """Whether the model's gathered multi-process DP folds into in-process lanes.
+
+    True for the Galaxy generators and for GPT-OSS, both of which drive data
+    parallelism within a single process. Other models keep gathered
+    multi-process DP.
+    """
+    if _galaxy_generator_version() is not None:
+        return True
+    return getattr(model_class, "__name__", None) == _GPT_OSS_ARCH
+
+
 def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     """Reset DP-derived ParallelConfig fields to single-process values.
 
@@ -94,14 +114,17 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     parallel_config.distributed_executor_backend = "uni"
 
 
-def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
+def _convert_gather_dp_to_lanes(
+    vllm_config: "VllmConfig", model_class=None
+) -> None:
     """Transparently convert gathered multi-process DP into in-process TT lanes.
 
-    Galaxy-generator models (``llama3_70b_galaxy``, ``qwen3_32b_galaxy``) are
-    served by a single Galaxy device mesh. Gathered multi-process DP is
-    deprecated in favor of single-process TT lanes. Rather than asking users to
-    migrate flags, we run ``--data_parallel_size N`` as ``N`` in-process lanes:
-    record the resolved lane count and reset ``data_parallel_size`` to 1.
+    Models that run as a single shared device execute on one mesh -- the Galaxy
+    generators (``llama3_70b_galaxy``, ``qwen3_32b_galaxy``) and GPT-OSS under
+    user-row sharding -- do not need gathered multi-process DP. Rather than
+    asking users to migrate flags, we run ``--data_parallel_size N`` as ``N``
+    in-process lanes: record the resolved lane count and reset
+    ``data_parallel_size`` to 1.
 
     To preserve the historical capacity contract -- where each of the ``N``
     gathered DP ranks handled ``max_num_seqs`` requests -- the global
@@ -110,16 +133,15 @@ def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
     value the user requested (e.g. ``--data_parallel_size 4 --max_num_seqs 8``
     becomes 4 lanes, each with max 8 seqs, for a global max of 32).
 
-    No-op unless a Galaxy-generator model is active with
-    ``data_parallel_size > 1``. Idempotent: after conversion
-    ``data_parallel_size == 1``, so re-entry short-circuits.
+    No-op unless ``data_parallel_size > 1`` and the model folds gathered DP
+    into lanes (``_model_folds_gather_dp_into_lanes``). Idempotent: after
+    conversion ``data_parallel_size == 1``, so re-entry short-circuits.
     """
     parallel_config = vllm_config.parallel_config
     data_parallel_size = parallel_config.data_parallel_size
     if data_parallel_size <= 1:
         return
-    galaxy_version = _galaxy_generator_version()
-    if galaxy_version is None:
+    if not _model_folds_gather_dp_into_lanes(model_class):
         return
 
     lanes = data_parallel_size
@@ -132,11 +154,10 @@ def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
     _collapse_parallel_config_to_single_process(parallel_config)
 
     logger.info(
-        "Galaxy model %s requested DP "
-        "(--data_parallel_size=%d); running single-process TT lane-DP instead "
+        "Model requested gathered DP (--data_parallel_size=%d) but runs as a "
+        "single device execute; running single-process TT lane-DP instead "
         "(%d lanes, per-lane max_num_seqs=%d, global max_num_seqs=%d).",
-        galaxy_version,
-        lanes,
+        data_parallel_size,
         lanes,
         per_lane_max_num_seqs,
         global_max_num_seqs,
@@ -637,12 +658,13 @@ class TTPlatform(Platform):
             )
             vllm_config.scheduler_config.async_scheduling = False
 
-        # Galaxy-generator models (Llama3 70B, Qwen3-32B) are served by a single
-        # device mesh. Convert
-        # it transparently into single-process TT lanes so users keep passing
-        # --data_parallel_size with no other flag changes. Must run before the
-        # validation/routing below so the lane path is selected.
-        _convert_galaxy_gather_dp_to_lanes(vllm_config)
+        # Single-execute models (Galaxy generators, GPT-OSS under user-row
+        # sharding) run one shared device execute on the full mesh, so gathered
+        # multi-process DP is folded transparently into single-process TT lanes
+        # -- users keep passing --data_parallel_size with no other flag changes.
+        # Must run before the validation/routing below so the lane path is
+        # selected. model_class carries the single-execute decision for GPT-OSS.
+        _convert_gather_dp_to_lanes(vllm_config, model_class)
 
         if uses_tt_lane_coordinator(vllm_config):
             # Fail fast on misconfiguration: lane mode requires max_num_seqs to

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -504,6 +504,19 @@ class TTPlatform(Platform):
             )
             model_config.max_logprobs = MAX_TOP_K
 
+        # Opt into vLLM's auto-fit of max_model_len against the KV cache the TT
+        # device can actually hold. The TT worker sizes the KV cache from the
+        # model's total token budget (max_tokens_all_users) and pins it via
+        # cache_config.num_gpu_blocks_override, which is decoupled from the
+        # model's per-request max_model_len (often the HF default, e.g. 262144).
+        # vLLM's _check_enough_kv_cache_memory raises when max_model_len needs
+        # more KV than the override provides. Setting original_max_model_len=-1
+        # makes get_kv_cache_configs run _auto_fit_max_model_len, which clamps
+        # max_model_len down to the largest length the override-backed capacity
+        # can serve (it never expands, so a smaller user-set max_model_len is
+        # preserved) and syncs the reduced value to workers.
+        model_config.original_max_model_len = -1
+
         # Import and register models from tt-metal.
         #
         # NOTE: We also register TT models early in `vllm_tt_plugin.worker`

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -36,6 +36,14 @@ class TTScheduler(AsyncScheduler):
       or all-decode.
     - No chunked prefill: each prefill must be scheduled in full.
 
+    The base scheduler holds prefill requests that are temporarily blocked
+    (e.g. ``WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR`` while a grammar compiles)
+    in a separate ``skipped_waiting`` queue, not ``waiting``. Its waiting loop
+    drains both queues and can promote a now-ready blocked request into the
+    same step that schedules running decodes. To preserve the all-prefill or
+    all-decode invariant, every place that inspects or hides pending prefill
+    work must treat ``waiting`` and ``skipped_waiting`` together.
+
     Inherits from AsyncScheduler to get num_output_placeholders support.
     TT uses this scheduler in both sync and async execution modes:
     - with async_scheduling=False, it behaves as the single TT scheduler
@@ -65,8 +73,17 @@ class TTScheduler(AsyncScheduler):
     def set_forced_mode(self, mode: TTSchedulingMode) -> None:
         self._forced_mode = mode
 
+    def _has_pending_prefill(self) -> bool:
+        """Whether any request is waiting to be prefilled.
+
+        Includes ``skipped_waiting`` so a request blocked on grammar
+        compilation still routes scheduling through the prefill-only path
+        instead of leaking into a decode step.
+        """
+        return bool(self.waiting) or bool(self.skipped_waiting)
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        has_waiting = bool(self.waiting)
+        has_waiting = self._has_pending_prefill()
         has_running = bool(self.running)
         mode = self._forced_mode
 
@@ -129,17 +146,23 @@ class TTScheduler(AsyncScheduler):
     def _schedule_decode_only(self, throttle_prefills: bool = False) -> SchedulerOutput:
         """Schedule only running (decode) requests.
 
-        Temporarily hides the waiting queue so the base scheduler's
-        waiting loop is a no-op.  Any requests that get preempted
-        during decode scheduling are merged back into the original
-        waiting queue afterwards.
+        Temporarily hides both the ``waiting`` and ``skipped_waiting`` queues
+        so the base scheduler's waiting loop is a no-op and cannot promote a
+        grammar-ready structured-output request into this decode step.  Any
+        requests that get preempted during decode scheduling are merged back
+        into the original queues afterwards.
         """
         saved_waiting = self.waiting
+        saved_skipped_waiting = self.skipped_waiting
         self.waiting = create_request_queue(self.policy)
+        self.skipped_waiting = create_request_queue(self.policy)
         try:
             result = super().schedule(throttle_prefills)
         finally:
             if self.waiting:
                 saved_waiting.prepend_requests(self.waiting)
+            if self.skipped_waiting:
+                saved_skipped_waiting.prepend_requests(self.skipped_waiting)
             self.waiting = saved_waiting
+            self.skipped_waiting = saved_skipped_waiting
         return result

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -311,6 +311,17 @@ class TTWorker(WorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
+    def update_max_model_len(self, max_model_len: int) -> None:
+        # The engine calls this via collective_rpc after get_kv_cache_configs
+        # auto-fits max_model_len down to the KV cache the TT device can hold
+        # (TTPlatform.check_and_update_config opts in by setting
+        # original_max_model_len=-1). WorkerBase has no such hook -- only the GPU
+        # worker defines it -- so TTWorker must provide it or the RPC raises
+        # AttributeError. TTModelRunner reads self.model_config.max_model_len
+        # directly for KV-cache sizing and per-request bounds, so updating the
+        # shared model_config is sufficient; it keeps no separate cached copy.
+        self.model_config.max_model_len = max_model_len
+
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Newer vLLM reduces per-worker timings returned here into
         # compilation_config.compilation_time; older vLLM ignores the return.

--- a/tests/test_galaxy_dp_conversion.py
+++ b/tests/test_galaxy_dp_conversion.py
@@ -125,9 +125,7 @@ def test_gpt_oss_gather_dp_converted_to_lanes(monkeypatch):
     monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
     config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
 
-    tt_platform._convert_gather_dp_to_lanes(
-        config, _model_class("GptOssForCausalLM")
-    )
+    tt_platform._convert_gather_dp_to_lanes(config, _model_class("GptOssForCausalLM"))
 
     assert config.parallel_config.data_parallel_size == 1
     assert tt_config.get_tt_data_parallel_size(config) == 4
@@ -143,9 +141,7 @@ def test_non_gpt_oss_model_not_converted(monkeypatch):
     monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
     config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
 
-    tt_platform._convert_gather_dp_to_lanes(
-        config, _model_class("LlamaForCausalLM")
-    )
+    tt_platform._convert_gather_dp_to_lanes(config, _model_class("LlamaForCausalLM"))
 
     assert config.parallel_config.data_parallel_size == 4
     assert tt_config._RESOLVED_LANE_COUNT_KEY not in config.additional_config

--- a/tests/test_galaxy_dp_conversion.py
+++ b/tests/test_galaxy_dp_conversion.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 """Host tests for the transparent gathered-DP -> single-process lane conversion.
 
-Galaxy-generator models (llama3_70b_galaxy, qwen3_32b_galaxy) are served on a
-single device mesh, so ``--data_parallel_size N`` is folded into ``N``
-in-process TT lanes by ``platform._convert_galaxy_gather_dp_to_lanes``.
+Single-execute models are served on one device mesh, so ``--data_parallel_size
+N`` is folded into ``N`` in-process TT lanes by
+``platform._convert_gather_dp_to_lanes``. This covers the Galaxy generators
+(llama3_70b_galaxy, qwen3_32b_galaxy) and GPT-OSS under user-row sharding.
 """
 
 from types import SimpleNamespace
@@ -29,11 +30,16 @@ def _vllm_config(*, data_parallel_size, max_num_seqs):
     )
 
 
+def _model_class(name):
+    """A stand-in model class whose ``__name__`` drives GPT-OSS detection."""
+    return type(name, (), {})
+
+
 def test_galaxy_gather_dp_converted_to_lanes(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Gathered DP collapsed to a single in-process engine with 4 lanes.
     assert config.parallel_config.data_parallel_size == 1
@@ -48,7 +54,7 @@ def test_qwen3_galaxy_gather_dp_converted_to_lanes(monkeypatch):
     monkeypatch.setenv("TT_QWEN3_TEXT_VER", "qwen3_32b_galaxy")
     config = _vllm_config(data_parallel_size=2, max_num_seqs=16)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     assert config.parallel_config.data_parallel_size == 1
     assert tt_config.get_tt_data_parallel_size(config) == 2
@@ -61,7 +67,7 @@ def test_collapse_resets_derived_parallel_fields(monkeypatch):
     config.parallel_config.data_parallel_size_local = 4
     config.parallel_config.data_parallel_external_lb = True
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     pc = config.parallel_config
     assert pc.data_parallel_size_local == 1
@@ -75,12 +81,12 @@ def test_collapse_resets_derived_parallel_fields(monkeypatch):
     assert pc.data_parallel_hybrid_lb is False
 
 
-def test_no_conversion_for_non_galaxy_model(monkeypatch):
+def test_no_conversion_for_non_single_execute_model(monkeypatch):
     monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
     monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Left as gathered multi-process DP, untouched.
     assert config.parallel_config.data_parallel_size == 4
@@ -92,7 +98,7 @@ def test_conversion_is_noop_without_dp(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=1, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     assert config.parallel_config.data_parallel_size == 1
     assert config.scheduler_config.max_num_seqs == 8
@@ -103,10 +109,43 @@ def test_conversion_is_idempotent(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Second call short-circuits (data_parallel_size already 1); no double scale.
     assert config.parallel_config.data_parallel_size == 1
     assert config.scheduler_config.max_num_seqs == 32
     assert tt_config.get_tt_data_parallel_size(config) == 4
+
+
+def test_gpt_oss_gather_dp_converted_to_lanes(monkeypatch):
+    # GPT-OSS drives DP inside one process, so gathered DP folds into lanes
+    # regardless of mesh shape or batch size.
+    monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
+    monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
+    config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
+
+    tt_platform._convert_gather_dp_to_lanes(
+        config, _model_class("GptOssForCausalLM")
+    )
+
+    assert config.parallel_config.data_parallel_size == 1
+    assert tt_config.get_tt_data_parallel_size(config) == 4
+    assert tt_config.uses_tt_lane_coordinator(config)
+    # Per-lane capacity stays the requested 32; global scaled to 128.
+    assert config.scheduler_config.max_num_seqs == 128
+    assert tt_config.get_tt_per_lane_max_num_seqs(config) == 32
+
+
+def test_non_gpt_oss_model_not_converted(monkeypatch):
+    # A non-GPT-OSS, non-Galaxy model keeps gathered multi-process DP.
+    monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
+    monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
+    config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
+
+    tt_platform._convert_gather_dp_to_lanes(
+        config, _model_class("LlamaForCausalLM")
+    )
+
+    assert config.parallel_config.data_parallel_size == 4
+    assert tt_config._RESOLVED_LANE_COUNT_KEY not in config.additional_config

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -4,8 +4,8 @@
 
 The coordinator is exercised over lightweight fake lane schedulers: a real
 ``TTScheduler`` needs a device KV cache config, but the coordinator only relies
-on a small surface of each lane (``waiting`` / ``running`` length, forced-mode
-scheduling, and ``update_from_output``).
+on a small surface of each lane (``waiting`` / ``skipped_waiting`` / ``running``
+length, forced-mode scheduling, and ``update_from_output``).
 """
 
 from types import SimpleNamespace
@@ -32,8 +32,9 @@ class FakeLane:
     fallback.
     """
 
-    def __init__(self, waiting=0, running=0, pending_finished=()):
+    def __init__(self, waiting=0, running=0, skipped_waiting=0, pending_finished=()):
         self.waiting = [object()] * waiting
+        self.skipped_waiting = [object()] * skipped_waiting
         self.running = [object()] * running
         self._pending_finished = set(pending_finished)
         self._mode = TTSchedulingMode.DEFAULT
@@ -92,6 +93,14 @@ def test_negotiate_prefill_when_any_lane_wants_prefill():
 def test_negotiate_decode_when_no_lane_wants_prefill():
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(running=1)])
     assert coordinator._negotiate_forced_mode() == TTSchedulingMode.DECODE_ONLY
+
+
+def test_negotiate_prefill_when_lane_has_only_grammar_blocked_request():
+    # Lane 1's only pending work is a grammar-blocked structured-output request
+    # held in skipped_waiting (waiting is empty). It must still force prefill so
+    # the base scheduler cannot promote it into lane 0's decode step.
+    coordinator = _make_coordinator([FakeLane(running=2), FakeLane(skipped_waiting=1)])
+    assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
 
 
 def test_idle_step_propagates_finished_req_ids():

--- a/tests/tt/test_seeding_and_variety.py
+++ b/tests/tt/test_seeding_and_variety.py
@@ -265,9 +265,7 @@ class TestSeedingAndVariety:
 
         # Overall
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
-        assert_varied(
-            results, 2, "With temperature=2.0, outputs should vary in batch."
-        )
+        assert_varied(results, 2, "With temperature=2.0, outputs should vary in batch.")
 
         # First token (prefill)
         prefill_results = [x[:1] for x in results]

--- a/tests/tt/test_seeding_and_variety.py
+++ b/tests/tt/test_seeding_and_variety.py
@@ -185,7 +185,7 @@ class TestSeedingAndVariety:
         prompt = "Random story: "
         configs = [
             RequestConfig(
-                prompt=prompt, max_tokens=20, temperature=10.0, top_k=50, seed=seed
+                prompt=prompt, max_tokens=20, temperature=2.0, top_k=50, seed=seed
             )
         ]
         results = []
@@ -201,7 +201,7 @@ class TestSeedingAndVariety:
         """
         prompt = "Random story: "
         configs = [
-            RequestConfig(prompt=prompt, max_tokens=20, temperature=10.0, top_k=50)
+            RequestConfig(prompt=prompt, max_tokens=20, temperature=2.0, top_k=50)
         ]
         results = []
         for _ in range(10):
@@ -234,7 +234,7 @@ class TestSeedingAndVariety:
         """
         prompt = "Random story: "
         configs = [
-            RequestConfig(prompt=prompt, max_tokens=20, temperature=10.0, top_k=50)
+            RequestConfig(prompt=prompt, max_tokens=20, temperature=2.0, top_k=50)
             for _ in range(max_batch_size)
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -259,24 +259,28 @@ class TestSeedingAndVariety:
         prompt = "Random letter: "
 
         configs = [
-            RequestConfig(prompt=prompt, max_tokens=10, temperature=5)
+            RequestConfig(prompt=prompt, max_tokens=10, temperature=2.0)
             for _ in range(batch_size)
         ]
 
         # Overall
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
-        assert_varied(results, 2, "With temperature=5, outputs should vary in batch.")
+        assert_varied(
+            results, 2, "With temperature=2.0, outputs should vary in batch."
+        )
 
         # First token (prefill)
         prefill_results = [x[:1] for x in results]
         assert_varied(
-            prefill_results, 2, "With temperature=5, first tokens should vary in batch."
+            prefill_results,
+            2,
+            "With temperature=2.0, first tokens should vary in batch.",
         )
 
     def test_temperature_varied_between_batches(self, tt_server, tt_model_name):
         prompt = "Random letter: "
 
-        configs = [RequestConfig(prompt=prompt, max_tokens=10, temperature=5)]
+        configs = [RequestConfig(prompt=prompt, max_tokens=10, temperature=2.0)]
 
         tries = 10
 
@@ -285,14 +289,16 @@ class TestSeedingAndVariety:
             run_concurrent_batch(tt_server, tt_model_name, configs)[0]
             for _ in range(tries)
         ]
-        assert_varied(results, 2, "With temperature=5, outputs should vary on re-runs.")
+        assert_varied(
+            results, 2, "With temperature=2.0, outputs should vary on re-runs."
+        )
 
         # First token (prefill)
         prefill_results = [x[:1] for x in results]
         assert_varied(
             prefill_results,
             2,
-            "With temperature=5, first tokens should vary on re-runs.",
+            "With temperature=2.0, first tokens should vary on re-runs.",
         )
 
     @pytest.mark.parametrize("batch_size", [15, 19, 32])
@@ -305,7 +311,7 @@ class TestSeedingAndVariety:
         ]
 
         topk_configs = [
-            RequestConfig(prompt=prompt, max_tokens=10, top_k=10, temperature=50)
+            RequestConfig(prompt=prompt, max_tokens=10, top_k=10, temperature=2.0)
             for _ in range(batch_size - num_greedy)
         ]
         joint_configs = greedy_config + topk_configs


### PR DESCRIPTION
Compatibility fixes for running the TT plugin against upstream vLLM v0.24.0. Each commit is an independent fix for a behavior change between the old 0.16 fork and 0.24.

## Changes

- **`platform: implement TTPlatform.set_device as no-op`** - 0.24's multiproc executor calls `current_platform.set_device` from its async-output-copy thread. The base `Platform.set_device` raises `NotImplementedError`, killing that thread. TT device context is owned by the ttnn mesh device, not a torch device context, so a no-op is correct.

- **`platform: auto-fit max_model_len to TT KV cache capacity`** - 0.24's `get_kv_cache_configs` now rejects configs where the model's `max_model_len` (often the HF default, e.g. gemma-4-12B's 262144) needs more KV than TT's `num_gpu_blocks_override` provides, crashing EngineCore. TT sizes the KV cache from `max_tokens_all_users`, decoupled from per-request `max_model_len`. Opt into vLLM's native auto-fit (`original_max_model_len=-1`) to clamp `max_model_len` down to the servable length, and add the `update_max_model_len` worker hook the engine calls afterward (absent on `WorkerBase`).

- **`scheduler: keep grammar-blocked prefills out of decode batches`** - 0.24 segregates requests blocked on grammar compilation into a separate `skipped_waiting` queue. The TT prefill/decode routing only inspected `waiting`, so the base scheduler promoted a ready structured request into a running-decode step, violating the all-prefill-or-all-decode invariant and tripping the model_runner batch assert.

- **`tt-plugin: fold GPT-OSS gather-DP into lane-DP`** - GPT-OSS is served by the tt_transformers generator, which drives data parallelism inside a single process, so gathered multi-process DP is unnecessary: `--data_parallel_size` folds into in-process TT lanes like the Galaxy generators. Gated on model architecture plus `data_parallel_size > 1`; other models keep gather-DP. Config-gating is covered by host tests; the lane execution path with GPT-OSS is not yet validated on Galaxy hardware.

- **`platform: force compact JSON from structured output grammars`** - 0.24 defaults `disable_any_whitespace` to `False`, so under greedy decoding the model can loop on grammar-legal whitespace until the token budget is spent, returning truncated unparseable JSON.

- **`tests: cap sampling temperatures at 2.0 for upstream vllm compat`** - 0.24 rejects temperature outside `[0, 2]` at the OpenAI request-validation layer (400 BadRequest); the old 0.16 fork had no upper bound, so temperature 5/10/50 reached the sampler. 2.0 keeps the variety these tests assert on while staying inside the accepted range.

# CI

TBD
