### PR TITLE
scheduler: fix #436 livelock and route plugin logs through vllm

### DIFF
--- a/src/vllm_tt_plugin/config.py
+++ b/src/vllm_tt_plugin/config.py
@@ -3,12 +3,12 @@
 
 from typing import TYPE_CHECKING, Any
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 def _extract_tt_config(

--- a/src/vllm_tt_plugin/engine.py
+++ b/src/vllm_tt_plugin/engine.py
@@ -12,7 +12,6 @@ from typing import Any, TypeVar, cast
 import torch
 import torch.distributed as dist
 from vllm.config import ParallelConfig, VllmConfig
-from vllm.logger import init_logger
 from vllm.utils.network_utils import get_tcp_uri
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.engine import (
@@ -25,9 +24,10 @@ from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.request import Request
 
 from vllm_tt_plugin.config import get_tt_config, get_tt_per_lane_max_num_seqs
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.scheduler import TTSchedulingMode
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 _T = TypeVar("_T")
 
 

--- a/src/vllm_tt_plugin/entrypoints.py
+++ b/src/vllm_tt_plugin/entrypoints.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 def register() -> None:

--- a/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -15,11 +15,12 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
-from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
 
-logger = init_logger(__name__)
+from vllm_tt_plugin.logger import init_tt_logger
+
+logger = init_tt_logger(__name__)
 
 # Gemma4 tool-call wire format (emitted by the model, see the chat template):
 #

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -33,7 +33,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
@@ -48,6 +47,7 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_per_lane_max_num_seqs,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
 if TYPE_CHECKING:
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request, RequestStatus
     from vllm.v1.structured_output import StructuredOutputManager
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/vllm_tt_plugin/launcher.py
+++ b/src/vllm_tt_plugin/launcher.py
@@ -13,7 +13,6 @@ import weakref
 import cloudpickle
 import yaml
 from vllm.config import ParallelConfig, VllmConfig
-from vllm.logger import init_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
@@ -21,8 +20,9 @@ from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPla
 from vllm.v1.executor.abstract import UniProcExecutor
 
 from vllm_tt_plugin.config import get_tt_config
+from vllm_tt_plugin.logger import init_tt_logger
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 class TTLaunchPlan(EngineLaunchPlan):

--- a/src/vllm_tt_plugin/loader.py
+++ b/src/vllm_tt_plugin/loader.py
@@ -3,7 +3,6 @@
 
 from torch import nn
 from vllm.config import ModelConfig, VllmConfig
-from vllm.logger import init_logger
 from vllm.model_executor.model_loader import BaseModelLoader
 from vllm.model_executor.model_loader.utils import get_model_architecture
 
@@ -12,8 +11,9 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_max_batch_size,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 class TTModelLoader(BaseModelLoader):

--- a/src/vllm_tt_plugin/logger.py
+++ b/src/vllm_tt_plugin/logger.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+
+import logging
+
+from vllm.logger import init_logger
+
+_VLLM_LOGGER_PREFIX = "vllm."
+
+
+def init_tt_logger(name: str) -> logging.Logger:
+    """Initialize a TT plugin logger under vLLM's configured logger tree."""
+    if name.startswith(_VLLM_LOGGER_PREFIX):
+        return init_logger(name)
+    return init_logger(f"{_VLLM_LOGGER_PREFIX}{name}")

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -14,7 +14,6 @@ import regex as re
 import torch
 import ttnn
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.utils.math_utils import cdiv
@@ -55,6 +54,7 @@ from vllm_tt_plugin.input_batch import (
 )
 from vllm_tt_plugin.lane_scheduler import get_tt_step_plan
 from vllm_tt_plugin.loader import TTModelLoader
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.logprobs import build_device_logprobs
 from vllm_tt_plugin.model_input import (
     TTModelInput,
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 # Matches the upstream attention-layer naming convention used by registered
 # vLLM models (e.g. "model.language_model.layers.5.self_attn") as well as

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -7,7 +7,6 @@ import sys
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
-from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum
 
 from vllm_tt_plugin.config import (
@@ -17,6 +16,7 @@ from vllm_tt_plugin.config import (
     uses_tt_lane_coordinator,
     validate_tt_lane_config,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 else:
     FlexibleArgumentParser = object
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"
@@ -454,6 +454,25 @@ class TTPlatform(Platform):
         if vllm_config.scheduler_config.enable_chunked_prefill:
             logger.info("Chunked prefill is not yet supported for TT backend")
             vllm_config.scheduler_config.enable_chunked_prefill = False
+            # vLLM does this bump silently earlier
+            # if chunked prefill is already disabled,
+            # and max_num_batched_tokens is not explicitly set.
+            # We can't know if it was specified
+            # or the default, hence the warning.
+            if (
+                vllm_config.scheduler_config.max_num_batched_tokens
+                < vllm_config.model_config.max_model_len
+            ):
+                logger.warning(
+                    "max_num_batched_tokens=%d < max_model_len=%d with chunked prefill "
+                    "disabled, bumping max_num_batched_tokens to match.",
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    vllm_config.model_config.max_model_len,
+                )
+                vllm_config.scheduler_config.max_num_batched_tokens = (
+                    vllm_config.model_config.max_model_len
+                )
+
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )
@@ -645,6 +664,10 @@ class TTPlatform(Platform):
         logger.info(
             "Automatic prefix caching is %s",
             "enabled" if vllm_config.cache_config.enable_prefix_caching else "disabled",
+        )
+        # Check that all invariants are satisfied after all rewriting
+        vllm_config.scheduler_config.verify_max_model_len(
+            vllm_config.model_config.max_model_len
         )
 
     @classmethod

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -4,13 +4,14 @@
 from enum import Enum
 from typing import cast
 
-from vllm.logger import init_logger
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
 from vllm.v1.request import Request
 
-logger = init_logger(__name__)
+from vllm_tt_plugin.logger import init_tt_logger
+
+logger = init_tt_logger(__name__)
 
 
 class TTSchedulingMode(Enum):

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 import ttnn
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model_architecture
 from vllm.tasks import SupportedTask
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.v1.core.kv_cache_utils import get_max_concurrency_for_kv_cache_config
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -23,6 +23,8 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
+
+from vllm_tt_plugin.logger import init_tt_logger
 
 try:
     # Newer vLLM has compile_or_warm_up_model return per-worker timings, which
@@ -54,13 +56,39 @@ if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.outputs import LogprobsLists
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 # Ensure TT model architectures are registered in this process as early as
 # possible. `WorkerWrapperBase.init_worker` imports the worker class module
 # before initializing multimodal caches; without this, early architecture
 # inspection may fail for TT-prefixed architectures.
 register_tt_models(register_test_models=_should_pre_register_tt_test_models_from_cli())
+
+
+def _validate_tt_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> None:
+    """Reject TT KV configs that cannot serve one max_model_len request."""
+    # When rebased to include https://github.com/vllm-project/vllm/pull/41069
+    # verify and remove this check.
+    if not kv_cache_config.kv_cache_groups:
+        return
+
+    max_concurrency = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config
+    )
+    if max_concurrency >= 1.0:
+        return
+
+    model_config = vllm_config.model_config
+    raise ValueError(
+        "TT KV cache cannot hold one request at max_model_len. "
+        f"Maximum concurrency for {model_config.max_model_len:,} tokens per "
+        f"request is {max_concurrency:.2f}x, but must be at least 1.00x. "
+        f"num_blocks={kv_cache_config.num_blocks}, corresponding to approximately "
+        f"{kv_cache_config.num_blocks * vllm_config.cache_config.block_size:,} tokens, "
+        "Increase max_tokens_all_users or reduce max_model_len."
+    )
 
 
 class TTWorker(WorkerBase):
@@ -275,6 +303,7 @@ class TTWorker(WorkerBase):
         """Allocate TT KV cache (only DP rank 0) and initialize persistent
         input batch (all DP ranks) with the specified kv_cache_config.
         """
+        _validate_tt_kv_cache_capacity(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:


### PR DESCRIPTION
Picks the one plugin-touching commit that landed in the `vllm` repo `dev` branch after the `vllm-tt-plugin` repo was extracted: `61bbb1eae3` (vllm PR #438).

## What
- Bump `max_num_batched_tokens` to `max_model_len` when chunked prefill is disabled, and guard the second #436 livelock scenario, so requests stay schedulable.
- Add `logger.py` (`init_tt_logger`) and route all plugin loggers through vLLM's configured logger tree, so warnings emitted early during startup are no longer swallowed by the ttnn root logger.

## Notes
- Applied by stripping the `plugins/vllm-tt-plugin/` path prefix; content is identical to the upstream commit except:
  - `logger.py` SPDX header uses the Tenstorrent copyright line, matching this repo's convention.
  - Import ordering was normalized by this repo's ruff config (first-party `vllm_tt_plugin` grouping).
- `pre-commit` passes (trailing-whitespace, eof, merge-conflict, ruff-check, ruff-format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)