### PR TITLE
platform: implement TTPlatform.set_device as no-op

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -441,6 +441,15 @@ class TTPlatform(Platform):
         pass
 
     @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        # No-op: TT device context is owned by the ttnn mesh device opened in
+        # TTWorker.init_device, not by a torch device context. torch has no "tt"
+        # backend to switch to, so the base Platform.set_device raises
+        # NotImplementedError. vLLM's multiproc executor calls this from its
+        # async-output-copy thread, which would crash that thread without this.
+        pass
+
+    @classmethod
     def is_async_output_supported(cls, enforce_eager: bool | None) -> bool:
         return True
 


### PR DESCRIPTION
vLLM 0.24's multiproc executor calls `current_platform.set_device` from its async-output-copy thread. The base `Platform.set_device` raises `NotImplementedError`, killing that thread. TT device context is owned by the ttnn mesh device, not a torch device context, so a no-op is correct.

Split out of #4 (compatibility fixes for upstream vLLM v0.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)