### PR TITLE
platform: auto-fit max_model_len to TT KV cache capacity

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -495,6 +495,19 @@ class TTPlatform(Platform):
             )
             model_config.max_logprobs = MAX_TOP_K
 
+        # Opt into vLLM's auto-fit of max_model_len against the KV cache the TT
+        # device can actually hold. The TT worker sizes the KV cache from the
+        # model's total token budget (max_tokens_all_users) and pins it via
+        # cache_config.num_gpu_blocks_override, which is decoupled from the
+        # model's per-request max_model_len (often the HF default, e.g. 262144).
+        # vLLM's _check_enough_kv_cache_memory raises when max_model_len needs
+        # more KV than the override provides. Setting original_max_model_len=-1
+        # makes get_kv_cache_configs run _auto_fit_max_model_len, which clamps
+        # max_model_len down to the largest length the override-backed capacity
+        # can serve (it never expands, so a smaller user-set max_model_len is
+        # preserved) and syncs the reduced value to workers.
+        model_config.original_max_model_len = -1
+
         # Import and register models from tt-metal.
         #
         # NOTE: We also register TT models early in `vllm_tt_plugin.worker`

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -311,6 +311,17 @@ class TTWorker(WorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
+    def update_max_model_len(self, max_model_len: int) -> None:
+        # The engine calls this via collective_rpc after get_kv_cache_configs
+        # auto-fits max_model_len down to the KV cache the TT device can hold
+        # (TTPlatform.check_and_update_config opts in by setting
+        # original_max_model_len=-1). WorkerBase has no such hook -- only the GPU
+        # worker defines it -- so TTWorker must provide it or the RPC raises
+        # AttributeError. TTModelRunner reads self.model_config.max_model_len
+        # directly for KV-cache sizing and per-request bounds, so updating the
+        # shared model_config is sufficient; it keeps no separate cached copy.
+        self.model_config.max_model_len = max_model_len
+
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Newer vLLM reduces per-worker timings returned here into
         # compilation_config.compilation_time; older vLLM ignores the return.


### PR DESCRIPTION
vLLM 0.24's `get_kv_cache_configs` now rejects configs where the model's `max_model_len` (often the HF default, e.g. gemma-4-12B's 262144) needs more KV than TT's `num_gpu_blocks_override` provides, crashing EngineCore. TT sizes the KV cache from `max_tokens_all_users`, decoupled from per-request `max_model_len`. Opt into vLLM's native auto-fit (`original_max_model_len=-1`) to clamp `max_model_len` down to the servable length, and add the `update_max_model_len` worker hook the engine calls afterward (absent on `WorkerBase`).

Split out of #4 (compatibility fixes for upstream vLLM v0.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)