### PR TITLE
scheduler: keep grammar-blocked prefills out of decode batches

### DIFF
--- a/src/vllm_tt_plugin/engine.py
+++ b/src/vllm_tt_plugin/engine.py
@@ -323,7 +323,13 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
     def _dp_negotiate_forced_mode(self) -> TTSchedulingMode:
         has_running = bool(getattr(self.scheduler, "running", []))
-        has_waiting = bool(getattr(self.scheduler, "waiting", False))
+        # ``skipped_waiting`` holds prefill requests blocked on grammar
+        # compilation; count them so a rank with only grammar-blocked
+        # structured-output work still signals prefill intent instead of
+        # letting the base scheduler promote them into a gathered decode step.
+        has_waiting = bool(getattr(self.scheduler, "waiting", False)) or bool(
+            getattr(self.scheduler, "skipped_waiting", False)
+        )
         max_running = getattr(self.scheduler, "max_num_running_reqs", 0)
         has_capacity = len(getattr(self.scheduler, "running", [])) < max_running
         local_prefill_intent = (

--- a/src/vllm_tt_plugin/engine.py
+++ b/src/vllm_tt_plugin/engine.py
@@ -323,13 +323,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
     def _dp_negotiate_forced_mode(self) -> TTSchedulingMode:
         has_running = bool(getattr(self.scheduler, "running", []))
-        # ``skipped_waiting`` holds prefill requests blocked on grammar
-        # compilation; count them so a rank with only grammar-blocked
-        # structured-output work still signals prefill intent instead of
-        # letting the base scheduler promote them into a gathered decode step.
-        has_waiting = bool(getattr(self.scheduler, "waiting", False)) or bool(
-            getattr(self.scheduler, "skipped_waiting", False)
-        )
+        has_waiting = bool(getattr(self.scheduler, "waiting", False))
         max_running = getattr(self.scheduler, "max_num_running_reqs", 0)
         has_capacity = len(getattr(self.scheduler, "running", [])) < max_running
         local_prefill_intent = (

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -356,8 +356,14 @@ class TTLaneCoordinator(SchedulerInterface):
         A lane wants to prefill when it has queued requests and either nothing
         running (so it must prefill to make progress) or spare capacity to admit
         more alongside its running decodes.
+
+        ``skipped_waiting`` holds prefill requests blocked on grammar
+        compilation and counts as queued work: without it a lane whose only
+        pending request is a grammar-blocked structured-output request would
+        signal decode-only, and the base scheduler could then promote that
+        request into a mixed prefill+decode step.
         """
-        has_waiting = bool(sched.waiting)
+        has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)
         has_capacity = len(sched.running) < self._per_lane_max
         return int(has_waiting and ((not has_running) or has_capacity))

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -358,7 +358,9 @@ class TTLaneCoordinator(SchedulerInterface):
         more alongside its running decodes.
 
         ``skipped_waiting`` holds prefill requests blocked on grammar
-        compilation. We want to try to schedule them, because otherwise base scheduler won't revisit and promote them - decode intent hides that queue.
+        compilation. We want to try to schedule them, because otherwise the
+        base scheduler won't revisit and promote them - decode intent hides
+        that queue.
         """
         has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -360,8 +360,9 @@ class TTLaneCoordinator(SchedulerInterface):
         ``skipped_waiting`` holds prefill requests blocked on grammar
         compilation and counts as queued work: without it a lane whose only
         pending request is a grammar-blocked structured-output request would
-        signal decode-only, and the base scheduler could then promote that
-        request into a mixed prefill+decode step.
+        signal decode-only. Decode-only scheduling hides that queue, so the
+        base scheduler would never revisit it to promote the request after its
+        grammar becomes ready.
         """
         has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -358,11 +358,7 @@ class TTLaneCoordinator(SchedulerInterface):
         more alongside its running decodes.
 
         ``skipped_waiting`` holds prefill requests blocked on grammar
-        compilation and counts as queued work: without it a lane whose only
-        pending request is a grammar-blocked structured-output request would
-        signal decode-only. Decode-only scheduling hides that queue, so the
-        base scheduler would never revisit it to promote the request after its
-        grammar becomes ready.
+        compilation. We want to try to schedule them, because otherwise base scheduler won't revisit and promote them - decode intent hides that queue.
         """
         has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -89,14 +89,10 @@ class TTScheduler(AsyncScheduler):
         mode = self._forced_mode
 
         if mode == TTSchedulingMode.PREFILL_ONLY:
+            # Forced mode is shared by every lane. Return an empty prefill
+            # result unchanged so the coordinator can decide whether all lanes
+            # should fall back to decode together.
             result = self._schedule_prefill_only()
-            # If the forced prefill scheduled nothing (e.g. grammar still
-            # compiling, or KV pressure with chunked prefill disabled) but
-            # there are running decode requests, fall back to decode-only
-            # to avoid a livelock where no decode progress is made and no
-            # KV capacity is freed.
-            if result.total_num_scheduled_tokens == 0 and has_running:
-                result = self._schedule_decode_only()
             return self._finalize_scheduler_output(result)
         if mode == TTSchedulingMode.DECODE_ONLY:
             if has_waiting:

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -36,13 +36,11 @@ class TTScheduler(AsyncScheduler):
       or all-decode.
     - No chunked prefill: each prefill must be scheduled in full.
 
-    The base scheduler holds prefill requests that are temporarily blocked
-    (e.g. waiting for grammar compilation) in a separate ``skipped_waiting``
-    queue, not ``waiting``. Its waiting loop drains both queues and can
-    promote a now-ready blocked request into the same step that schedules
-    running decodes. To preserve the all-prefill or all-decode invariant,
-    every place that inspects or hides pending prefill work must treat
-    ``waiting`` and ``skipped_waiting`` together.
+    The base scheduler holds temporarily blocked prefill requests (e.g. while
+    a structured-output grammar compiles) in ``skipped_waiting`` rather than
+    ``waiting``. Its prefill loop revisits that queue and promotes requests
+    whose dependency is ready. Decode-only scheduling must hide both queues so
+    that the base scheduler cannot admit a prefill into a decode step.
 
     Inherits from AsyncScheduler to get num_output_placeholders support.
     TT uses this scheduler in both sync and async execution modes:
@@ -52,7 +50,7 @@ class TTScheduler(AsyncScheduler):
       re-scheduled before update_from_output processes the previous step's
       results, enabling host/device overlap
 
-    Supports ``set_forced_mode`` for DP-gather coordination:
+    Supports ``set_forced_mode`` for lane coordination:
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
       queue is non-empty).
     - ``TTSchedulingMode.PREFILL_ONLY`` forces prefill-only (and may return an
@@ -76,12 +74,10 @@ class TTScheduler(AsyncScheduler):
     def _has_pending_prefill(self) -> bool:
         """Whether any request is waiting to be prefilled.
 
-        Includes ``skipped_waiting`` because promotion from
-        ``skipped_waiting`` to ``waiting`` only happens inside the base
-        scheduler's prefill loop.  Without this check, a rank whose only
-        pending work is a grammar-blocked request would signal decode-only,
-        the prefill loop would never run, and the request would never be
-        promoted — stalling indefinitely.
+        A request in ``skipped_waiting`` still needs a future prefill pass:
+        that is where the base scheduler retries promotion after its dependency
+        becomes ready. In decode-only mode this check also ensures both waiting
+        queues are hidden from the base scheduler.
         """
         return bool(self.waiting) or bool(getattr(self, "skipped_waiting", False))
 

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -4,8 +4,8 @@
 
 The coordinator is exercised over lightweight fake lane schedulers: a real
 ``TTScheduler`` needs a device KV cache config, but the coordinator only relies
-on a small surface of each lane (``waiting`` / ``running`` length, forced-mode
-scheduling, and ``update_from_output``).
+on a small surface of each lane (``waiting`` / ``skipped_waiting`` / ``running``
+length, forced-mode scheduling, and ``update_from_output``).
 """
 
 from types import SimpleNamespace
@@ -32,8 +32,9 @@ class FakeLane:
     fallback.
     """
 
-    def __init__(self, waiting=0, running=0, pending_finished=()):
+    def __init__(self, waiting=0, running=0, skipped_waiting=0, pending_finished=()):
         self.waiting = [object()] * waiting
+        self.skipped_waiting = [object()] * skipped_waiting
         self.running = [object()] * running
         self._pending_finished = set(pending_finished)
         self._mode = TTSchedulingMode.DEFAULT
@@ -92,6 +93,14 @@ def test_negotiate_prefill_when_any_lane_wants_prefill():
 def test_negotiate_decode_when_no_lane_wants_prefill():
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(running=1)])
     assert coordinator._negotiate_forced_mode() == TTSchedulingMode.DECODE_ONLY
+
+
+def test_negotiate_prefill_when_lane_has_only_grammar_blocked_request():
+    # Lane 1's only pending work is a grammar-blocked structured-output request
+    # held in skipped_waiting (waiting is empty). It must still force prefill so
+    # the base scheduler cannot promote it into lane 0's decode step.
+    coordinator = _make_coordinator([FakeLane(running=2), FakeLane(skipped_waiting=1)])
+    assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
 
 
 def test_idle_step_propagates_finished_req_ids():

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -98,7 +98,7 @@ def test_negotiate_decode_when_no_lane_wants_prefill():
 def test_negotiate_prefill_when_lane_has_only_grammar_blocked_request():
     # Lane 1's only pending work is a grammar-blocked structured-output request
     # held in skipped_waiting (waiting is empty). It must still force prefill so
-    # the base scheduler cannot promote it into lane 0's decode step.
+    # the base scheduler can revisit and promote it after the grammar is ready.
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(skipped_waiting=1)])
     assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,6 +8,27 @@ from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_qu
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
 
+def test_forced_prefill_does_not_fallback_to_decode_per_lane(monkeypatch):
+    scheduler = TTScheduler.__new__(TTScheduler)
+    scheduler.policy = SchedulingPolicy.FCFS
+    scheduler.waiting = create_request_queue(scheduler.policy)
+    scheduler.waiting.add_request(object())
+    scheduler.skipped_waiting = create_request_queue(scheduler.policy)
+    scheduler.running = [object()]
+    scheduler._forced_mode = TTSchedulingMode.PREFILL_ONLY
+
+    monkeypatch.setattr(scheduler, "_schedule_prefill_only", SchedulerOutput.make_empty)
+
+    def fail_local_decode_fallback():
+        raise AssertionError("forced prefill must remain coordinated across lanes")
+
+    monkeypatch.setattr(scheduler, "_schedule_decode_only", fail_local_decode_fallback)
+
+    output = scheduler.schedule()
+
+    assert output.total_num_scheduled_tokens == 0
+
+
 def test_forced_decode_hides_and_restores_skipped_waiting(monkeypatch):
     scheduler = TTScheduler.__new__(TTScheduler)
     scheduler.policy = SchedulingPolicy.FCFS

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+
+from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
+
+
+def test_forced_decode_hides_and_restores_skipped_waiting(monkeypatch):
+    scheduler = TTScheduler.__new__(TTScheduler)
+    scheduler.policy = SchedulingPolicy.FCFS
+    scheduler.waiting = create_request_queue(scheduler.policy)
+    scheduler.skipped_waiting = create_request_queue(scheduler.policy)
+    scheduler.skipped_waiting.add_request(object())
+    scheduler.running = [object()]
+    scheduler._forced_mode = TTSchedulingMode.DECODE_ONLY
+
+    saved_waiting = scheduler.waiting
+    saved_skipped_waiting = scheduler.skipped_waiting
+    skipped_request = scheduler.skipped_waiting.peek_request()
+    visible_queues = []
+
+    def fake_base_schedule(self, throttle_prefills=False):
+        visible_queues.append((bool(self.waiting), bool(self.skipped_waiting)))
+        return SchedulerOutput.make_empty()
+
+    monkeypatch.setattr(AsyncScheduler, "schedule", fake_base_schedule)
+
+    scheduler.schedule()
+
+    assert visible_queues == [(False, False)]
+    assert scheduler.waiting is saved_waiting
+    assert scheduler.skipped_waiting is saved_skipped_waiting
+    assert scheduler.skipped_waiting.peek_request() is skipped_request


### PR DESCRIPTION
vLLM 0.24 segregates requests blocked on grammar compilation into a separate `skipped_waiting` queue. The TT scheduler must revisit that queue during prefill scheduling so ready requests can be promoted, and must hide both waiting queues during decode-only scheduling to prevent mixed prefill and decode batches.

PR #12 already landed the shared scheduler queue handling while replacing legacy gathered-DP with standard DP or single-process lane-DP. This PR now completes the lane-DP behavior:

- Count `skipped_waiting` when negotiating lane-wide prefill intent, so grammar-ready requests are revisited and promoted.
- Keep forced-prefill fallback coordinated by `TTLaneCoordinator`; an individual lane must not fall back to decode while another lane successfully prefills.
- Add regression coverage for lane intent, decode queue isolation, and lane-wide fallback ownership.
- Clarify the separate roles of prefill intent and decode queue isolation.

`engine.py` remains unchanged because the standalone plugin now routes through upstream standard DP or single-process lane-DP after #12. The separate gathered-DP livelock in the vLLM fork is tracked in https://github.com/tenstorrent/vllm/issues/450.

Split out of #4 (compatibility fixes for upstream vLLM v0.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)