### PR TITLE
tt-plugin: fold GPT-OSS gather-DP into lane-DP

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -54,6 +54,26 @@ def _galaxy_generator_version() -> str | None:
     return None
 
 
+# GPT-OSS is served by the tt_transformers generator, which drives data
+# parallelism inside a single process -- either user-row sharding on multi-row
+# meshes or one Generator over per-DP submeshes. Gathered multi-process DP is
+# therefore unnecessary: --data_parallel_size folds into in-process TT lanes,
+# the same as the Galaxy generators.
+_GPT_OSS_ARCH = "GptOssForCausalLM"
+
+
+def _model_folds_gather_dp_into_lanes(model_class) -> bool:
+    """Whether the model's gathered multi-process DP folds into in-process lanes.
+
+    True for the Galaxy generators and for GPT-OSS, both of which drive data
+    parallelism within a single process. Other models keep gathered
+    multi-process DP.
+    """
+    if _galaxy_generator_version() is not None:
+        return True
+    return getattr(model_class, "__name__", None) == _GPT_OSS_ARCH
+
+
 def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     """Reset DP-derived ParallelConfig fields to single-process values.
 
@@ -94,14 +114,15 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     parallel_config.distributed_executor_backend = "uni"
 
 
-def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
+def _convert_gather_dp_to_lanes(vllm_config: "VllmConfig", model_class=None) -> None:
     """Transparently convert gathered multi-process DP into in-process TT lanes.
 
-    Galaxy-generator models (``llama3_70b_galaxy``, ``qwen3_32b_galaxy``) are
-    served by a single Galaxy device mesh. Gathered multi-process DP is
-    deprecated in favor of single-process TT lanes. Rather than asking users to
-    migrate flags, we run ``--data_parallel_size N`` as ``N`` in-process lanes:
-    record the resolved lane count and reset ``data_parallel_size`` to 1.
+    Models that run as a single shared device execute on one mesh -- the Galaxy
+    generators (``llama3_70b_galaxy``, ``qwen3_32b_galaxy``) and GPT-OSS under
+    user-row sharding -- do not need gathered multi-process DP. Rather than
+    asking users to migrate flags, we run ``--data_parallel_size N`` as ``N``
+    in-process lanes: record the resolved lane count and reset
+    ``data_parallel_size`` to 1.
 
     To preserve the historical capacity contract -- where each of the ``N``
     gathered DP ranks handled ``max_num_seqs`` requests -- the global
@@ -110,16 +131,15 @@ def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
     value the user requested (e.g. ``--data_parallel_size 4 --max_num_seqs 8``
     becomes 4 lanes, each with max 8 seqs, for a global max of 32).
 
-    No-op unless a Galaxy-generator model is active with
-    ``data_parallel_size > 1``. Idempotent: after conversion
-    ``data_parallel_size == 1``, so re-entry short-circuits.
+    No-op unless ``data_parallel_size > 1`` and the model folds gathered DP
+    into lanes (``_model_folds_gather_dp_into_lanes``). Idempotent: after
+    conversion ``data_parallel_size == 1``, so re-entry short-circuits.
     """
     parallel_config = vllm_config.parallel_config
     data_parallel_size = parallel_config.data_parallel_size
     if data_parallel_size <= 1:
         return
-    galaxy_version = _galaxy_generator_version()
-    if galaxy_version is None:
+    if not _model_folds_gather_dp_into_lanes(model_class):
         return
 
     lanes = data_parallel_size
@@ -132,11 +152,10 @@ def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
     _collapse_parallel_config_to_single_process(parallel_config)
 
     logger.info(
-        "Galaxy model %s requested DP "
-        "(--data_parallel_size=%d); running single-process TT lane-DP instead "
+        "Model requested gathered DP (--data_parallel_size=%d) but runs as a "
+        "single device execute; running single-process TT lane-DP instead "
         "(%d lanes, per-lane max_num_seqs=%d, global max_num_seqs=%d).",
-        galaxy_version,
-        lanes,
+        data_parallel_size,
         lanes,
         per_lane_max_num_seqs,
         global_max_num_seqs,
@@ -615,12 +634,13 @@ class TTPlatform(Platform):
             )
             vllm_config.scheduler_config.async_scheduling = False
 
-        # Galaxy-generator models (Llama3 70B, Qwen3-32B) are served by a single
-        # device mesh. Convert
-        # it transparently into single-process TT lanes so users keep passing
-        # --data_parallel_size with no other flag changes. Must run before the
-        # validation/routing below so the lane path is selected.
-        _convert_galaxy_gather_dp_to_lanes(vllm_config)
+        # Single-execute models (Galaxy generators, GPT-OSS under user-row
+        # sharding) run one shared device execute on the full mesh, so gathered
+        # multi-process DP is folded transparently into single-process TT lanes
+        # -- users keep passing --data_parallel_size with no other flag changes.
+        # Must run before the validation/routing below so the lane path is
+        # selected. model_class carries the single-execute decision for GPT-OSS.
+        _convert_gather_dp_to_lanes(vllm_config, model_class)
 
         if uses_tt_lane_coordinator(vllm_config):
             # Fail fast on misconfiguration: lane mode requires max_num_seqs to

--- a/tests/test_galaxy_dp_conversion.py
+++ b/tests/test_galaxy_dp_conversion.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 """Host tests for the transparent gathered-DP -> single-process lane conversion.
 
-Galaxy-generator models (llama3_70b_galaxy, qwen3_32b_galaxy) are served on a
-single device mesh, so ``--data_parallel_size N`` is folded into ``N``
-in-process TT lanes by ``platform._convert_galaxy_gather_dp_to_lanes``.
+Single-execute models are served on one device mesh, so ``--data_parallel_size
+N`` is folded into ``N`` in-process TT lanes by
+``platform._convert_gather_dp_to_lanes``. This covers the Galaxy generators
+(llama3_70b_galaxy, qwen3_32b_galaxy) and GPT-OSS under user-row sharding.
 """
 
 from types import SimpleNamespace
@@ -29,11 +30,16 @@ def _vllm_config(*, data_parallel_size, max_num_seqs):
     )
 
 
+def _model_class(name):
+    """A stand-in model class whose ``__name__`` drives GPT-OSS detection."""
+    return type(name, (), {})
+
+
 def test_galaxy_gather_dp_converted_to_lanes(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Gathered DP collapsed to a single in-process engine with 4 lanes.
     assert config.parallel_config.data_parallel_size == 1
@@ -48,7 +54,7 @@ def test_qwen3_galaxy_gather_dp_converted_to_lanes(monkeypatch):
     monkeypatch.setenv("TT_QWEN3_TEXT_VER", "qwen3_32b_galaxy")
     config = _vllm_config(data_parallel_size=2, max_num_seqs=16)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     assert config.parallel_config.data_parallel_size == 1
     assert tt_config.get_tt_data_parallel_size(config) == 2
@@ -61,7 +67,7 @@ def test_collapse_resets_derived_parallel_fields(monkeypatch):
     config.parallel_config.data_parallel_size_local = 4
     config.parallel_config.data_parallel_external_lb = True
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     pc = config.parallel_config
     assert pc.data_parallel_size_local == 1
@@ -75,12 +81,12 @@ def test_collapse_resets_derived_parallel_fields(monkeypatch):
     assert pc.data_parallel_hybrid_lb is False
 
 
-def test_no_conversion_for_non_galaxy_model(monkeypatch):
+def test_no_conversion_for_non_single_execute_model(monkeypatch):
     monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
     monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Left as gathered multi-process DP, untouched.
     assert config.parallel_config.data_parallel_size == 4
@@ -92,7 +98,7 @@ def test_conversion_is_noop_without_dp(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=1, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     assert config.parallel_config.data_parallel_size == 1
     assert config.scheduler_config.max_num_seqs == 8
@@ -103,10 +109,39 @@ def test_conversion_is_idempotent(monkeypatch):
     monkeypatch.setenv("TT_LLAMA_TEXT_VER", "llama3_70b_galaxy")
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
-    tt_platform._convert_galaxy_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
+    tt_platform._convert_gather_dp_to_lanes(config)
 
     # Second call short-circuits (data_parallel_size already 1); no double scale.
     assert config.parallel_config.data_parallel_size == 1
     assert config.scheduler_config.max_num_seqs == 32
     assert tt_config.get_tt_data_parallel_size(config) == 4
+
+
+def test_gpt_oss_gather_dp_converted_to_lanes(monkeypatch):
+    # GPT-OSS drives DP inside one process, so gathered DP folds into lanes
+    # regardless of mesh shape or batch size.
+    monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
+    monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
+    config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
+
+    tt_platform._convert_gather_dp_to_lanes(config, _model_class("GptOssForCausalLM"))
+
+    assert config.parallel_config.data_parallel_size == 1
+    assert tt_config.get_tt_data_parallel_size(config) == 4
+    assert tt_config.uses_tt_lane_coordinator(config)
+    # Per-lane capacity stays the requested 32; global scaled to 128.
+    assert config.scheduler_config.max_num_seqs == 128
+    assert tt_config.get_tt_per_lane_max_num_seqs(config) == 32
+
+
+def test_non_gpt_oss_model_not_converted(monkeypatch):
+    # A non-GPT-OSS, non-Galaxy model keeps gathered multi-process DP.
+    monkeypatch.delenv("TT_LLAMA_TEXT_VER", raising=False)
+    monkeypatch.delenv("TT_QWEN3_TEXT_VER", raising=False)
+    config = _vllm_config(data_parallel_size=4, max_num_seqs=32)
+
+    tt_platform._convert_gather_dp_to_lanes(config, _model_class("LlamaForCausalLM"))
+
+    assert config.parallel_config.data_parallel_size == 4
+    assert tt_config._RESOLVED_LANE_COUNT_KEY not in config.additional_config


### PR DESCRIPTION
GPT-OSS is served by the tt_transformers generator, which drives data parallelism inside a single process, so gathered multi-process DP is unnecessary: `--data_parallel_size` folds into in-process TT lanes like the Galaxy generators. Gated on model architecture plus `data_parallel_size > 1`; other models keep gather-DP.

Config-gating is covered by host tests; the lane execution path with GPT-OSS is **not yet validated on Galaxy hardware**.

Split out of #4 (compatibility fixes for upstream vLLM v0.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)