### PR TITLE
platform: force compact JSON from structured output grammars

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -495,6 +495,17 @@ class TTPlatform(Platform):
             )
             model_config.max_logprobs = MAX_TOP_K
 
+        # Force the grammar backends to emit compact JSON. xgrammar and guidance
+        # allow arbitrary inter-field whitespace by default; under greedy decoding
+        # the model can pick a whitespace token as the argmax indefinitely,
+        # exhausting the token budget before it emits a property name and
+        # returning truncated, unparseable JSON. Masking whitespace out of the
+        # grammar makes that loop structurally impossible for any decoding
+        # strategy. Backend stays "auto" so schemas xgrammar cannot compile still
+        # fall back to guidance (which also honors this flag); outlines and
+        # lm-format-enforcer ignore it.
+        vllm_config.structured_outputs_config.disable_any_whitespace = True
+
         # Import and register models from tt-metal.
         #
         # NOTE: We also register TT models early in `vllm_tt_plugin.worker`


### PR DESCRIPTION
vLLM 0.24 defaults `disable_any_whitespace` to `False`, so under greedy decoding the model can loop on grammar-legal whitespace until the token budget is spent, returning truncated unparseable JSON.

Split out of #4 (compatibility fixes for upstream vLLM v0.24.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)