### PR TITLE
[feature] Register models dynamically from 'EXTRA_MODELS_DIR' (tenstorrent/vllm#440)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,27 @@ implementations. Current families:
 Model availability, supported device shapes, max sequence limits, and required
 environment variables are documented in the corresponding tt-metal model demos.
 
+### Registering models dynamically (`EXTRA_MODELS_DIR`)
+
+Instead of adding a hard-coded line to `platform.py`, a model can be registered at
+startup by dropping a **bundle folder** under a directory named by the
+`EXTRA_MODELS_DIR` environment variable. Each subfolder holds a `vllm_metadata.json`
+and the adapter class (plus its dependencies):
+
+```text
+$EXTRA_MODELS_DIR/
+  my-model/
+    vllm_metadata.json      # {"arch": "<HFArch>", "main_class": "module:Class", ...}
+    <adapter class + deps>
+```
+
+At import time the plugin scans `EXTRA_MODELS_DIR`, appends each folder to `sys.path`
+(so an installed package of the same name is never shadowed), and registers `arch`
+under the plugin's `TT`-prefixed convention (`TT<HFArch>`) pointing at `main_class`.
+This lets a distribution tool (e.g. `tt-kernel`) deliver a ready-to-serve model with no
+source edit to the plugin. The built-in map above stays enabled by default; set
+`TT_VLLM_BUILTIN_MODELS=0` to rely solely on `EXTRA_MODELS_DIR`.
+
 ## Operational Constraints
 
 `TTPlatform` rejects or adjusts unsupported feature combinations early, giving a

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -220,8 +220,112 @@ def _install_tt_harmony_truncation_patch() -> None:
         renderer_registry.tokenizer_args_from_config = tokenizer_args_from_config_tt
 
 
+def _iter_extra_model_bundles():
+    """Yield ``(folder, arch, main_class)`` for each bundle under ``EXTRA_MODELS_DIR``.
+
+    ``EXTRA_MODELS_DIR`` is a directory of self-contained per-model bundle
+    folders. Each folder holds a ``vllm_metadata.json`` (``arch`` = HF
+    architecture name, ``main_class`` = ``"module:Class"`` implementing the vLLM
+    generator adapter) plus the adapter class and its dependencies. Any
+    distribution tool (e.g. tt-kernel) can drop a bundle folder here and have it
+    registered with no source edit to this plugin. Malformed / incomplete folders
+    are skipped with a warning.
+    """
+    base = os.getenv("EXTRA_MODELS_DIR")
+    if not base:
+        return
+
+    if not os.path.isdir(base):
+        logger.warning("EXTRA_MODELS_DIR=%s is not a directory; ignoring.", base)
+        return
+
+    for name in sorted(os.listdir(base)):
+        folder = os.path.join(base, name)
+        if not os.path.isdir(folder):
+            continue
+
+        meta_path = os.path.join(folder, "vllm_metadata.json")
+        if not os.path.isfile(meta_path):
+            continue
+        try:
+            with open(meta_path) as fh:
+                data = json.load(fh)
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "Skipping %s: cannot read vllm_metadata.json (%s)", folder, exc
+            )
+            continue
+
+        arch = data.get("arch")
+        main_class = data.get("main_class")
+        if not arch or not main_class:
+            logger.warning(
+                "Skipping %s: vllm_metadata.json needs 'arch' and 'main_class'.",
+                folder,
+            )
+            continue
+
+        yield folder, arch, main_class
+
+
+def _register_models_from_extra_dir(ModelRegistry) -> int:
+    """Register every model found under ``EXTRA_MODELS_DIR``; return the count.
+
+    Registration is lazy (a ``"module:Class"`` string resolved by vLLM later), so
+    a bundle folder that carries its own adapter module must stay importable when
+    that resolution happens. We ``append`` the folder to ``sys.path`` (never
+    ``insert(0)``, so an installed package of the same name always wins and
+    nothing is shadowed); built-in adapters given as a full dotted path resolve
+    normally and need no path entry. The arch is registered under the plugin's
+    ``TT``-prefixed convention (mirroring ``check_and_update_config``).
+    """
+    count = 0
+
+    for folder, arch, main_class in _iter_extra_model_bundles():
+        if folder not in sys.path:
+            sys.path.append(folder)
+
+        tt_arch = arch if arch.startswith("TT") else "TT" + arch
+        _register_model_if_missing(ModelRegistry, tt_arch, main_class)
+
+        logger.info(
+            "Registered TT model %s -> %s (from EXTRA_MODELS_DIR/%s)",
+            tt_arch,
+            main_class,
+            os.path.basename(folder),
+        )
+
+        count += 1
+
+    return count
+
+
+def _builtin_models_enabled() -> bool:
+    """Whether to register the built-in (hard-coded) TT model map.
+
+    Defaults to enabled for backward compatibility. Set
+    ``TT_VLLM_BUILTIN_MODELS=0`` to rely solely on ``EXTRA_MODELS_DIR`` (the
+    intended end-state once all models ship as bundles). Any of 0/false/no/off
+    disables it.
+    """
+    val = os.getenv("TT_VLLM_BUILTIN_MODELS")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "false", "no", "off")
+
+
 def register_tt_models(register_test_models=False) -> None:
     from vllm.model_executor.models.registry import ModelRegistry
+
+    # Dynamic hook: register any bundles dropped under EXTRA_MODELS_DIR. Runs
+    # first so a distributed bundle can supply a model without touching this file.
+    _register_models_from_extra_dir(ModelRegistry)
+
+    # Built-in map. Kept for compatibility; disable with TT_VLLM_BUILTIN_MODELS=0.
+    if not _builtin_models_enabled():
+        if register_test_models:
+            register_tt_test_models()
+        return
 
     llama_text_version = os.getenv("TT_LLAMA_TEXT_VER", "tt_transformers")
     if llama_text_version == "tt_transformers":


### PR DESCRIPTION
From tenstorrent/vllm#440:

---

## Summary

Adds a dynamic model-registration hook to the TT vLLM plugin so a model can be registered
at startup by dropping a self-contained **bundle folder** under a directory named by the
`EXTRA_MODELS_DIR` environment variable — no per-model edit to `platform.py` required.

This is the hook system suggested in the current bring-up flow ("adding a line here … but a
PR adding a hook system would be very welcome"). It lets a distribution tool (e.g.
`tt-kernel`) deliver a servable model as a drop-in folder.

## How it works

`register_tt_models()` now runs a scan first, then the existing built-in map:

- `_iter_extra_model_bundles()` — for each subfolder of `EXTRA_MODELS_DIR`, read its
  `vllm_metadata.json`; skip malformed/incomplete folders with a warning.
- `_register_models_from_extra_dir()` — prepend the folder to `sys.path` (so a bundle-local
  adapter module imports; a built-in dotted `main_class` resolves as usual) and register the
  arch under the plugin's `TT`-prefixed convention (`TT<HFArch>`), mirroring
  `check_and_update_config`.

### `vllm_metadata.json` (per bundle folder)

```json
{
  "arch": "LlamaForCausalLM",
  "main_class": "models.tt_transformers.tt.generator_vllm:LlamaForCausalLM",
  "hf_weights": "meta-llama/Llama-3.1-8B-Instruct",
  "launch": { "<machine>": { "command": ["python3", "server_example_tt.py", "..."], "env": {} } }
}
```

`arch` is the HF `architectures` name (the plugin prepends `TT`). `main_class` may reference
an existing tt-metal generator (folder is metadata-only) or a bundle-local adapter shipped in
the folder. `launch` is read by the distribution tool, not the plugin.

## Backward compatibility

The built-in hard-coded map stays **enabled by default**. Set `TT_VLLM_BUILTIN_MODELS=0` to
rely solely on `EXTRA_MODELS_DIR` (the eventual end-state once models are distributed as
bundles). No behavior change unless `EXTRA_MODELS_DIR` is set or the toggle is flipped.

## Tests

`tests/test_extra_models_dir.py` covers registration, malformed/incomplete skipping, no-dir
no-op, the already-`TT`-prefixed case, and the builtin toggle. README updated with a
"Registering models dynamically" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
