### PR TITLE
Uninstall torchaudio which is unusable with CPU torch install

### DIFF
--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -2,4 +2,5 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
 VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm vllm==0.24.0
+uv pip uninstall torchaudio   # CUDA wheel, unloadable next to CPU torch; transformers>=5.12 imports it if merely installed
 uv pip install -e .


### PR DESCRIPTION
t-metal main commit 68827466439 — "Bump transformers to 5.12.1" (#50434) — which changed requirements-dev.txt from transformers == 5.10.2 to transformers == 5.12.1, and therefore rebuilt the docker image (b6194207… → 07fe5b40…).

transformers 5.12 added transformers/loss/loss_rnnt.py, imported unconditionally from loss/loss_utils.py:27. That module does:

```
if is_torchaudio_available():
    import torchaudio
```

and is_torchaudio_available() is a metadata check (_is_package_available("torchaudio")) — it only asks whether the package is installed, not whether it can be imported.

torchaudio is installed, and it's unusable:

The image's torch comes from the CPU index (--extra-index-url https://download.pytorch.org/whl/cpu, requirements-dev.txt:111-113) → torch 2.11.0+cpu, which never preloads the nvidia libs.
Plugin install runs uv pip install vllm==0.24.0, and upstream vLLM 0.24.0 pulls torchaudio==2.11.0 from default PyPI — the CUDA-13-linked wheel.

So the guard passes, the import runs, and _torchaudio.abi3.so can't dlopen libcudart.so.13 → OSError.

CI before: https://github.com/tenstorrent/tt-metal/actions/runs/30431047457/job/90509593221#step:20:69
CI after: https://github.com/tenstorrent/tt-metal/actions/runs/30435283091