### PR TITLE
install: override opencv pin so the vLLM install resolves against numpy<2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ If installing tt-metal from source, build it, create the virtual environment,
 and set the environment variables needed for tt-metal tests.
 
 Activate the environment where tt-metal is installed, then install vLLM
-and the TT plugin:
+and the TT plugin. Run it from the repository root, which the relative paths
+inside assume:
 
 ```bash
 source docs/install-vllm-tt.sh
@@ -66,6 +67,13 @@ The script installs vLLM with
 `VLLM_TARGET_DEVICE=empty` because `tt` platform is provided by this plugin
 at runtime. It then installs the plugin with a few dependencies.
 Most dependencies come from the active tt-metal env.
+
+vLLM is installed with `--override docs/vllm-overrides.txt`. vLLM asks for
+`opencv-python-headless>=4.13.0`, which requires `numpy>=2`, while `ttnn` pins
+`numpy<2`; without the override the install cannot resolve. The overrides keep
+`numpy<2` and hold opencv at the last release compatible with it. opencv is only
+reached by vLLM's video-IO path, which no TT-supported model uses. See the
+comments in that file before changing the pinned vLLM version.
 
 To install or refresh only the plugin package:
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,6 @@ The script installs vLLM with
 at runtime. It then installs the plugin with a few dependencies.
 Most dependencies come from the active tt-metal env.
 
-vLLM is installed with `--override docs/vllm-overrides.txt`. vLLM asks for
-`opencv-python-headless>=4.13.0`, which requires `numpy>=2`, while `ttnn` pins
-`numpy<2`; without the override the install cannot resolve. The overrides keep
-`numpy<2` and hold opencv at the last release compatible with it. opencv is only
-reached by vLLM's video-IO path, which no TT-supported model uses. See the
-comments in that file before changing the pinned vLLM version.
-
 To install or refresh only the plugin package:
 
 ```bash

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
 VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm \
-    --override docs/vllm-overrides.txt vllm==0.24.0   # see that file for why
+    --override docs/vllm-overrides.txt vllm==0.24.0   # see that file for why. Must read when bumping vllm version!
 uv pip uninstall torchaudio   # CUDA wheel, unloadable next to CPU torch; transformers>=5.12 imports it if merely installed
 uv pip install -e .

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm vllm==0.24.0
+VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm \
+    --override docs/vllm-overrides.txt vllm==0.24.0   # see that file for why
 uv pip uninstall torchaudio   # CUDA wheel, unloadable next to CPU torch; transformers>=5.12 imports it if merely installed
 uv pip install -e .

--- a/docs/vllm-overrides.txt
+++ b/docs/vllm-overrides.txt
@@ -1,8 +1,8 @@
 # Dependency overrides for the vLLM install in install-vllm-tt.sh.
 #
 # ttnn pins numpy>=1.24.4,<2, but vLLM's requirements/common.txt asks for
-# opencv-python-headless>=4.13.0, which requires numpy>=2. The two are
-# unsatisfiable together, so the install fails without an override.
+# opencv-python-headless>=4.13.0, which requires numpy>=2.
+# Without overrides, the install rewrites numpy with the newer version.
 #
 # numpy<2 wins: it is fixed by the tt-metal env this plugin runs inside
 # (tt-metal pyproject.toml and tt_metal/python_env/requirements-dev.txt) and
@@ -10,11 +10,8 @@
 # path (vllm/multimodal/video.py), which no TT-registered model uses, so 4.11 —
 # the last release without a numpy 2 floor — is safe.
 #
-# These must be overrides rather than constraints: vLLM *declares*
-# opencv-python-headless>=4.13.0, and a constraint can only narrow a declared
-# range, never contradict it.
-#
 # Revisit when bumping the pinned vLLM version (upstream may relax the opencv
-# floor again), or if a TT-supported model gains video input.
+# floor again), or if a TT-supported model gains video input, or if tt-metal
+# bumps the numpy requirement.
 opencv-python-headless==4.11.0.86
 numpy>=1.24.4,<2

--- a/docs/vllm-overrides.txt
+++ b/docs/vllm-overrides.txt
@@ -1,0 +1,20 @@
+# Dependency overrides for the vLLM install in install-vllm-tt.sh.
+#
+# ttnn pins numpy>=1.24.4,<2, but vLLM's requirements/common.txt asks for
+# opencv-python-headless>=4.13.0, which requires numpy>=2. The two are
+# unsatisfiable together, so the install fails without an override.
+#
+# numpy<2 wins: it is fixed by the tt-metal env this plugin runs inside
+# (tt-metal pyproject.toml and tt_metal/python_env/requirements-dev.txt) and
+# cannot be moved from here. opencv is reached only by vLLM's lazy video-IO
+# path (vllm/multimodal/video.py), which no TT-registered model uses, so 4.11 —
+# the last release without a numpy 2 floor — is safe.
+#
+# These must be overrides rather than constraints: vLLM *declares*
+# opencv-python-headless>=4.13.0, and a constraint can only narrow a declared
+# range, never contradict it.
+#
+# Revisit when bumping the pinned vLLM version (upstream may relax the opencv
+# floor again), or if a TT-supported model gains video input.
+opencv-python-headless==4.11.0.86
+numpy>=1.24.4,<2

--- a/docs/vllm-overrides.txt
+++ b/docs/vllm-overrides.txt
@@ -12,6 +12,7 @@
 #
 # Revisit when bumping the pinned vLLM version (upstream may relax the opencv
 # floor again), or if a TT-supported model gains video input, or if tt-metal
-# bumps the numpy requirement.
+# bumps the numpy requirement
+# (https://github.com/tenstorrent/tt-metal/issues/30193).
 opencv-python-headless==4.11.0.86
 numpy>=1.24.4,<2


### PR DESCRIPTION
Fixes #17.

## Problem

`docs/install-vllm-tt.sh` cannot resolve. `VLLM_TARGET_DEVICE=empty` makes vLLM's
`setup.py` take its `install_requires` from `requirements/common.txt` (the
`_no_device()` branch of `get_requirements()`), and vLLM 0.24.0 lists
`opencv-python-headless >= 4.13.0` there. Per PyPI metadata:

| package | numpy requirement |
| --- | --- |
| `ttnn==0.74.0` | `numpy>=1.24.4,<2` |
| `opencv-python-headless==4.13.0.90` | `numpy>=2` (py>=3.9) |
| `opencv-python-headless==4.12.0.88` | `numpy>=2,<2.3` |
| `opencv-python-headless==4.11.0.86` | `numpy>=1.21.2` (3.10) / `>=1.23.5` (3.11) / `>=1.26.0` (3.12) — no numpy 2 floor |

No version satisfies both, so the resolver has to lose one.

## Why numpy<2 wins

`ttnn`'s pin is not negotiable: the plugin only runs inside a tt-metal
`python_env`, and tt-metal pins the same range itself (its `pyproject.toml` and
`tt_metal/python_env/requirements-dev.txt`). opencv, by contrast, is reachable
only from vLLM's video-IO path — every `import cv2` in vLLM is lazy and confined
to `vllm/multimodal/video.py`, `vllm/assets/video.py`,
`model_executor/models/nemotron_parse.py`, and `benchmarks/datasets.py`. No
TT-registered model touches it.

Upstream's bump to 4.13 (`[Misc] Bump opencv-python dependecy version to 4.13`)
carries no stated functional driver, so overriding it is low risk.

## Change

Adds `docs/vllm-overrides.txt` and passes it to the documented install via
`--override`. Overrides rather than constraints because vLLM *declares*
`>=4.13.0` and a constraint can only narrow a declared range, never contradict
it — `--constraint 'opencv-python-headless==4.11.0.86'` would fail to resolve.

Result is a single coherent resolution — opencv 4.11.0.86 (prebuilt manylinux
`cp37-abi3` wheels for x86_64 and aarch64, no source build), numpy left at the
tt-metal env's 1.26.x, ttnn untouched — rather than installing and then
correcting afterwards, which leaves an env that `uv pip check` reports as broken
and that a later `uv pip install` may "repair" by pulling numpy 2 back in.

The tenstorrent/vllm fork already carries the equivalent patch to `common.txt`
(`Revert opencv dependency bump`), but that cannot help plugin users, who install
vLLM from PyPI.

## Notes for review

- The override file's version pin is coupled to `vllm==0.24.0`. Whoever bumps the
  pinned vLLM version should re-check whether upstream still requires opencv
  >= 4.12; there's a comment in the file saying so.
- Video input is unsupported on TT today. If that changes, this pin is the thing
  to revisit.
- The script uses a repo-root-relative path, consistent with the existing
  `uv pip install -e .` line, which already assumes that cwd. README now states
  it explicitly. Deriving the script's own directory isn't portable here since
  the script is `source`d, so `\$0` is the user's shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)