### PR TITLE
[port  tenstorrent/vllm#444] Llama 70B Galaxy DP dedup fix

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import threading
 from collections import deque
 from dataclasses import dataclass, fields, replace
@@ -1177,6 +1176,19 @@ class TTModelRunner:
         if not scheduler_output.total_num_scheduled_tokens:
             return None
 
+        # ``_update_states`` may have just discovered a layout change that the
+        # scheduler-output prediction could not see: it predicts the resets caused by
+        # new or resumed requests, but removals, unscheduled requests and batch
+        # condensation only surface here, after the drain decision was already made.
+        # ``_decode_layout_changed_since_last_decode = True`` implies
+        # ``reset_batch=True``: ``_prepare_model_inputs`` below reloads inputs from host
+        # state, which a pending async decode step has not been applied to yet. This
+        # step is therefore not steady-decode eligible, so drain pending decodes to
+        # ensure updated host inputs. No-op when the flag was already set before the
+        # step (the caller's drain decision covered it) or when nothing is pending.
+        if self._decode_layout_changed_since_last_decode:
+            self.async_decode.wait_for_all_pending_async_steps()
+
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output, grammar_output)
         return model_input
@@ -1910,8 +1922,6 @@ class TTModelRunner:
                             rank_output_tokens
                         )
 
-        if os.environ.get("DP_GATHER_DEBUG") == "1":
-            logger.info("batch_size_per_dp=%s", batch_size_per_dp)
         merged = TTModelInput(
             input_tokens=input_tokens,
             input_positions=input_positions,
@@ -1993,6 +2003,11 @@ class TTModelRunner:
         )
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
+            # ``_decode_layout_changed_since_last_decode = True`` implies
+            # ``reset_batch=True``: the model will reload inputs. This step is not
+            # steady-decode eligible, so drain pending decodes to ensure updated
+            # host inputs.
+            self.async_decode.wait_for_all_pending_async_steps()
 
         if not scheduler_output.total_num_scheduled_tokens:
             return EMPTY_MODEL_RUNNER_OUTPUT


### PR DESCRIPTION
## Purpose

Port the runner-side Llama 70B Galaxy DP dedup fix from tenstorrent/vllm#444 into the standalone `vllm-tt-plugin` repository.

Llama 70B Galaxy uses multi-lane, single-process DP decode with async overlap. During steady decode, sampled tokens are fed back on device and `current_pos` advances in trace, so the host copy of tokens and positions intentionally trails the device.

When the persistent-batch layout changes, the next `reset_batch` reloads host-authoritative tokens and positions for every slot. If the just-submitted async decode is still pending, continuing device-resident slots receive stale host state, re-decode the previous token, and can produce greedy token "doubling."

## Changes

- Drain pending async decode steps after `_update_states` discovers a layout change that the scheduler prediction could not see.
- Drain pending async decode steps immediately after a lane-DP layout change, before rebuilding model inputs.
- Remove the leftover `DP_GATHER_DEBUG` batch-size log and its now-unused `os` import.

The synchronization cost is limited to layout-change steps; steady-state decode retains async overlap.

## Validation

- `python3 -m py_compile src/vllm_tt_plugin/model_runner.py`
- `ruff==0.14.0 check src/vllm_tt_plugin/model_runner.py`
- `ruff==0.14.0 format --check src/vllm_tt_plugin/model_runner.py`

Hardware validation not run locally. The targeted reproducer is `tests/tt/test_seeding_and_variety.py` with Llama 70B on a WH Galaxy `[8,4]` mesh, DP=4 lane mode, on-device sampling, and traced decode. Full validation also requires the paired host/model-side fix from tenstorrent/tt-metal#50685.

## Related

- tenstorrent/vllm#444
- tenstorrent/tt-metal#50685
