### PR TITLE
Add MambaSpec state ownership to the TT plugin

### DIFF
--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -582,6 +582,8 @@ class TTAsyncDecodeController:
         # kwarg.
         if model_input.block_tables_per_layer is not None:
             kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
+        if model_input.gdn_state_indices is not None:
+            kwargs["gdn_state_indices"] = model_input.gdn_state_indices
         if perform_device_sampling:
             sampling_param_dict = {
                 field.name: (

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -49,6 +49,17 @@ SEED_NONE_SENTINEL = -1
 LOGPROBS_NONE_SENTINEL = -2
 
 
+def _lane_gdn_state_indices(
+    total: int, scheduled_rows: tuple[int, ...]
+) -> torch.Tensor:
+    """Route only scheduled lane rows to live GDN state."""
+    scheduled = set(scheduled_rows)
+    return torch.tensor(
+        [row if row in scheduled else total + row for row in range(total)],
+        dtype=torch.int32,
+    )
+
+
 def build_cached_request_state(new_req_data) -> CachedRequestState:
     """Build a ``CachedRequestState`` for one newly-scheduled request.
 
@@ -1172,6 +1183,11 @@ class TTLaneInputBatch(InputBatch):
             logitsprocs_list=[None],
             generators_list=[{}],
             prefill_empty_slots=None,
+            gdn_state_indices=(
+                _lane_gdn_state_indices(total, plan.scheduled_rows)
+                if runner._mamba_group_indices
+                else None
+            ),
         )
 
     def _build_prefill_input(
@@ -1256,6 +1272,7 @@ class TTLaneInputBatch(InputBatch):
                 if plan.prefill_empty_slots is not None
                 else None
             ),
+            gdn_state_indices=None,
         )
 
     def extract_output(

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -122,6 +122,12 @@ class TTModelInput:
     # per-rank [B] tensors for DP).
     slot_remap: torch.Tensor | None = None
 
-    # Single-process DP prefill only: global stable slots supplied by the
-    # scheduler-owned step plan. ``None`` for non-DP, gathered-DP, and decode.
+    # Prefill-only: compact GDN state slots. In lane mode these are stable rows
+    # from the step plan; in non-DP they come from the logical Mamba-owner map.
+    # ``None`` for models without MambaSpec and for decode.
     prefill_empty_slots: list[int] | None = None
+
+    # Qwen/GDN decode: compact recurrent-state slots in decode row order.
+    # Logical ownership comes from the request's MambaSpec block group; TT
+    # lowers it to a concurrency-sized physical pool.
+    gdn_state_indices: torch.Tensor | list[int] | None = None

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -20,6 +20,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheConfig,
+    MambaSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.outputs import (
@@ -214,6 +215,12 @@ class TTModelRunner:
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
+        # Physical lowering for scheduler-owned Mamba/GDN state. Requests keep
+        # their compact slot while temporarily unscheduled; preemption/finish
+        # releases it and resumed prefills overwrite the newly assigned slot.
+        self._req_state_slot: dict[str, int] = {}
+        self._req_state_owner: dict[str, tuple[int, ...]] = {}
+        self._mamba_group_indices: list[int] = []
 
         # Every standard-DP rank owns its own mesh and therefore its own host
         # sampler state. Single-process modes also instantiate exactly one.
@@ -359,6 +366,11 @@ class TTModelRunner:
         # Number of kv_cache_groups; needed by DP gather/merge to pack
         # per-group block tables into the gather payload.
         self._num_kv_cache_groups = len(kv_cache_groups)
+        self._mamba_group_indices = [
+            i
+            for i, group in enumerate(kv_cache_groups)
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
         # Cache layer→group index mapping for hybrid models so submit_*
         # can expand ``block_tables_per_group`` into ``block_tables_per_layer``
         # without re-deriving vLLM's group construction order. Non-hybrid
@@ -369,9 +381,12 @@ class TTModelRunner:
         # worker loads the model.
         self._layer_to_group_idx: list[int] | None = None
         if len(kv_cache_groups) > 1:
-            num_layers = self.model_config.get_num_layers_by_block_type(
-                self.parallel_config, "attention"
-            )
+            parsed_layer_indices = [
+                _parse_layer_index(layer_name)
+                for group in kv_cache_groups
+                for layer_name in group.layer_names
+            ]
+            num_layers = max(parsed_layer_indices) + 1
             mapping: list[int | None] = [None] * num_layers
             for g_idx, group in enumerate(kv_cache_groups):
                 for layer_name in group.layer_names:
@@ -401,11 +416,20 @@ class TTModelRunner:
             # full layers 1x512). We unwrap it to per-layer specs in
             # ``_build_per_layer_specs``, so accept it here too.
             if not isinstance(
-                group.kv_cache_spec, (AttentionSpec, UniformTypeKVCacheSpecs)
+                group.kv_cache_spec,
+                (AttentionSpec, MambaSpec, UniformTypeKVCacheSpecs),
             ):
                 raise TypeError(
-                    f"Expected AttentionSpec/UniformTypeKVCacheSpecs for group "
+                    f"Expected AttentionSpec/MambaSpec/UniformTypeKVCacheSpecs for group "
                     f"{group.layer_names}, got {type(group.kv_cache_spec).__name__}"
+                )
+            if (
+                isinstance(group.kv_cache_spec, MambaSpec)
+                and group.kv_cache_spec.mamba_cache_mode != "none"
+            ):
+                raise NotImplementedError(
+                    "TT supports MambaSpec cache mode 'none'; align/all require "
+                    "token-chunked prefill and state-copy support"
                 )
 
     def _kv_cache_shape(
@@ -432,8 +456,12 @@ class TTModelRunner:
         the older ``allocate_kv_cache(shape, dtype, num_layers)`` signature
         and we adapt to it here, asserting the per-layer specs are uniform.
         """
-        num_layers = self.model_config.get_num_layers_by_block_type(
-            self.parallel_config, "attention"
+        num_layers = (
+            len(self._layer_to_group_idx)
+            if self._layer_to_group_idx is not None
+            else self.model_config.get_num_layers_by_block_type(
+                self.parallel_config, "attention"
+            )
         )
         per_layer_specs = self._build_per_layer_specs(kv_cache_config, num_layers)
 
@@ -444,6 +472,11 @@ class TTModelRunner:
         # layer must have the same shape/dtype. The third tuple element is
         # the tensor index, which is irrelevant for the legacy uniform
         # path (each layer gets its own buffer there).
+        if isinstance(per_layer_specs[0], dict):
+            raise NotImplementedError(
+                f"{type(self.model).__name__} must implement "
+                "allocate_kv_cache_per_layer for MambaSpec"
+            )
         shape, dtype, _ = per_layer_specs[0]
         for entry_shape, entry_dtype, _ in per_layer_specs[1:]:
             if (entry_shape, entry_dtype) != (shape, dtype):
@@ -498,7 +531,7 @@ class TTModelRunner:
 
     def _build_per_layer_specs(
         self, kv_cache_config: KVCacheConfig, num_layers: int
-    ) -> list[tuple[tuple[int, int, int, int], Any, int]]:
+    ) -> list[Any]:
         """Resolve ``KVCacheConfig`` → list of ``(shape, dtype, tensor_idx)``
         per layer in model layer-index order.
 
@@ -517,6 +550,62 @@ class TTModelRunner:
         every layer gets a unique buffer and ``tensor_idx == layer_idx``.
         """
         kv_cache_groups = kv_cache_config.kv_cache_groups
+
+        if any(isinstance(group.kv_cache_spec, MambaSpec) for group in kv_cache_groups):
+            spec_by_layer_name = {
+                layer_name: group.kv_cache_spec
+                for group in kv_cache_groups
+                for layer_name in group.layer_names
+            }
+            tensor_idx_by_layer_name = {
+                layer_name: tensor_idx
+                for tensor_idx, tensor in enumerate(kv_cache_config.kv_cache_tensors)
+                for layer_name in tensor.shared_by
+            }
+            per_layer: list[dict[str, Any] | None] = [None] * num_layers
+            for layer_name, spec in spec_by_layer_name.items():
+                idx = _parse_layer_index(layer_name)
+                if not 0 <= idx < num_layers:
+                    raise ValueError(
+                        f"Layer index {idx} parsed from {layer_name!r} is out "
+                        f"of range for {num_layers} cache layers"
+                    )
+                tensor_idx = tensor_idx_by_layer_name.get(layer_name)
+                if tensor_idx is None:
+                    raise ValueError(
+                        f"No KVCacheTensor.shared_by entry covers {layer_name!r}"
+                    )
+                if isinstance(spec, AttentionSpec):
+                    per_layer[idx] = {
+                        "type": "attention",
+                        "shape": self._kv_cache_shape(
+                            spec, kv_cache_config.num_blocks
+                        ),
+                        "dtype": spec.dtype,
+                        "tensor_idx": tensor_idx,
+                    }
+                elif isinstance(spec, MambaSpec):
+                    per_layer[idx] = {
+                        "type": "mamba",
+                        "shapes": spec.shapes,
+                        "dtypes": spec.dtypes,
+                        "tensor_idx": tensor_idx,
+                        # TT cannot expose heterogeneous typed views of
+                        # upstream's shared raw slab. Cache mode none is
+                        # lowered to a compact concurrency-sized state pool.
+                        "compact_slots": self.tt_max_batch_size,
+                    }
+                else:
+                    raise TypeError(
+                        f"Unsupported hybrid cache spec {type(spec).__name__} "
+                        f"for {layer_name}"
+                    )
+            missing = [i for i, entry in enumerate(per_layer) if entry is None]
+            if missing:
+                raise ValueError(
+                    f"No KV cache descriptor covers model layer indices {missing}"
+                )
+            return per_layer  # type: ignore[return-value]
 
         if len(kv_cache_groups) == 1:
             spec = kv_cache_groups[0].kv_cache_spec
@@ -607,6 +696,11 @@ class TTModelRunner:
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
+            self._req_state_slot.pop(req_id, None)
+            self._req_state_owner.pop(req_id, None)
+        for req_id in scheduler_output.preempted_req_ids or ():
+            self._req_state_slot.pop(req_id, None)
+            self._req_state_owner.pop(req_id, None)
 
         # Remove the finished requests from the persistent batch.
         # NOTE(woosuk): There could be an edge case where finished_req_ids and
@@ -802,6 +896,90 @@ class TTModelRunner:
             num_logprobs=num_logprobs,
             enable_log_probs=num_logprobs >= 0,
         )
+
+    def _mamba_state_owner_keys(
+        self,
+        block_tables_per_group: list[torch.Tensor],
+        num_rows: int,
+    ) -> list[tuple[int, ...]] | None:
+        """Return scheduler-owned Mamba block tuples for each request row."""
+        if not self._mamba_group_indices:
+            return None
+        keys = []
+        for row in range(num_rows):
+            key = tuple(
+                int(block_tables_per_group[group_idx][row, 0].item())
+                for group_idx in self._mamba_group_indices
+            )
+            if any(block_id < 0 for block_id in key):
+                raise ValueError(
+                    f"request row {row} has invalid Mamba state blocks {key}"
+                )
+            keys.append(key)
+        return keys
+
+    def _managed_state_slots(
+        self,
+        row_req_ids: list[str],
+        owner_keys: list[tuple[int, ...]] | None,
+        *,
+        is_prompt: bool,
+    ) -> list[int] | None:
+        """Map logical Mamba ownership to compact TT state slots."""
+        if owner_keys is None:
+            return None
+        if len(owner_keys) != len(row_req_ids):
+            raise ValueError("Mamba owner keys and request rows are misaligned")
+
+        capacity = self.tt_per_lane_max_num_seqs
+        held = {
+            slot
+            for req_id, slot in self._req_state_slot.items()
+            if req_id in self.requests
+        }
+        assigned: list[int] = []
+        for row, (req_id, owner) in enumerate(zip(row_req_ids, owner_keys)):
+            slot = self._req_state_slot.get(req_id)
+            old_owner = self._req_state_owner.get(req_id)
+            if slot is None:
+                if not is_prompt:
+                    raise RuntimeError(
+                        f"decode request {req_id!r} has Mamba blocks {owner} "
+                        "but no initialized TT state slot"
+                    )
+                preferred = row if row < capacity else None
+                if preferred is not None and preferred not in held:
+                    slot = preferred
+                else:
+                    slot = next(
+                        (
+                            candidate
+                            for candidate in range(capacity)
+                            if candidate not in held
+                        ),
+                        None,
+                    )
+                if slot is None:
+                    raise RuntimeError(
+                        "no compact GDN state slot is available: "
+                        f"held={sorted(held)}, capacity={capacity}"
+                    )
+            elif old_owner != owner and not is_prompt:
+                raise RuntimeError(
+                    f"decode request {req_id!r} changed Mamba ownership "
+                    f"from {old_owner} to {owner} without a rebuilding prefill"
+                )
+
+            held.add(slot)
+            self._req_state_slot[req_id] = slot
+            self._req_state_owner[req_id] = owner
+            assigned.append(slot)
+
+        if len(set(assigned)) != len(assigned):
+            raise RuntimeError(
+                f"current Mamba requests alias compact state slots {assigned}"
+            )
+        return assigned
 
     def _prepare_model_inputs(
         self,
@@ -1134,6 +1312,21 @@ class TTModelRunner:
         block_tables_per_group = [bt.contiguous() for bt in block_tables_per_group]
         block_tables = block_tables_per_group[0]
         slot_remap = input_batch.pop_slot_remap() if capture_slot_remap else None
+        row_req_ids = [input_batch.req_ids[i] for i in req_indices]
+        owner_keys = self._mamba_state_owner_keys(
+            block_tables_per_group, len(row_req_ids)
+        )
+        state_slots = self._managed_state_slots(
+            row_req_ids,
+            owner_keys,
+            is_prompt=is_prompt,
+        )
+        prefill_empty_slots = state_slots if is_prompt else None
+        gdn_state_indices = (
+            torch.tensor(state_slots, dtype=torch.int32)
+            if state_slots is not None and not is_prompt
+            else None
+        )
 
         return TTModelInput(
             input_tokens=input_tokens,
@@ -1157,6 +1350,8 @@ class TTModelRunner:
             max_num_logprobs=[input_batch.max_num_logprobs],
             logitsprocs_list=[logitsprocs],
             generators_list=[generators],
+            prefill_empty_slots=prefill_empty_slots,
+            gdn_state_indices=gdn_state_indices,
         )
 
     def build_model_input(
@@ -2375,16 +2570,16 @@ class TTModelRunner:
                 for s in sampling_param_dict["seed"]
             ]
             kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
-        if len(batch_size_per_dp) > 1:
-            empty_slots = model_input.prefill_empty_slots
-            if empty_slots is None:
-                # TODO: the model should only require DP ranks, but passing
-                # "global" user ids instead for backwards compatibility.
-                stride = self.tt_per_lane_max_num_seqs
-                empty_slots = []
-                for dp_rank, sz in enumerate(batch_size_per_dp):
-                    for i in range(int(sz)):
-                        empty_slots.append(dp_rank * stride + i)
+        empty_slots = model_input.prefill_empty_slots
+        if empty_slots is None and len(batch_size_per_dp) > 1:
+            # TODO: the model should only require DP ranks, but passing
+            # "global" user ids instead for backwards compatibility.
+            stride = self.tt_per_lane_max_num_seqs
+            empty_slots = []
+            for dp_rank, sz in enumerate(batch_size_per_dp):
+                for i in range(int(sz)):
+                    empty_slots.append(dp_rank * stride + i)
+        if empty_slots is not None:
             kwargs["empty_slots"] = list(empty_slots)
 
         if self.request_specific_rope:
@@ -3011,8 +3206,11 @@ class TTModelRunner:
         if hasattr(self.model, "already_warmed_up_prefill"):
             self.model.already_warmed_up_prefill = False
 
-        # Phase 2: capture traces (all ops already compiled)
-        if trace_prefill_mode:
-            self.model.warmup_model_prefill(enable_trace=True, **prefill_kwargs)
+        # Phase 2: capture traces (all ops already compiled). Capture decode
+        # first and the much larger prefill trace last. A later trace capture
+        # can reuse addresses held by an earlier trace's temporaries; keeping
+        # the largest trace last prevents decode capture from clobbering it.
         if trace_decode_mode:
             self.model.warmup_model_decode(enable_trace=True, **decode_kwargs)
+        if trace_prefill_mode:
+            self.model.warmup_model_prefill(enable_trace=True, **prefill_kwargs)

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1046,6 +1046,22 @@ class TTPlatform(Platform):
                         "models with sliding window, disabling it"
                     )
 
+        # Upstream's hybrid-Mamba config runs before this platform hook and
+        # may have selected cache mode "all" while prefix caching was still
+        # enabled. If TT disabled prefix caching, restore the non-prefix
+        # lifecycle expected by the scheduler and TT's compact state lowering.
+        if (
+            not vllm_config.cache_config.enable_prefix_caching
+            and hasattr(model_class, "get_mamba_state_shape_from_config")
+        ):
+            vllm_config.cache_config.mamba_cache_mode = "none"
+            vllm_config.cache_config.mamba_block_size = (
+                vllm_config.model_config.max_model_len
+            )
+            # The model's cache-spec hook recomputes padding after any TT
+            # trace-compatible attention block adjustment.
+            vllm_config.cache_config.mamba_page_size_padded = None
+
         logger.info(
             "Automatic prefix caching is %s",
             "enabled" if vllm_config.cache_config.enable_prefix_caching else "disabled",

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -5,6 +5,7 @@ import math
 import os
 import time
 import warnings
+from collections import Counter
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -22,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     MLAAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -46,6 +48,7 @@ except ImportError:  # pragma: no cover - older vLLM without the timing contract
 from vllm_tt_plugin.config import (
     get_tt_config,
     get_tt_data_parallel_size,
+    get_tt_max_batch_size,
     get_tt_per_lane_max_num_seqs,
 )
 from vllm_tt_plugin.model_input import TTModelInput
@@ -69,6 +72,25 @@ logger = init_tt_logger(__name__)
 # before initializing multimodal caches; without this, early architecture
 # inspection may fail for TT-prefixed architectures.
 register_tt_models(register_test_models=_should_pre_register_tt_test_models_from_cli())
+
+
+def _count_mamba_cache_groups(kv_cache_specs: dict[str, KVCacheSpec] | None) -> int:
+    """Mirror upstream hybrid grouping and count logical Mamba block tables."""
+    if not kv_cache_specs:
+        return 0
+    same_spec_counts = Counter(kv_cache_specs.values())
+    if not any(isinstance(spec, MambaSpec) for spec in same_spec_counts):
+        return 0
+
+    layer_counts = list(same_spec_counts.values())
+    group_size = min(layer_counts)
+    if max(layer_counts) < group_size * 1.25:
+        group_size = max(layer_counts)
+    return sum(
+        math.ceil(count / group_size)
+        for spec, count in same_spec_counts.items()
+        if isinstance(spec, MambaSpec)
+    )
 
 
 def _ensure_visible_devices_env(
@@ -645,6 +667,15 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig, num_devices: int = 1) -
         )
     # endregion
 
+    # Resolve model-owned hybrid specs before doing any block-sized arithmetic.
+    # Qwen may raise the upstream minimum hybrid block to a traced-prefill page
+    # boundary; using the old size for per-request padding would under-reserve
+    # the shared BlockPool.
+    cache_spec_hook = getattr(model_class, "get_kv_cache_spec", None)
+    kv_cache_specs = (
+        cache_spec_hook(vllm_config) if cache_spec_hook is not None else None
+    )
+
     # To fit a max batch with (max_tokens_all_users / max batch) per user,
     # allocate an extra block_size per user since vLLM uses a worst-case
     # heuristic and assumes each touched block will require a new
@@ -692,7 +723,51 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig, num_devices: int = 1) -
             sliding_window * max_batch * _MAX_SLIDING_GROUPS_HEURISTIC
         )
 
+    # Cache mode "none" still allocates one logical block per request for
+    # every Mamba group. TT keeps the actual recurrent tensors in a compact
+    # model-owned pool, but the IDs still consume upstream BlockPool entries.
+    if kv_cache_specs is not None:
+        mamba_groups = _count_mamba_cache_groups(kv_cache_specs)
+        max_tokens_all_users += (
+            mamba_groups * max_batch * cache_config.block_size
+        )
+
     num_tt_blocks = math.ceil(max_tokens_all_users / cache_config.block_size)
+
+    # TT lowers MambaSpec mode "none" into model-owned typed state pools
+    # rather than the shared raw KV slab. Reserve their actual per-device DRAM
+    # by removing the equivalent number of all-attention blocks.
+    managed_state_hook = getattr(model_class, "get_managed_state_pool_bytes", None)
+    if managed_state_hook is not None:
+        managed_state_bytes = int(
+            managed_state_hook(
+                vllm_config,
+                get_tt_max_batch_size(vllm_config),
+            )
+        )
+        attention_bytes_per_block = sum(
+            spec.page_size_bytes
+            for spec in (kv_cache_specs or {}).values()
+            if isinstance(spec, FullAttentionSpec)
+        )
+        if managed_state_bytes and not attention_bytes_per_block:
+            raise ValueError("Managed Mamba state has no attention cache capacity to reserve")
+        reserved_blocks = (
+            math.ceil(managed_state_bytes / attention_bytes_per_block)
+            if managed_state_bytes
+            else 0
+        )
+        if reserved_blocks >= num_tt_blocks:
+            raise ValueError(
+                f"Managed Mamba state requires {reserved_blocks} cache-block equivalents, "
+                f"but only {num_tt_blocks} blocks are configured"
+            )
+        num_tt_blocks -= reserved_blocks
+        logger.info(
+            "Reserving %d bytes (%d all-attention block equivalents) for managed Mamba state",
+            managed_state_bytes,
+            reserved_blocks,
+        )
 
     return num_tt_blocks
 

--- a/tests/test_mamba_state_slots.py
+++ b/tests/test_mamba_state_slots.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+"""Host-only tests for scheduler-owned TT GDN state."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_tt_plugin.input_batch import _lane_gdn_state_indices
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+
+def _runner(capacity=8):
+    return SimpleNamespace(
+        tt_per_lane_max_num_seqs=capacity,
+        _req_state_slot={},
+        _req_state_owner={},
+        requests={},
+    )
+
+
+def _prefill(runner, req_ids, owners):
+    runner.requests.update(dict.fromkeys(req_ids))
+    return TTModelRunner._managed_state_slots(
+        runner,
+        list(req_ids),
+        list(owners),
+        is_prompt=True,
+    )
+
+
+def _decode(runner, req_ids, owners):
+    return TTModelRunner._managed_state_slots(
+        runner,
+        list(req_ids),
+        list(owners),
+        is_prompt=False,
+    )
+
+
+def test_state_follows_owner_without_permuting_the_decode_batch():
+    r = _runner()
+    assert _prefill(r, ["A"], [(100,)]) == [0]
+
+    incoming = [f"B{i}" for i in range(7)]
+    incoming_owners = [(200 + i,) for i in range(7)]
+    assert _prefill(r, incoming, incoming_owners) == list(range(1, 8))
+
+    req_ids = incoming + ["A"]
+    owners = incoming_owners + [(100,)]
+    assert _decode(r, req_ids, owners) == [1, 2, 3, 4, 5, 6, 7, 0]
+    assert _decode(r, list(reversed(req_ids)), list(reversed(owners))) == [
+        0,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+    ]
+
+
+def test_unscheduled_state_is_held_until_finish_or_preemption():
+    r = _runner(capacity=2)
+    assert _prefill(r, ["A", "B"], [(10,), (11,)]) == [0, 1]
+    assert _decode(r, ["B"], [(11,)]) == [1]
+    with pytest.raises(RuntimeError, match="no compact GDN state slot"):
+        _prefill(r, ["C"], [(12,)])
+
+    r.requests.pop("A")
+    r._req_state_slot.pop("A")
+    r._req_state_owner.pop("A")
+    assert _prefill(r, ["C"], [(12,)]) == [0]
+
+
+def test_owner_change_requires_rebuilding_prefill():
+    r = _runner()
+    assert _prefill(r, ["A"], [(10,)]) == [0]
+    with pytest.raises(RuntimeError, match="changed Mamba ownership"):
+        _decode(r, ["A"], [(99,)])
+    assert _prefill(r, ["A"], [(99,)]) == [0]
+    assert _decode(r, ["A"], [(99,)]) == [0]
+
+
+def test_lane_unscheduled_occupied_rows_use_dummy_state():
+    # Rows 0 and 2 may both be occupied, but only row 2 runs this step.
+    assert _lane_gdn_state_indices(4, (2,)).tolist() == [4, 5, 2, 7]

--- a/tests/test_num_available_blocks.py
+++ b/tests/test_num_available_blocks.py
@@ -31,6 +31,7 @@ exercise the headroom formula.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from vllm_tt_plugin import config as tt_config
 
@@ -76,6 +77,8 @@ def _model_budget(max_tokens: int, hybrid_enabled: bool = False):
     """
     fake_model_class = MagicMock()
     fake_model_class.get_max_tokens_all_users.return_value = max_tokens
+    fake_model_class.get_kv_cache_spec = None
+    fake_model_class.get_managed_state_pool_bytes = None
     fake_model_class._HYBRID_KV_CACHE_GROUPS_ENABLED = hybrid_enabled
     return patch(
         "vllm_tt_plugin.worker.get_model_architecture",
@@ -182,3 +185,143 @@ def test_per_model_branch_with_sliding_window(cfg):
     # gemma-3-4b N300 branch: 65536 base + 64*32 padding + 1024*32*8 sliding
     # = 65536 + 2048 + 262144 = 329728 -> ceil/64 = 5152
     assert n == 5152
+
+
+def test_mamba_group_count_matches_upstream_hybrid_partitioning():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+    from vllm_tt_plugin.worker import _count_mamba_cache_groups
+
+    attention = FullAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba = MambaSpec(
+        shapes=((3, 128), (1, 128, 128)),
+        dtypes=(torch.bfloat16, torch.bfloat16),
+        block_size=4096,
+    )
+    specs = {
+        **{f"layers.{i}.attn": attention for i in range(8)},
+        **{f"layers.{i}.gdn": mamba for i in range(8, 32)},
+    }
+    assert _count_mamba_cache_groups(specs) == 3
+
+
+def test_mamba_groups_add_one_block_per_live_request(cfg):
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+    from vllm_tt_plugin.worker import get_num_available_blocks_tt
+
+    attention = FullAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba = MambaSpec(
+        shapes=((3, 128), (1, 128, 128)),
+        dtypes=(torch.bfloat16, torch.bfloat16),
+        block_size=4096,
+    )
+    specs = {
+        **{f"layers.{i}.attn": attention for i in range(8)},
+        **{f"layers.{i}.gdn": mamba for i in range(8, 32)},
+    }
+    fake_model_class = MagicMock()
+    fake_model_class.get_max_tokens_all_users.return_value = 6400
+    fake_model_class.get_kv_cache_spec.return_value = specs
+    fake_model_class.get_managed_state_pool_bytes = None
+    fake_model_class._HYBRID_KV_CACHE_GROUPS_ENABLED = False
+    cfg.scheduler_config.max_num_seqs = 2
+
+    with (
+        patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
+        patch(
+            "vllm_tt_plugin.worker.get_model_architecture",
+            return_value=(fake_model_class, "arch"),
+        ),
+    ):
+        n = get_num_available_blocks_tt(cfg)
+
+    assert n == 108
+
+
+def test_hybrid_hook_updates_block_size_before_headroom_math(cfg):
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+    from vllm_tt_plugin.worker import get_num_available_blocks_tt
+
+    attention = FullAttentionSpec(
+        block_size=1024,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba = MambaSpec(
+        shapes=((3, 128), (1, 128, 128)),
+        dtypes=(torch.bfloat16, torch.bfloat16),
+        block_size=4096,
+    )
+    specs = {
+        **{f"layers.{i}.attn": attention for i in range(8)},
+        **{f"layers.{i}.gdn": mamba for i in range(8, 32)},
+    }
+
+    def get_specs(vllm_config):
+        vllm_config.cache_config.block_size = 1024
+        return specs
+
+    fake_model_class = MagicMock()
+    fake_model_class.get_max_tokens_all_users.return_value = 65_536
+    fake_model_class.get_kv_cache_spec.side_effect = get_specs
+    fake_model_class.get_managed_state_pool_bytes = None
+    fake_model_class._HYBRID_KV_CACHE_GROUPS_ENABLED = False
+
+    with patch(
+        "vllm_tt_plugin.worker.get_model_architecture",
+        return_value=(fake_model_class, "arch"),
+    ):
+        n = get_num_available_blocks_tt(cfg)
+
+    # 64 attention blocks + 32 per-request padding blocks + 3*32 Mamba blocks.
+    assert n == 192
+
+
+def test_managed_state_dram_reduces_attention_block_capacity(cfg):
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+    from vllm_tt_plugin.worker import get_num_available_blocks_tt
+
+    attention = FullAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba = MambaSpec(
+        shapes=((3, 128), (1, 128, 128)),
+        dtypes=(torch.bfloat16, torch.bfloat16),
+        block_size=4096,
+    )
+    specs = {
+        **{f"layers.{i}.attn": attention for i in range(8)},
+        **{f"layers.{i}.gdn": mamba for i in range(8, 32)},
+    }
+    bytes_per_all_attention_block = 8 * attention.page_size_bytes
+    fake_model_class = MagicMock()
+    fake_model_class.get_max_tokens_all_users.return_value = 6400
+    fake_model_class.get_kv_cache_spec.return_value = specs
+    fake_model_class.get_managed_state_pool_bytes.return_value = (
+        bytes_per_all_attention_block + 1
+    )
+    fake_model_class._HYBRID_KV_CACHE_GROUPS_ENABLED = False
+    cfg.scheduler_config.max_num_seqs = 2
+
+    with patch(
+        "vllm_tt_plugin.worker.get_model_architecture",
+        return_value=(fake_model_class, "arch"),
+    ):
+        n = get_num_available_blocks_tt(cfg)
+
+    # The base hybrid calculation yields 108 blocks; state needs two
+    # all-attention block equivalents.
+    assert n == 106


### PR DESCRIPTION
## Summary

Add upstream MambaSpec ownership and hybrid-cache lowering to the standalone TT plugin.

Requests retain compact managed-state slots while temporarily unscheduled; finish and preemption release them. Decode receives state indices in batch-row order, so GDN state is gathered instead of permuting either the state pool or decode batch.

Also included:
- per-layer attention and Mamba cache descriptors;
- standard-DP and lane routing;
- scheduled-only live state for lane decode;
- logical Mamba BlockPool headroom;
- managed-state DRAM reservation;
- restoration of cache mode `none` when TT disables prefix caching;
- decode-before-prefill trace capture order.

Companion PRs:
- tt-metal model and operations: https://github.com/tenstorrent/tt-metal/pull/51653
- embedded plugin: https://github.com/tenstorrent/vllm/pull/457

## Validation

- Python syntax compilation passed.
- `git diff --check` passed.
- Added host regression tests for ownership, reorder, unscheduling, preemption, grouping, block-size changes, and state DRAM reservation.
- Device and pytest execution remain pending because the local environment lacks the runtime dependencies and no suitable Blackhole IRD reservation was available.