### PR TITLE
[port tenstorrent/vllm#446] Return None from sample_tokens when no pending forward

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -2251,7 +2251,7 @@ class TTModelRunner:
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
-    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
+    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput | None:
         """Sample the forward deferred by a preceding ``execute_model``.
 
         Pops the oldest pending forward (FIFO, matching the engine's
@@ -2259,7 +2259,16 @@ class TTModelRunner:
         produces its output (or an async wrapper for overlapped decode). The
         engine calls this exactly once per ``execute_model`` that returned
         ``None``.
+
+        If the preceding ``execute_model`` failed it enqueued no pending
+        forward, so return ``None`` instead of raising ``IndexError`` on an
+        empty deque. The engine treats ``None`` here as "the original
+        execute_model failed" and re-raises that real exception (see
+        ``EngineCore``'s ``if model_output is None`` path), so the true cause
+        surfaces instead of being masked by the empty-popleft error.
         """
+        if not self._pending_samples:
+            return None
         finish = self._pending_samples.popleft()
         return finish(grammar_output)
 


### PR DESCRIPTION
## Purpose

Port the runner-side error propagation fix from tenstorrent/vllm#446 into the standalone `vllm-tt-plugin` repository.

On the TT `uniproc_executor(non_block)` path, when `execute_model()` fails it enqueues no pending forward. The subsequent `sample_tokens()` call raised `IndexError` on an unconditional `popleft()` from an empty `_pending_samples` deque, masking the original `execute_model()` exception.

## Changes

- Return `None` from `sample_tokens()` when no pending forward is queued.
- Extend the method return annotation to include `None`.

The engine already treats a `None` sampling result as an indication that the original `execute_model()` failed and re-raises that exception through `exec_model_fut.result()`. The normal success path is unchanged.

## Validation

- `python3 -m py_compile src/vllm_tt_plugin/model_runner.py`
- `ruff==0.14.0 check src/vllm_tt_plugin/model_runner.py`
- `ruff==0.14.0 format --check src/vllm_tt_plugin/model_runner.py`
- `git diff --check`

Pytest was not run locally because the host does not have the required `ttnn` environment.

## Related

- tenstorrent/vllm#446