### PR TITLE
[port tenstorrent/vllm#465] mesh: map MESH_DEVICE=BH-Galaxy to the Galaxy mesh grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ python examples/offline_inference_tt.py --measure_perf
 ```
 
 To run a different text model, set `MESH_DEVICE` to `N150`, `N300`, `T3K`, `TG`,
-or a mesh shape such as `"(4,8)"`, then pass `--model`:
+`BH-Galaxy`, or a mesh shape such as `"(4,8)"`, then pass `--model`:
 
 - Llama 3.1 8B: `--model "meta-llama/Llama-3.1-8B"`
 - Llama 3.2 1B: `--model "meta-llama/Llama-3.2-1B"`

--- a/src/vllm_tt_plugin/utils/dp_discovery.py
+++ b/src/vllm_tt_plugin/utils/dp_discovery.py
@@ -43,6 +43,9 @@ def _parse_mesh_grid(
     """
     mesh_grid_dict = dict(_MESH_GRID_PRESETS)
     mesh_grid_dict["TG"] = tg_mesh_grid
+    # BH Galaxy is 32x P150 in the same 32-chip topology as the WH Galaxy, so it
+    # takes the caller's Galaxy grid too.
+    mesh_grid_dict["BH-Galaxy"] = tg_mesh_grid
 
     if mesh_device_env is None:
         return (1, num_devices_available)

--- a/tests/test_dp_modes.py
+++ b/tests/test_dp_modes.py
@@ -20,6 +20,7 @@ from vllm_tt_plugin.platform import (
 )
 from vllm_tt_plugin.utils.dp_discovery import (
     _maybe_reorder_standard_dp_visible_device_groups,
+    _resolve_parent_mesh_grid,
 )
 from vllm_tt_plugin.worker import TTWorker, _resolve_mesh_grid
 
@@ -200,6 +201,15 @@ class TestDPModes:
         assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)
         assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
         assert _resolve_mesh_grid("P150x8", 8, "3") == (1, 1)
+
+    def test_bh_galaxy_resolves_like_wh_galaxy(self) -> None:
+        assert _resolve_mesh_grid("BH-Galaxy", 32, None) == (8, 4)
+        assert _resolve_mesh_grid("BH-Galaxy", 32, None) == _resolve_mesh_grid(
+            "TG", 32, None
+        )
+        assert _resolve_parent_mesh_grid("BH-Galaxy", 32) == _resolve_parent_mesh_grid(
+            "TG", 32
+        )
 
     def test_visible_devices_use_discovered_submesh_shape(
         self,


### PR DESCRIPTION
Port of https://github.com/tenstorrent/vllm/pull/465 (original fix by @vcankovic).

### Problem

Bringing up Qwen3-32B on BH Galaxy fails at engine start:

```
AssertionError: Invalid MESH_DEVICE: BH-Galaxy
```

tt-inference-server emits `MESH_DEVICE=BH-Galaxy` for `DeviceTypes.BLACKHOLE_GALAXY`
(`workflows/workflow_types.py:107`, `utils/device_utils.py:21`), but the plugin's
preset table has no entry for it, so `_parse_mesh_grid()` raises.

### Fix

In this repo the preset table lives in `utils/dp_discovery.py` and `TG` is not a
fixed preset: it is injected per caller, `(8, 4)` from the worker
(`_resolve_mesh_grid`) and `(4, 8)` from parent-mesh discovery
(`_resolve_parent_mesh_grid`). So `BH-Galaxy` is aliased to the same
caller-supplied Galaxy grid rather than hardcoded to `(8, 4)`, which reproduces
the upstream behaviour on the worker path and keeps the discovery path
consistent with `TG`.

### Why the Galaxy grid

BH Galaxy is 32x P150, the same 32-chip 8x4 topology as the Wormhole Galaxy
(`TG`), just Blackhole silicon. Corroborated by tt-inference-server's model spec:
the `BLACKHOLE_GALAXY` block for `qwen3_32b_galaxy` in
`workflows/model_specs/dev/llm.yaml` is a byte-identical copy of the `GALAXY`
block, including `max_concurrency: 32  # 8 * 4` and `data_parallel_size: 4`.

Note that `BLACKHOLE_GALAXY` is a distinct `ttnn.cluster.ClusterType` from
`GALAXY`, so the WH-Galaxy DP=4 device-group reorder in
`_maybe_reorder_standard_dp_visible_device_groups()` does not fire for BH Galaxy.
That path is left untouched here; it needs its own validation on hardware.

### Tests

Added `test_bh_galaxy_resolves_like_wh_galaxy` in `tests/test_dp_modes.py`,
asserting `(8, 4)` on the worker path and parity with `TG` on both paths.
`pre-commit` passes; the pytest suite was not run locally (no TT runtime on this
machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)