### PR TITLE
feature: serve DiffusionGemma block outputs on vLLM 0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K \
 python examples/server_example_tt.py
 ```
 
+DiffusionGemma uses a 256-token block-serving contract with stricter launch and
+request constraints. See [DiffusionGemma block serving](docs/diffusion-gemma.md)
+for the exact vLLM 0.24 command, paired tt-metal commit, request validation, and
+block metrics.
+
 Send a completion request:
 
 ```bash

--- a/docs/diffusion-gemma.md
+++ b/docs/diffusion-gemma.md
@@ -1,0 +1,117 @@
+# DiffusionGemma Block Serving
+
+DiffusionGemma is a block-output model. One model invocation commits a complete
+256-token canvas, not one autoregressive token. The paired implementation is
+`tenstorrent/tt-metal` commit
+`e37613fd2973d969c362a127b2d0c401a5e145d6`. Its adapter declares:
+
+- `output_tokens_per_step=256`
+- `supports_sample_on_device=True`
+- `supports_async_decode=False`
+- `supports_prefix_caching=False`
+
+The adapter owns the Gumbel sampler and temperature schedule, prompt and canvas
+KV state, denoise loop, and persistent Metal captures. vLLM schedules physical
+canvases and trims the final canvas to the request's logical `max_tokens`.
+
+## Installation
+
+Install vLLM 0.24.0 into an activated tt-metal environment, then install this
+plugin. Do not install a CUDA vLLM wheel over that environment.
+
+```bash
+VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm vllm==0.24.0
+uv pip install -e .
+```
+
+## Launch
+
+Run from the paired tt-metal checkout so the registered model target under
+`models.experimental.diffusion_gemma` is importable.
+
+```bash
+export PYTHONPATH=/path/to/tt-metal
+export MESH_DEVICE=P150x4
+
+python -m vllm.entrypoints.openai.api_server \
+  --model <diffusion-gemma-checkpoint> \
+  --served-model-name diffusiongemma-26B-A4B-it \
+  --generation-config vllm \
+  --max-model-len <served-context-limit> \
+  --max-num-batched-tokens <served-context-limit> \
+  --max-num-seqs 1 \
+  --block-size 64 \
+  --no-enable-prefix-caching \
+  --no-enable-chunked-prefill \
+  --no-async-scheduling \
+  --reasoning-parser diffusion_gemma \
+  --additional-config '{"tt":{"sample_on_device_mode":"all","enable_model_warmup":true,"trace_mode":"all"}}'
+```
+
+The plugin pins `VLLM_USE_V2_MODEL_RUNNER=0` because vLLM 0.24 otherwise
+classifies any model with `canvas_length` as a Triton-only V2 diffusion runner.
+The TT worker implements the V1 runner.
+
+`--max-num-batched-tokens` concerns scheduler prompt admission. It does not
+disable DiffusionGemma's model-internal ragged and chunked prompt processing.
+Set the trace-region and DiffusionGemma capture environment variables required
+by the paired tt-metal model for the target context and mesh.
+
+## Request Contract
+
+Current support is synchronous, DP=1, one active sequence, on-device sampling
+for all model calls, and no vLLM automatic prefix caching or scheduler chunked
+prefill. Async scheduling, structured output, vLLM logprobs, host sampling,
+custom logits processors, and multiple responses are rejected.
+
+Omitted controls and these neutral transport values are accepted:
+
+- `temperature=1.0`
+- `top_p=1.0`
+- `top_k=0` or `-1`
+- `min_p=0.0`
+- no seed
+- presence/frequency penalties `0.0`
+- repetition penalty `1.0`
+
+Explicit non-neutral values are rejected with a 4xx request error; they are
+never silently ignored or rewritten. Response-contract controls such as
+`n>1`, logprobs, structured outputs, bad words, logit bias, allowed token IDs,
+nonzero minimum tokens, and custom sampling `extra_args` are also rejected
+before EngineCore.
+
+Physical admission rounds logical output up to complete canvases:
+
+```text
+prompt_tokens + ceil(max_tokens / 256) * 256 <= max_model_len
+```
+
+The historical `/v1/completions` default `max_tokens=16` remains valid. It
+runs one physical canvas and returns at most 16 logical tokens. An omitted
+output limit is clamped to the largest whole-canvas capacity that fits.
+
+## Metrics
+
+vLLM request metrics count client-visible logical output tokens after EOS,
+stop, and `max_tokens` trimming. DiffusionGemma model telemetry is physical:
+one block is 256 committed tokens. Use the adapter's `prefill_block0`,
+`decode_block`, `block_ids`, `committed_tokens`, `denoise_steps`, and
+block-latency events for
+device performance. Report block throughput as:
+
+```text
+physical tokens per block second = 256 / block_latency_seconds
+```
+
+Do not report autoregressive TPOT for this model.
+
+## Current Limitations
+
+- One request at a time (`max_num_seqs=1`) and DP=1.
+- No generic async block scheduling or preemption overlap.
+- No vLLM APC, scheduler chunked prefill, speculative decoding, or host-side
+  sampling controls.
+- A running block request prevents forced prefix-cache reset; finish or abort
+  it first.
+- Device server validation requires the paired tt-metal checkout and model
+  artifacts. Host plugin tests do not prove model correctness or performance.

--- a/docs/diffusion-gemma.md
+++ b/docs/diffusion-gemma.md
@@ -64,21 +64,19 @@ for all model calls, and no vLLM automatic prefix caching or scheduler chunked
 prefill. Async scheduling, structured output, vLLM logprobs, host sampling,
 custom logits processors, and multiple responses are rejected.
 
-Omitted controls and these neutral transport values are accepted:
+HTTP sampling controls are accepted for OpenAI-client compatibility but ignored:
 
-- `temperature=1.0`
-- `top_p=1.0`
-- `top_k=0` or `-1`
-- `min_p=0.0`
-- no seed
-- presence/frequency penalties `0.0`
-- repetition penalty `1.0`
+- `temperature`, `top_p`, `top_k`, and `min_p`
+- `seed`
+- presence, frequency, and repetition penalties
 
-Explicit non-neutral values are rejected with a 4xx request error; they are
-never silently ignored or rewritten. Response-contract controls such as
-`n>1`, logprobs, structured outputs, bad words, logit bias, allowed token IDs,
-nonzero minimum tokens, and custom sampling `extra_args` are also rejected
-before EngineCore.
+The model-owned denoise loop always uses its internal temperature schedule and
+Gumbel sampler, so these fields do not alter generation. Validation neutralizes
+them in place before vLLM clones `SamplingParams`; offline callers must not
+reuse the same object for a later autoregressive request. Response-contract
+controls such as `n>1`, logprobs, structured outputs, bad words, logit bias,
+allowed token IDs, nonzero minimum tokens, and custom sampling `extra_args`
+remain rejected before EngineCore.
 
 Physical admission rounds logical output up to complete canvases:
 

--- a/src/vllm_tt_plugin/config.py
+++ b/src/vllm_tt_plugin/config.py
@@ -38,6 +38,7 @@ def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
 # than user input. Written by store_tt_lane_count, read by
 # get_tt_data_parallel_size.
 _RESOLVED_LANE_COUNT_KEY = "_tt_resolved_lane_count"
+_OUTPUT_TOKENS_PER_STEP_KEY = "_tt_output_tokens_per_step"
 
 
 def get_tt_data_parallel_size(vllm_config: "VllmConfig") -> int:
@@ -70,6 +71,37 @@ def store_tt_lane_count(vllm_config: "VllmConfig", lanes: int) -> None:
         additional = {}
         vllm_config.additional_config = additional
     additional[_RESOLVED_LANE_COUNT_KEY] = lanes
+
+
+def get_tt_output_tokens_per_step(vllm_config: "VllmConfig") -> int:
+    """Return the normalized model output width, defaulting to AR behavior.
+
+    ``TTPlatform.check_and_update_config`` resolves the model capability once
+    and stores it on the serializable vLLM config. Scheduler and worker
+    construction therefore do not need to import model-loader code.
+    """
+    additional = getattr(vllm_config, "additional_config", None) or {}
+    return int(additional.get(_OUTPUT_TOKENS_PER_STEP_KEY, 1))
+
+
+def store_tt_output_tokens_per_step(
+    vllm_config: "VllmConfig", output_tokens_per_step: int
+) -> None:
+    """Store the validated per-request output width on the vLLM config."""
+    if (
+        isinstance(output_tokens_per_step, bool)
+        or not isinstance(output_tokens_per_step, int)
+        or output_tokens_per_step < 1
+    ):
+        raise ValueError(
+            "resolved TT output_tokens_per_step must be an integer >= 1, got "
+            f"{output_tokens_per_step!r}"
+        )
+    additional = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional, dict):
+        additional = {}
+        vllm_config.additional_config = additional
+    additional[_OUTPUT_TOKENS_PER_STEP_KEY] = output_tokens_per_step
 
 
 def get_tt_max_batch_size(vllm_config: "VllmConfig") -> int:

--- a/src/vllm_tt_plugin/entrypoints.py
+++ b/src/vllm_tt_plugin/entrypoints.py
@@ -87,7 +87,22 @@ def _install_diffusion_gemma_complete_parser_adapter() -> None:
                 token_extractor = getattr(
                     reasoning_parser, "extract_reasoning_from_token_ids", None
                 )
-                if model_output_token_ids and callable(token_extractor):
+                # When the request kept special tokens (the tool parser's
+                # adjust_request forces skip_special_tokens=False whenever
+                # tools are enabled), the plain text path both suffices and
+                # preserves the literal <|tool_call> frames the tool parser
+                # needs; re-decoding segments with skip_special_tokens=True
+                # would strip them. The token-ID rescue is only for text that
+                # detokenization already stripped the channel markers from.
+                marker_text_visible = (
+                    reasoning_parser.start_token in model_output
+                    or reasoning_parser.end_token in model_output
+                )
+                if (
+                    model_output_token_ids
+                    and callable(token_extractor)
+                    and not marker_text_visible
+                ):
                     reasoning, content = token_extractor(
                         model_output_token_ids, model_output
                     )

--- a/src/vllm_tt_plugin/entrypoints.py
+++ b/src/vllm_tt_plugin/entrypoints.py
@@ -29,6 +29,81 @@ def _register_tt_reasoning_parsers() -> None:
         "vllm_tt_plugin.gemma4_reasoning_parser",
         "Gemma4ReasoningParser",
     )
+    ReasoningParserManager.register_lazy_module(
+        "diffusion_gemma",
+        "vllm_tt_plugin.gemma4_reasoning_parser",
+        "Gemma4ReasoningParser",
+    )
+    _install_diffusion_gemma_complete_parser_adapter()
+
+
+def _install_diffusion_gemma_complete_parser_adapter() -> None:
+    """Forward non-streaming token IDs to the DiffusionGemma parser.
+
+    vLLM 0.24 supplies ``model_output_token_ids`` to ``Parser.parse`` but its
+    generated ``DelegatingParser`` ignores them. DiffusionGemma needs those IDs
+    because normal detokenization may strip its reasoning markers. Keep the
+    compatibility adapter scoped to the plugin's ``diffusion_gemma`` alias.
+    """
+    from collections.abc import Sequence
+    from typing import Any
+
+    from vllm.parser.parser_manager import ParserManager
+
+    if getattr(ParserManager, "_tt_diffusion_complete_parser_installed", False):
+        return
+
+    original_get_parser = ParserManager.get_parser
+
+    @classmethod
+    def get_parser(
+        cls,
+        tool_parser_name: str | None = None,
+        reasoning_parser_name: str | None = None,
+        enable_auto_tools: bool = False,
+        model_name: str | None = None,
+        is_harmony: bool = False,
+    ):
+        del cls
+        parser_cls = original_get_parser(
+            tool_parser_name=tool_parser_name,
+            reasoning_parser_name=reasoning_parser_name,
+            enable_auto_tools=enable_auto_tools,
+            model_name=model_name,
+            is_harmony=is_harmony,
+        )
+        if parser_cls is None or reasoning_parser_name != "diffusion_gemma":
+            return parser_cls
+
+        class DiffusionGemmaParser(parser_cls):
+            def parse(
+                self,
+                model_output: str,
+                request: Any,
+                enable_auto_tools: bool = False,
+                model_output_token_ids: Sequence[int] = (),
+            ):
+                reasoning_parser = self.reasoning_parser
+                token_extractor = getattr(
+                    reasoning_parser, "extract_reasoning_from_token_ids", None
+                )
+                if model_output_token_ids and callable(token_extractor):
+                    reasoning, content = token_extractor(
+                        model_output_token_ids, model_output
+                    )
+                else:
+                    reasoning, content = self.extract_reasoning(model_output, request)
+                tool_calls, content = self._extract_tool_calls(
+                    content=content,
+                    request=request,
+                    enable_auto_tools=enable_auto_tools,
+                )
+                return reasoning, content, tool_calls
+
+        return DiffusionGemmaParser
+
+    ParserManager.get_parser = get_parser
+    ParserManager._tt_diffusion_complete_parser_installed = True
 
 
 def _register_tt_tool_parsers() -> None:

--- a/src/vllm_tt_plugin/gemma4_reasoning_parser.py
+++ b/src/vllm_tt_plugin/gemma4_reasoning_parser.py
@@ -24,6 +24,8 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         super().__init__(tokenizer, *args, **kwargs)
         self._reasoning_text: str = ""
         self._prefix_stripped: bool = False
+        self._stream_phase: str = "unknown"
+        self._marker_buffer: str = ""
         self.new_turn_token_id = self.vocab["<|turn>"]
         self.tool_call_token_id = self.vocab["<|tool_call>"]
         self.tool_response_token_id = self.vocab["<|tool_response>"]
@@ -73,6 +75,40 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
             reasoning = _strip_thought_label(reasoning)
         return reasoning, content
 
+    def extract_reasoning_from_token_ids(
+        self,
+        token_ids: Sequence[int],
+        fallback_text: str,
+    ) -> tuple[str | None, str | None]:
+        """Split a complete response when detokenization hid special markers.
+
+        vLLM 0.24 passes raw output token IDs to its unified non-streaming
+        parser, but its delegating parser does not forward them to legacy
+        reasoning parsers. The plugin installs a narrow adapter for the
+        ``diffusion_gemma`` alias that calls this method.
+        """
+        try:
+            start_idx = token_ids.index(self.start_token_id)
+        except ValueError:
+            start_idx = None
+
+        search_from = start_idx + 1 if start_idx is not None else 0
+        end_idx = _index_after(token_ids, self.end_token_id, search_from)
+        if start_idx is None and end_idx is None:
+            return None, fallback_text
+
+        reasoning_start = start_idx + 1 if start_idx is not None else 0
+        reasoning_end = end_idx if end_idx is not None else len(token_ids)
+        reasoning = _strip_thought_label(
+            self._decode_visible(token_ids[reasoning_start:reasoning_end])
+        )
+        content = (
+            self._decode_visible(token_ids[end_idx + 1 :])
+            if end_idx is not None
+            else None
+        )
+        return reasoning or None, content or None
+
     def extract_reasoning_streaming(
         self,
         previous_text: str,
@@ -82,13 +118,9 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
     ) -> DeltaMessage | None:
-        result = super().extract_reasoning_streaming(
-            previous_text,
-            current_text,
-            delta_text,
-            previous_token_ids,
-            current_token_ids,
-            delta_token_ids,
+        del current_text, current_token_ids
+        result = self._extract_stream_delta(
+            delta_text, previous_token_ids, delta_token_ids
         )
         if result is None:
             return None
@@ -122,14 +154,138 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
             return None
 
         if _THOUGHT_PREFIX.startswith(self._reasoning_text):
+            # If the reasoning marker also ended in this delta, the short text
+            # is the complete reasoning body rather than a partial label.
+            if result.content is not None:
+                self._prefix_stripped = True
+                result.reasoning = self._reasoning_text
+                return result
             return None
 
         self._prefix_stripped = True
         result.reasoning = self._reasoning_text
         return result
 
+    def _extract_stream_delta(
+        self,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        """Split a delta by marker IDs, even when decoded marker text is absent."""
+        if self.start_token_id in delta_token_ids:
+            start_idx = delta_token_ids.index(self.start_token_id)
+            end_idx = _index_after(delta_token_ids, self.end_token_id, start_idx + 1)
+            prefix = self._decode_visible(delta_token_ids[:start_idx])
+            if end_idx is None:
+                self._stream_phase = "reasoning"
+                reasoning = self._decode_visible(delta_token_ids[start_idx + 1 :])
+                return _delta(prefix, reasoning, None)
+
+            self._stream_phase = "content"
+            reasoning = self._decode_visible(delta_token_ids[start_idx + 1 : end_idx])
+            content = self._decode_visible(delta_token_ids[end_idx + 1 :])
+            return _delta(prefix, reasoning, content)
+
+        previous_in_reasoning = (
+            self.start_token_id in previous_token_ids
+            and not self.is_reasoning_end(previous_token_ids)
+        )
+        if self._marker_buffer or self.end_token in delta_text:
+            return self._extract_stream_text(delta_text)
+        if previous_in_reasoning or self._stream_phase == "reasoning":
+            if self.end_token_id in delta_token_ids:
+                end_idx = delta_token_ids.index(self.end_token_id)
+                self._stream_phase = "content"
+                return _delta(
+                    None,
+                    self._decode_visible(delta_token_ids[:end_idx]),
+                    self._decode_visible(delta_token_ids[end_idx + 1 :]),
+                )
+            return DeltaMessage(reasoning=delta_text) if delta_text else None
+
+        if self.is_reasoning_end(previous_token_ids) or self._stream_phase == "content":
+            return DeltaMessage(content=delta_text) if delta_text else None
+
+        # Text fallback covers tokenizers that expose marker text in pieces
+        # across deltas. Complete special-token IDs take the path above.
+        return self._extract_stream_text(delta_text)
+
+    def _extract_stream_text(self, delta_text: str) -> DeltaMessage | None:
+        combined = self._marker_buffer + delta_text
+        self._marker_buffer = ""
+        if self._stream_phase == "unknown":
+            if self.start_token in combined:
+                prefix, _, after = combined.partition(self.start_token)
+                self._stream_phase = "reasoning"
+                return self._extract_reasoning_text(after, prefix or None)
+            held = _longest_marker_prefix_suffix(combined, self.start_token)
+            if held:
+                self._marker_buffer = held
+                visible = combined[: -len(held)]
+                return DeltaMessage(content=visible) if visible else None
+            self._stream_phase = "content"
+            return DeltaMessage(content=combined) if combined else None
+
+        if self._stream_phase == "reasoning":
+            return self._extract_reasoning_text(combined, None)
+        return DeltaMessage(content=combined) if combined else None
+
+    def _extract_reasoning_text(
+        self, text: str, prefix_content: str | None
+    ) -> DeltaMessage | None:
+        if self.end_token in text:
+            reasoning, _, content = text.partition(self.end_token)
+            self._stream_phase = "content"
+            return _delta(prefix_content, reasoning, content)
+
+        held = _longest_marker_prefix_suffix(text, self.end_token)
+        if held:
+            self._marker_buffer = held
+            text = text[: -len(held)]
+        return _delta(prefix_content, text, None)
+
+    def _decode_visible(self, token_ids: Sequence[int]) -> str:
+        if not token_ids:
+            return ""
+        try:
+            return self.model_tokenizer.decode(
+                list(token_ids), skip_special_tokens=True
+            )
+        except TypeError:
+            return self.model_tokenizer.decode(list(token_ids))
+
 
 def _strip_thought_label(text: str) -> str:
     if text.startswith(_THOUGHT_PREFIX):
         return text[len(_THOUGHT_PREFIX) :]
     return text
+
+
+def _index_after(token_ids: Sequence[int], token_id: int, start: int) -> int | None:
+    for idx in range(start, len(token_ids)):
+        if token_ids[idx] == token_id:
+            return idx
+    return None
+
+
+def _longest_marker_prefix_suffix(text: str, marker: str) -> str:
+    max_len = min(len(text), len(marker) - 1)
+    for length in range(max_len, 0, -1):
+        if text.endswith(marker[:length]):
+            return text[-length:]
+    return ""
+
+
+def _delta(
+    prefix_content: str | None,
+    reasoning: str | None,
+    content: str | None,
+) -> DeltaMessage | None:
+    combined_content = (prefix_content or "") + (content or "")
+    if not reasoning and not combined_content:
+        return None
+    return DeltaMessage(
+        reasoning=reasoning or None,
+        content=combined_content or None,
+    )

--- a/src/vllm_tt_plugin/gemma4_reasoning_parser.py
+++ b/src/vllm_tt_plugin/gemma4_reasoning_parser.py
@@ -97,14 +97,31 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         if start_idx is None and end_idx is None:
             return None, fallback_text
 
+        # A tool call inside an open thinking channel terminates it even
+        # without the close marker (``is_reasoning_end`` treats it that way);
+        # keep the call payload out of the reasoning field.
+        tool_idx = (
+            _index_after(token_ids, self.tool_call_token_id, search_from)
+            if start_idx is not None
+            else None
+        )
+        if tool_idx is not None and (end_idx is None or tool_idx < end_idx):
+            reasoning_end = tool_idx
+            content_start = tool_idx
+        elif end_idx is not None:
+            reasoning_end = end_idx
+            content_start = end_idx + 1
+        else:
+            reasoning_end = len(token_ids)
+            content_start = None
+
         reasoning_start = start_idx + 1 if start_idx is not None else 0
-        reasoning_end = end_idx if end_idx is not None else len(token_ids)
         reasoning = _strip_thought_label(
             self._decode_visible(token_ids[reasoning_start:reasoning_end])
         )
         content = (
-            self._decode_visible(token_ids[end_idx + 1 :])
-            if end_idx is not None
+            self._decode_visible(token_ids[content_start:])
+            if content_start is not None
             else None
         )
         return reasoning or None, content or None

--- a/src/vllm_tt_plugin/launcher.py
+++ b/src/vllm_tt_plugin/launcher.py
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import sys
 import weakref
+from dataclasses import dataclass, field
 
 import cloudpickle
 import yaml
@@ -16,7 +17,7 @@ from vllm.config import ParallelConfig, VllmConfig
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
-from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPlan
+from vllm.v1.engine.utils import CoreEngine
 from vllm.v1.executor.abstract import UniProcExecutor
 
 from vllm_tt_plugin.config import get_tt_config
@@ -24,6 +25,26 @@ from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
 _TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES"
+
+try:
+    from vllm.v1.engine.utils import CoreEngineLauncher, EngineLaunchPlan
+except ImportError:
+    # Upstream vLLM 0.24 launches engines directly from launch_core_engines()
+    # and has no public launcher extension classes. Keep the parsing and remote
+    # entrypoint portions of this plugin importable on 0.24; if a later call
+    # tries to use the absent extension point, fail explicitly rather than at
+    # module import (which would also break every DP=1 host test).
+    @dataclass
+    class EngineLaunchPlan:  # type: ignore[no-redef]
+        remote_launched: bool = False
+        non_device_dp_ranks: set[int] = field(default_factory=set)
+
+    class CoreEngineLauncher:  # type: ignore[no-redef]
+        def get_engines_to_handshake(self, *_args, **_kwargs):
+            raise RuntimeError(
+                "vLLM 0.24 does not expose the CoreEngineLauncher extension "
+                "point required by explicit tt-run/MPI launch"
+            )
 
 
 class TTLaunchPlan(EngineLaunchPlan):

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -233,12 +233,15 @@ class TTModelRunner:
             custom_logitsprocs=(self.model_config.logits_processors or ()),
         )
 
-    def __del__(self) -> None:
-        """Release model-owned persistent captures before TT devices close."""
-        self.shutdown()
-
     def shutdown(self) -> None:
-        """Deterministically release optional model-lifetime captures."""
+        """Deterministically release optional model-lifetime captures.
+
+        Called from ``TTWorker.shutdown`` while the mesh is still open. This
+        is intentionally not wired to ``__del__``: the runner sits in
+        reference cycles, so a destructor can fire during interpreter
+        teardown after the devices closed, where a device-side release is
+        worse than leaking the capture to process exit.
+        """
         if getattr(self, "_persistent_capture_released", False):
             return
         release = getattr(

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -40,6 +40,7 @@ from vllm_tt_plugin.async_decode import (
 from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_max_batch_size,
+    get_tt_output_tokens_per_step,
     get_tt_per_lane_max_num_seqs,
 )
 from vllm_tt_plugin.input_batch import (
@@ -133,6 +134,9 @@ class TTModelRunner:
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
         self.device_config = vllm_config.device_config
+        self._output_tokens_per_step = get_tt_output_tokens_per_step(vllm_config)
+        self._is_block_output_model = self._output_tokens_per_step > 1
+        self._persistent_capture_released = False
 
         if self.model_config.is_encoder_decoder:
             raise ValueError("Encoder-decoder models aren't yet supported for TT")
@@ -228,6 +232,24 @@ class TTModelRunner:
             is_pooling_model=False,
             custom_logitsprocs=(self.model_config.logits_processors or ()),
         )
+
+    def __del__(self) -> None:
+        """Release model-owned persistent captures before TT devices close."""
+        self.shutdown()
+
+    def shutdown(self) -> None:
+        """Deterministically release optional model-lifetime captures."""
+        if getattr(self, "_persistent_capture_released", False):
+            return
+        release = getattr(
+            getattr(self, "model", None), "release_persistent_capture", None
+        )
+        if callable(release):
+            try:
+                release()
+            except Exception:
+                logger.exception("Failed to release persistent model capture")
+        self._persistent_capture_released = True
 
     @property
     def lane_batch(self) -> TTLaneInputBatch:
@@ -594,6 +616,13 @@ class TTModelRunner:
             )
         return per_layer  # type: ignore[return-value]
 
+    def _release_model_request(self, req_id: str) -> None:
+        """Release optional row-owned state while the row mapping is valid."""
+        req_index = self.input_batch.req_id_to_index.get(req_id)
+        release = getattr(getattr(self, "model", None), "release_request", None)
+        if req_index is not None and callable(release):
+            release(req_index)
+
     def _update_states(self, scheduler_output: SchedulerOutput) -> None:
         """Update the cached states and the persistent batch with the
         scheduler output.
@@ -615,6 +644,7 @@ class TTModelRunner:
         # and handling the second as a new request.
         removed_req_indices: list[int] = []
         for req_id in scheduler_output.finished_req_ids:
+            self._release_model_request(req_id)
             req_index = self.input_batch.remove_request(req_id)
             if req_index is not None:
                 removed_req_indices.append(req_index)
@@ -623,6 +653,11 @@ class TTModelRunner:
         # Free the cached encoder outputs.
         for mm_hash in scheduler_output.free_encoder_mm_hashes:
             self.encoder_cache.pop(mm_hash, None)
+
+        # Explicit preemption invalidates model-owned request state. Temporary
+        # unscheduling does not: a request may simply be hidden for this step.
+        for req_id in scheduler_output.preempted_req_ids:
+            self._release_model_request(req_id)
 
         # Remove the unscheduled requests from the persistent batch.
         # NOTE(woosuk): The unscheduled requests are either preempted requests
@@ -2287,14 +2322,22 @@ class TTModelRunner:
         ]
         world = self.tt_data_parallel_size
         B = self.tt_per_lane_max_num_seqs
+        num_out_tokens = self._output_tokens_per_step
         for dp_rank in range(world):
             token_ids = sampled_token_ids_per_dp[dp_rank].to(torch.int32)
             if token_ids.numel() == 0:
-                token_ids = torch.zeros((B, 1), dtype=torch.int32)
+                token_ids = torch.zeros((B, num_out_tokens), dtype=torch.int32)
             else:
-                assert token_ids.dim() == 2 and token_ids.shape[1] == 1, (
-                    "Currently only supporting 1 output token per request"
-                )
+                if token_ids.dim() != 2 or token_ids.shape[1] != num_out_tokens:
+                    raise ValueError(
+                        "Model output width violates output_tokens_per_step: "
+                        f"got shape {tuple(token_ids.shape)}, expected "
+                        f"[num_requests, {num_out_tokens}]"
+                    )
+                if token_ids.shape[0] > B:
+                    raise ValueError(
+                        f"DP rank returned {token_ids.shape[0]} rows for capacity {B}"
+                    )
                 pad_rows = B - token_ids.shape[0]
                 if pad_rows > 0:
                     token_ids = torch.cat(
@@ -2655,7 +2698,9 @@ class TTModelRunner:
         start = 0
         for dp_rank, sz in enumerate(batch_size_per_dp):
             if sz <= 0:
-                sampled_token_ids_per_dp.append(torch.tensor([], dtype=torch.int32))
+                sampled_token_ids_per_dp.append(
+                    torch.empty((0, self._output_tokens_per_step), dtype=torch.int32)
+                )
                 logprobs_per_dp.append(None)
                 if is_decode:
                     # Fixed stride segments per DP rank for decode
@@ -2671,6 +2716,11 @@ class TTModelRunner:
                 return tensor[_rows]
 
             if not perform_device_sampling:
+                if self._is_block_output_model:
+                    raise ValueError(
+                        "Block-output models require sample_on_device_mode='all'; "
+                        "host sampling cannot construct a multi-token canvas"
+                    )
                 logits = tt_out[rows, -1, :]
 
                 grammar_bitmask = model_input.grammar_bitmask[dp_rank]
@@ -2794,10 +2844,13 @@ class TTModelRunner:
                 # Capture logprobs for this DP rank
                 logprobs_per_dp.append(sampler_output.logprobs_tensors)
             else:  # sample on device
-                # Normalize TT sampled tokens to 1D [sz]. Prefill can return [sz]
-                # while decode may return [sz, 1]; downstream logprobs packing
-                # expects a flat vector here.
-                next_token_ids = _take(tt_out).reshape(sz)
+                next_token_ids = _take(tt_out).reshape(sz, -1)
+                if next_token_ids.shape[1] != self._output_tokens_per_step:
+                    raise ValueError(
+                        "Model output width violates output_tokens_per_step: "
+                        f"{next_token_ids.shape[1]} != "
+                        f"{self._output_tokens_per_step}"
+                    )
                 rank_max_num_logprobs = model_input.max_num_logprobs[dp_rank]
                 # Extract logprobs if available from device sampling
                 # Always tensors - turned into lists only when passing to model
@@ -2806,13 +2859,20 @@ class TTModelRunner:
                 if rank_enable_lp.any():
                     # Sanity check for if we correctly detect
                     # when logprobs are supported.
-                    assert tt_log_probs is not None, (
-                        "model should return logprobs when requested"
-                    )
+                    if next_token_ids.shape[1] != 1:
+                        raise ValueError(
+                            "Device logprobs support one output token per step; "
+                            "block-output requests must reject logprobs"
+                        )
+                    if tt_log_probs is None:
+                        raise ValueError(
+                            "Model did not return device logprobs for a request "
+                            "that enabled them"
+                        )
                     logprobs_per_dp.append(
                         build_device_logprobs(
                             tt_log_probs=tt_log_probs,
-                            sampled_token_ids=next_token_ids,
+                            sampled_token_ids=next_token_ids.reshape(sz),
                             rows=rows,
                             max_num_logprobs=rank_max_num_logprobs or 0,
                         )
@@ -2820,7 +2880,7 @@ class TTModelRunner:
                 else:
                     logprobs_per_dp.append(None)
 
-            sampled_token_ids_per_dp.append(next_token_ids.view(sz, 1))
+            sampled_token_ids_per_dp.append(next_token_ids.reshape(sz, -1))
 
             if is_decode:
                 # Fixed stride segments per DP rank for decode
@@ -2878,8 +2938,21 @@ class TTModelRunner:
             f"Number of request outputs {sampled_token_ids.shape[0]} != "
             f"number of requests in input batch {num_reqs}"
         )
+        if num_reqs == 0 and sampled_token_ids.numel() == 0:
+            sampled_token_ids = sampled_token_ids.reshape(
+                0, self._output_tokens_per_step
+            )
+        if (
+            sampled_token_ids.dim() != 2
+            or sampled_token_ids.shape[1] != self._output_tokens_per_step
+        ):
+            raise ValueError(
+                "Model output width violates output_tokens_per_step: "
+                f"got shape {tuple(sampled_token_ids.shape)}, expected "
+                f"[num_requests, {self._output_tokens_per_step}]"
+            )
 
-        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        sampled_token_ids_np = sampled_token_ids.numpy()
         if sampled_token_ids_np.dtype != np.int32:
             sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
 
@@ -2887,7 +2960,7 @@ class TTModelRunner:
             (output_req_ids[i] for i in range(num_reqs)), None
         )
         sampled_token_id_lists = [
-            [int(token_id)] for token_id in sampled_token_ids_np.tolist()
+            [int(token_id) for token_id in row] for row in sampled_token_ids_np.tolist()
         ]
 
         return ModelRunnerOutput(
@@ -2917,35 +2990,69 @@ class TTModelRunner:
             f"Number of request outputs {sampled_token_ids.shape[0]} != "
             f"number of requests in input batch {num_reqs}"
         )
-        num_out_tokens = sampled_token_ids.shape[1]
-        assert num_out_tokens == 1, "Currently only supporting 1 output token"
+        if num_reqs == 0 and sampled_token_ids.numel() == 0:
+            sampled_token_ids = sampled_token_ids.reshape(
+                0, self._output_tokens_per_step
+            )
+        if (
+            sampled_token_ids.dim() != 2
+            or sampled_token_ids.shape[1] != self._output_tokens_per_step
+        ):
+            raise ValueError(
+                "Model output width violates output_tokens_per_step: "
+                f"got shape {tuple(sampled_token_ids.shape)}, expected "
+                f"[num_requests, {self._output_tokens_per_step}]"
+            )
+        num_out_tokens = self._output_tokens_per_step
 
-        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        sampled_token_ids_np = sampled_token_ids.numpy()
         if sampled_token_ids_np.dtype != np.int32:
             sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
 
         if not use_captured_req_ids:
             rows = np.arange(num_reqs)
             start_idxs = self.input_batch.num_tokens[rows]
-            end_idxs = start_idxs + 1
+            end_idxs = start_idxs + num_out_tokens
             max_end = int(end_idxs.max()) if num_reqs > 0 else 0
-            assert max_end <= self.model_config.max_model_len, (
-                "Sampled token IDs exceed the max model length. "
-                f"Total number of tokens: {max_end} > max_model_len: "
-                f"{self.model_config.max_model_len}"
-            )
-
-            self.input_batch.token_ids_cpu[rows, start_idxs] = sampled_token_ids_np
-            self.input_batch.num_tokens[rows] = end_idxs
+            if max_end > self.model_config.max_model_len:
+                raise ValueError(
+                    "Sampled token IDs exceed the max model length. "
+                    f"Total number of tokens: {max_end} > max_model_len: "
+                    f"{self.model_config.max_model_len}"
+                )
 
             for req_idx in range(num_reqs):
+                start_idx = int(start_idxs[req_idx])
+                block = sampled_token_ids_np[req_idx]
+                self.input_batch.token_ids_cpu[
+                    req_idx, start_idx : start_idx + num_out_tokens
+                ] = block
                 output_token_ids = self.input_batch.req_output_token_ids[req_idx]
                 assert output_token_ids is not None
-                output_token_ids.append(int(sampled_token_ids_np[req_idx]))
+                output_token_ids.extend(int(token_id) for token_id in block)
+            self.input_batch.num_tokens[rows] = end_idxs
             return
 
         assert req_ids is not None
         captured_req_ids = req_ids
+        # Validate every live row before mutating any of them, so an oversized
+        # block never leaves a partially applied batch.
+        for req_idx, req_id in enumerate(captured_req_ids):
+            req_state = self.requests.get(req_id)
+            if req_state is None:
+                continue
+            if request_states is not None and req_state is not request_states[req_idx]:
+                continue
+            current_row = self.input_batch.req_id_to_index.get(req_id)
+            if current_row is not None:
+                end_idx = int(self.input_batch.num_tokens[current_row]) + num_out_tokens
+                if end_idx > self.model_config.max_model_len:
+                    raise ValueError(
+                        "Sampled token IDs exceed the max model length. "
+                        f"Total number of tokens: {end_idx} > max_model_len: "
+                        f"{self.model_config.max_model_len}"
+                    )
+
         for req_idx, req_id in enumerate(captured_req_ids):
             req_state = self.requests.get(req_id)
             if req_state is None:
@@ -2956,18 +3063,14 @@ class TTModelRunner:
             current_row = self.input_batch.req_id_to_index.get(req_id)
             if current_row is not None:
                 start_idx = int(self.input_batch.num_tokens[current_row])
-                end_idx = start_idx + 1
-                assert end_idx <= self.model_config.max_model_len, (
-                    "Sampled token IDs exceed the max model length. "
-                    f"Total number of tokens: {end_idx} > max_model_len: "
-                    f"{self.model_config.max_model_len}"
-                )
-                self.input_batch.token_ids_cpu[current_row, start_idx] = (
-                    sampled_token_ids_np[req_idx]
-                )
+                end_idx = start_idx + num_out_tokens
+                block = sampled_token_ids_np[req_idx]
+                self.input_batch.token_ids_cpu[current_row, start_idx:end_idx] = block
                 self.input_batch.num_tokens[current_row] = end_idx
+            else:
+                block = sampled_token_ids_np[req_idx]
 
-            req_state.output_token_ids.append(int(sampled_token_ids_np[req_idx]))
+            req_state.output_token_ids.extend(int(token_id) for token_id in block)
 
     def apply_and_build_runner_output(
         self,

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -656,7 +656,7 @@ class TTModelRunner:
 
         # Explicit preemption invalidates model-owned request state. Temporary
         # unscheduling does not: a request may simply be hidden for this step.
-        for req_id in scheduler_output.preempted_req_ids:
+        for req_id in scheduler_output.preempted_req_ids or ():
             self._release_model_request(req_id)
 
         # Remove the unscheduled requests from the persistent batch.

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -991,6 +991,18 @@ class TTPlatform(Platform):
                 "in model_capabilities"
             )
         if is_block_output_model:
+            # Upstream 0.24 recognizes DiffusionGemma's original HF
+            # architecture before this platform hook runs and injects a
+            # DiffusionConfig(canvas_length=256). Scheduler interprets that
+            # canvas as speculative draft tokens, while this plugin separately
+            # reserves the model-owned output block. Clear the upstream
+            # diffusion path so one physical canvas is accounted exactly once.
+            if vllm_config.diffusion_config is not None:
+                logger.info(
+                    "Block-output model owns diffusion scheduling; disabling "
+                    "upstream DiffusionConfig speculative-token accounting."
+                )
+                vllm_config.diffusion_config = None
             if model_config.max_model_len < output_tokens_per_step:
                 raise ValueError(
                     f"max_model_len={model_config.max_model_len} must be at least "

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1247,37 +1247,48 @@ class TTPlatform(Platform):
                     "shorter prompt."
                 )
 
-        unsupported = []
+        # The model owns its Gumbel sampler and temperature schedule. Common
+        # OpenAI clients still send transport sampling controls, so accept and
+        # neutralize those values before InputProcessor clones SamplingParams.
+        # This intentionally mutates the caller-owned object; server requests
+        # construct a fresh object, while offline callers should not reuse it
+        # across block-output and autoregressive models.
+        ignored = []
         if params.temperature != 1.0:
-            unsupported.append(
-                f"temperature={params.temperature!r} (accepted neutral value: 1.0)"
-            )
+            ignored.append(f"temperature={params.temperature!r}")
+            params.temperature = 1.0
         if params.top_p != 1.0:
-            unsupported.append(f"top_p={params.top_p!r} (accepted neutral value: 1.0)")
+            ignored.append(f"top_p={params.top_p!r}")
+            params.top_p = 1.0
         if params.top_k not in (0, -1):
-            unsupported.append(
-                f"top_k={params.top_k!r} (accepted neutral values: 0 or -1)"
-            )
+            ignored.append(f"top_k={params.top_k!r}")
+            params.top_k = 0
         if params.min_p != 0.0:
-            unsupported.append(f"min_p={params.min_p!r} (accepted neutral value: 0.0)")
+            ignored.append(f"min_p={params.min_p!r}")
+            params.min_p = 0.0
         if params.seed is not None:
-            unsupported.append(f"seed={params.seed!r} (accepted: omitted/None)")
+            ignored.append(f"seed={params.seed!r}")
+            params.seed = None
         if params.presence_penalty != 0.0:
-            unsupported.append(
-                f"presence_penalty={params.presence_penalty!r} "
-                "(accepted neutral value: 0.0)"
-            )
+            ignored.append(f"presence_penalty={params.presence_penalty!r}")
+            params.presence_penalty = 0.0
         if params.frequency_penalty != 0.0:
-            unsupported.append(
-                f"frequency_penalty={params.frequency_penalty!r} "
-                "(accepted neutral value: 0.0)"
-            )
+            ignored.append(f"frequency_penalty={params.frequency_penalty!r}")
+            params.frequency_penalty = 0.0
         if params.repetition_penalty != 1.0:
-            unsupported.append(
-                f"repetition_penalty={params.repetition_penalty!r} "
-                "(accepted neutral value: 1.0)"
+            ignored.append(f"repetition_penalty={params.repetition_penalty!r}")
+            params.repetition_penalty = 1.0
+        if ignored:
+            logger.warning_once(
+                "This block-output model uses its model-owned sampler; HTTP "
+                "sampling controls are accepted but ignored."
+            )
+            logger.debug(
+                "Ignoring unsupported sampling controls for block-output model: %s",
+                "; ".join(ignored),
             )
 
+        unsupported = []
         if params.n != 1:
             unsupported.append(f"n={params.n!r} (accepted: 1)")
         if params.logprobs is not None:

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -14,6 +14,7 @@ from vllm_tt_plugin.config import (
     get_tt_config,
     get_tt_data_parallel_size,
     store_tt_lane_count,
+    store_tt_output_tokens_per_step,
     uses_tt_lane_coordinator,
     validate_tt_lane_config,
 )
@@ -670,6 +671,21 @@ def register_tt_models(register_test_models=False) -> None:
     ):
         _register_model_if_missing(ModelRegistry, arch, _gemma4_target)
 
+    # DiffusionGemma emits one complete 256-token canvas per model step. Both
+    # the checkpoint's HF architecture and TT-prefixed aliases must resolve
+    # before ModelConfig falls back to an unrelated Transformers backend.
+    _diffusion_gemma_target = (
+        "models.experimental.diffusion_gemma.tt.generator_vllm:"
+        "DiffusionGemmaForCausalLM"
+    )
+    for arch in (
+        "DiffusionGemmaForBlockDiffusion",
+        "DiffusionGemmaForCausalLM",
+        "TTDiffusionGemmaForBlockDiffusion",
+        "TTDiffusionGemmaForCausalLM",
+    ):
+        _register_model_if_missing(ModelRegistry, arch, _diffusion_gemma_target)
+
     # DeepseekV3
     _register_model_if_missing(
         ModelRegistry,
@@ -723,6 +739,8 @@ class TTPlatform(Platform):
     _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
     _standard_dp_mesh_grids: ClassVar[dict[str, tuple[int, int]]] = {}
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
+    output_tokens_per_step: ClassVar[int] = 1
+    block_model_max_len: ClassVar[int | None] = None
     # Disable torch.compile on TT platform - the triton version in tt-metal
     # is incompatible with torch's inductor backend.
     simple_compile_backend: str = "eager"
@@ -783,7 +801,36 @@ class TTPlatform(Platform):
             ttnn.SetDefaultDevice(device)
 
     @classmethod
+    def _resolve_output_tokens_per_step(cls, model_class: type) -> int:
+        """Validate and return a model's committed output-width capability."""
+        model_capabilities: dict | None = getattr(
+            model_class, "model_capabilities", None
+        )
+        output_tokens_per_step = (
+            model_capabilities.get("output_tokens_per_step", 1)
+            if model_capabilities
+            else 1
+        )
+        if (
+            isinstance(output_tokens_per_step, bool)
+            or not isinstance(output_tokens_per_step, int)
+            or output_tokens_per_step < 1
+        ):
+            raise ValueError(
+                f"Invalid output_tokens_per_step={output_tokens_per_step!r} for "
+                f"{model_class.__module__}.{model_class.__name__}; "
+                "expected an integer >= 1"
+            )
+        return output_tokens_per_step
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        # The standalone TT plugin implements the vLLM V1 runner only. vLLM
+        # 0.24 otherwise force-selects its Triton-only V2 runner for every HF
+        # config with ``canvas_length`` before applying the normal no-Triton
+        # fallback. Pinning this in the platform hook keeps diffusion models on
+        # the runner the TT worker actually implements.
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "0"
         _install_tt_harmony_truncation_patch()
         cls._standard_dp_visible_device_groups = None
         cls._standard_dp_mesh_grids = {}
@@ -870,6 +917,11 @@ class TTPlatform(Platform):
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
         arch_names = vllm_config.model_config.hf_config.architectures
+        is_diffusion_gemma = any(
+            arch.removeprefix("TT")
+            in ("DiffusionGemmaForBlockDiffusion", "DiffusionGemmaForCausalLM")
+            for arch in arch_names
+        )
         for i in range(len(arch_names)):
             if not arch_names[i].startswith("TT"):
                 arch_names[i] = "TT" + arch_names[i]
@@ -931,6 +983,60 @@ class TTPlatform(Platform):
         model_capabilities: dict | None = getattr(
             model_class, "model_capabilities", None
         )
+        output_tokens_per_step = cls._resolve_output_tokens_per_step(model_class)
+        is_block_output_model = output_tokens_per_step > 1
+        if is_diffusion_gemma and not is_block_output_model:
+            raise ValueError(
+                "DiffusionGemma must declare output_tokens_per_step > 1 "
+                "in model_capabilities"
+            )
+        if is_block_output_model:
+            if model_config.max_model_len < output_tokens_per_step:
+                raise ValueError(
+                    f"max_model_len={model_config.max_model_len} must be at least "
+                    f"output_tokens_per_step={output_tokens_per_step}"
+                )
+            if vllm_config.scheduler_config.max_num_seqs != 1:
+                raise ValueError(
+                    "Block-output models currently own one model-side request "
+                    "state and require --max-num-seqs 1"
+                )
+            if (
+                parallel_config.data_parallel_size != 1
+                or get_tt_data_parallel_size(vllm_config) != 1
+            ):
+                raise ValueError(
+                    "Block-output models do not yet support data parallelism; "
+                    "use --data-parallel-size 1"
+                )
+            if vllm_config.cache_config.enable_prefix_caching:
+                raise ValueError(
+                    "Block-output models do not support vLLM automatic prefix "
+                    "caching; disable prefix caching"
+                )
+            if model_config.logits_processors:
+                raise ValueError(
+                    "Block-output models do not support --logits-processors "
+                    "because output is sampled inside the model"
+                )
+            if vllm_config.scheduler_config.async_scheduling:
+                raise ValueError(
+                    "Block-output models currently support synchronous serving "
+                    "only; launch with --no-async-scheduling"
+                )
+            vllm_config.scheduler_config.long_prefill_token_threshold = 0
+            if model_config.generation_config == "auto":
+                logger.info(
+                    "Block-output model owns generation defaults; normalizing "
+                    "--generation-config auto to vllm."
+                )
+                model_config.generation_config = "vllm"
+
+        store_tt_output_tokens_per_step(vllm_config, output_tokens_per_step)
+        cls.output_tokens_per_step = output_tokens_per_step
+        cls.block_model_max_len = (
+            model_config.max_model_len if is_block_output_model else None
+        )
 
         # A model either supports the full on-device sampling pipeline or it
         # doesn't — there is no greedy-only mode. Models opt in by setting
@@ -946,6 +1052,12 @@ class TTPlatform(Platform):
                 f"but model {model_class.__name__} "
                 f"({model_class.__module__}) does not support on-device sampling. "
                 "Unset sample_on_device_mode or use a model that supports it."
+            )
+        if is_block_output_model and sample_on_device_mode != "all":
+            raise ValueError(
+                "Block-output models emit complete multi-token outputs from "
+                "their model-owned sampler and require "
+                f'sample_on_device_mode="all"; got {sample_on_device_mode!r}'
             )
 
         # Model-gated async scheduling. Async overlap requires generators that
@@ -1065,6 +1177,23 @@ class TTPlatform(Platform):
     def uses_host_device_handling(cls) -> bool:
         return True
 
+    def get_max_output_tokens(self, prompt_len: int) -> int:
+        """Clamp the platform default to complete physical output canvases."""
+        output_size = type(self).output_tokens_per_step
+        max_model_len = type(self).block_model_max_len
+        if output_size == 1 or max_model_len is None:
+            return super().get_max_output_tokens(prompt_len)
+
+        remaining = max_model_len - prompt_len
+        if remaining < output_size:
+            raise ValueError(
+                f"Prompt length {prompt_len} leaves {max(0, remaining)} tokens "
+                f"within max_model_len={max_model_len}, but this model commits "
+                f"physical {output_size}-token output canvases. Use a shorter "
+                "prompt or a larger max model length."
+            )
+        return remaining // output_size * output_size
+
     @classmethod
     def validate_request(
         cls,
@@ -1078,6 +1207,95 @@ class TTPlatform(Platform):
 
         if isinstance(params, SamplingParams) and params.prompt_logprobs is not None:
             raise ValueError(f"Not yet supporting prompt_logprobs on {dev}")
+
+        output_size = cls.output_tokens_per_step
+        if not isinstance(params, SamplingParams) or output_size == 1:
+            return
+
+        prompt_token_ids = processed_inputs.get("prompt_token_ids")
+        max_model_len = cls.block_model_max_len
+        if prompt_token_ids is not None and max_model_len is not None:
+            prompt_len = len(prompt_token_ids)
+            max_tokens = params.max_tokens
+            if max_tokens is None:
+                raise ValueError(
+                    "Block-output request max_tokens was not resolved before "
+                    "platform validation"
+                )
+            physical_output_tokens = (
+                (max_tokens + output_size - 1) // output_size
+            ) * output_size
+            if prompt_len + physical_output_tokens > max_model_len:
+                raise ValueError(
+                    "Block output is committed in physical "
+                    f"{output_size}-token canvases: prompt length {prompt_len} "
+                    f"plus max_tokens={max_tokens} requires "
+                    f"{physical_output_tokens} physical output tokens, exceeding "
+                    f"max_model_len={max_model_len}. Reduce max_tokens or use a "
+                    "shorter prompt."
+                )
+
+        unsupported = []
+        if params.temperature != 1.0:
+            unsupported.append(
+                f"temperature={params.temperature!r} (accepted neutral value: 1.0)"
+            )
+        if params.top_p != 1.0:
+            unsupported.append(f"top_p={params.top_p!r} (accepted neutral value: 1.0)")
+        if params.top_k not in (0, -1):
+            unsupported.append(
+                f"top_k={params.top_k!r} (accepted neutral values: 0 or -1)"
+            )
+        if params.min_p != 0.0:
+            unsupported.append(f"min_p={params.min_p!r} (accepted neutral value: 0.0)")
+        if params.seed is not None:
+            unsupported.append(f"seed={params.seed!r} (accepted: omitted/None)")
+        if params.presence_penalty != 0.0:
+            unsupported.append(
+                f"presence_penalty={params.presence_penalty!r} "
+                "(accepted neutral value: 0.0)"
+            )
+        if params.frequency_penalty != 0.0:
+            unsupported.append(
+                f"frequency_penalty={params.frequency_penalty!r} "
+                "(accepted neutral value: 0.0)"
+            )
+        if params.repetition_penalty != 1.0:
+            unsupported.append(
+                f"repetition_penalty={params.repetition_penalty!r} "
+                "(accepted neutral value: 1.0)"
+            )
+
+        if params.n != 1:
+            unsupported.append(f"n={params.n!r} (accepted: 1)")
+        if params.logprobs is not None:
+            unsupported.append(f"logprobs={params.logprobs!r} (accepted: None)")
+        if params.logprob_token_ids is not None:
+            unsupported.append("logprob_token_ids (accepted: omitted/None)")
+        if params.flat_logprobs:
+            unsupported.append("flat_logprobs=True (accepted: False)")
+        if params.bad_words:
+            unsupported.append("bad_words (accepted: omitted/empty)")
+        if params.structured_outputs is not None:
+            unsupported.append("structured_outputs (accepted: omitted/None)")
+        if params.logit_bias is not None:
+            unsupported.append("logit_bias (accepted: omitted/None)")
+        if params.allowed_token_ids is not None:
+            unsupported.append("allowed_token_ids (accepted: omitted/None)")
+        if params.min_tokens != 0:
+            unsupported.append(f"min_tokens={params.min_tokens!r} (accepted: 0)")
+        if params.thinking_token_budget is not None:
+            unsupported.append("thinking_token_budget (accepted: omitted/None)")
+        if params.repetition_detection is not None:
+            unsupported.append("repetition_detection (accepted: omitted/None)")
+        if params.extra_args:
+            unsupported.append("extra_args (accepted: omitted/empty)")
+
+        if unsupported:
+            raise ValueError(
+                "This block-output model owns its Gumbel sampling and does not "
+                "support these request parameters: " + "; ".join(unsupported)
+            )
 
     @staticmethod
     def compat_sampling_required(sampling_params, num_devices) -> bool:

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1230,10 +1230,24 @@ class TTPlatform(Platform):
             prompt_len = len(prompt_token_ids)
             max_tokens = params.max_tokens
             if max_tokens is None:
-                raise ValueError(
-                    "Block-output request max_tokens was not resolved before "
-                    "platform validation"
-                )
+                # OpenAI serving resolves max_tokens before this hook, but
+                # offline callers can pass max_tokens=None (the processor
+                # defaults it only after validation). Mirror the server-side
+                # whole-canvas default instead of failing opaquely; the
+                # neutralization block below documents the in-place mutation
+                # contract.
+                remaining = max_model_len - prompt_len
+                if remaining < output_size:
+                    raise ValueError(
+                        f"Prompt length {prompt_len} leaves "
+                        f"{max(0, remaining)} tokens within "
+                        f"max_model_len={max_model_len}, but this model "
+                        f"commits physical {output_size}-token output "
+                        "canvases. Use a shorter prompt or a larger max "
+                        "model length."
+                    )
+                params.max_tokens = remaining // output_size * output_size
+                max_tokens = params.max_tokens
             physical_output_tokens = (
                 (max_tokens + output_size - 1) // output_size
             ) * output_size

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -7,8 +7,10 @@ from typing import cast
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
+from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request
 
+from vllm_tt_plugin.config import get_tt_output_tokens_per_step
 from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
@@ -67,6 +69,8 @@ class TTScheduler(AsyncScheduler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._forced_mode = TTSchedulingMode.DEFAULT
+        self._output_tokens_per_step = get_tt_output_tokens_per_step(self.vllm_config)
+        self._is_block_output_model = self._output_tokens_per_step > 1
 
     def set_forced_mode(self, mode: TTSchedulingMode) -> None:
         self._forced_mode = mode
@@ -169,3 +173,64 @@ class TTScheduler(AsyncScheduler):
                 self.skipped_waiting = saved_skipped
             self.waiting = saved_waiting
         return result
+
+    def reset_prefix_cache(
+        self, reset_running_requests: bool = False, reset_connector: bool = False
+    ) -> bool:
+        """Avoid a stale-canvas resume that vLLM's AR reset cannot represent."""
+        if self._is_block_output_model and reset_running_requests and self.running:
+            logger.error(
+                "Cannot reset prefix cache while a block-output request is "
+                "running; finish or abort the request first."
+            )
+            return False
+        return super().reset_prefix_cache(reset_running_requests, reset_connector)
+
+    def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
+        """Reserve the complete physical output emitted by each block step.
+
+        vLLM 0.24 reserves zero sampled tokens for models detected as
+        diffusion. The TT adapter nevertheless returns one K-token canvas, so
+        reserve K positions after the normal scheduled-input accounting.
+        """
+        super()._update_after_schedule(scheduler_output)
+        if not self._is_block_output_model:
+            return
+        extra_placeholders = (
+            self._output_tokens_per_step - self.num_sampled_tokens_per_step
+        )
+        for req_id in scheduler_output.num_scheduled_tokens:
+            request = self.requests[req_id]
+            if not request.is_prefill_chunk:
+                request.num_output_placeholders += extra_placeholders
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int]
+    ) -> tuple[list[int], bool]:
+        """Commit one block and reconcile its full physical reservation."""
+        if not self._is_block_output_model:
+            return super()._update_request_with_output(request, new_token_ids)
+        if request.async_tokens_to_discard:
+            raise RuntimeError(
+                "A stale async output reached synchronous block serving; "
+                "block-output async scheduling and running prefix resets are "
+                "unsupported"
+            )
+        if len(new_token_ids) != self._output_tokens_per_step:
+            raise ValueError(
+                "Model output width violates output_tokens_per_step: "
+                f"{len(new_token_ids)} != {self._output_tokens_per_step}"
+            )
+
+        # Scheduler appends token-by-token and trims at EOS, stop tokens,
+        # max_tokens, or max_model_len. The reservation is physical, so consume
+        # all K placeholders even when the client-visible block is trimmed.
+        new_token_ids, stopped = Scheduler._update_request_with_output(
+            self, request, new_token_ids
+        )
+        request.num_output_placeholders -= self._output_tokens_per_step
+        if request.num_output_placeholders < 0:
+            raise RuntimeError(
+                "Output placeholders underflowed after block-output reconciliation"
+            )
+        return new_token_ids, stopped

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -459,7 +459,9 @@ class TTWorker(WorkerBase):
 
     def shutdown(self) -> None:
         """Release model-owned captures before the worker process exits."""
-        self.model_runner.shutdown()
+        runner = getattr(self, "model_runner", None)
+        if runner is not None:
+            runner.shutdown()
 
     # ---- DP gather hooks called by DPEngineCoreProc in core.py ----
 

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -435,6 +435,10 @@ class TTWorker(WorkerBase):
         assert self.is_driver_worker, "There should only be one Worker for TT"
         return self.model_runner.execute_model(scheduler_output)
 
+    def take_draft_token_ids(self) -> None:
+        """Diffusion models trigger this vLLM 0.24 worker RPC but TT has no drafter."""
+        return None
+
     def sample_tokens(
         self,
         grammar_output: "GrammarOutput | None",
@@ -452,6 +456,10 @@ class TTWorker(WorkerBase):
     def check_health(self) -> None:
         # Worker will always be healthy as long as it's running.
         return
+
+    def shutdown(self) -> None:
+        """Release model-owned captures before the worker process exits."""
+        self.model_runner.shutdown()
 
     # ---- DP gather hooks called by DPEngineCoreProc in core.py ----
 

--- a/tests/test_block_model_runner.py
+++ b/tests/test_block_model_runner.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_tt_plugin.model_runner import TTModelRunner
+from vllm_tt_plugin.worker import TTWorker
+
+
+def _runner(width: int, *, num_tokens: int = 0, max_model_len: int = 32):
+    output_tokens: list[int] = []
+    return (
+        SimpleNamespace(
+            _output_tokens_per_step=width,
+            input_batch=SimpleNamespace(
+                num_reqs=1,
+                req_ids=["req-0"],
+                num_tokens=np.array([num_tokens], dtype=np.int32),
+                token_ids_cpu=np.zeros((1, max_model_len), dtype=np.int32),
+                req_output_token_ids=[output_tokens],
+            ),
+            model_config=SimpleNamespace(max_model_len=max_model_len),
+        ),
+        output_tokens,
+    )
+
+
+def test_full_block_updates_state_and_runner_output():
+    runner, output_tokens = _runner(16)
+    block = torch.arange(16, dtype=torch.int32).reshape(1, 16)
+
+    TTModelRunner._apply_sampled_tokens_to_state(runner, block)
+    output = TTModelRunner._build_runner_output(runner, block)
+
+    assert runner.input_batch.num_tokens.tolist() == [16]
+    assert runner.input_batch.token_ids_cpu[0, :16].tolist() == list(range(16))
+    assert output_tokens == list(range(16))
+    assert output.sampled_token_ids == [list(range(16))]
+
+
+def test_output_width_is_strict():
+    runner, _ = _runner(16)
+
+    with pytest.raises(ValueError, match="violates output_tokens_per_step"):
+        TTModelRunner._build_runner_output(
+            runner, torch.zeros((1, 15), dtype=torch.int32)
+        )
+
+
+def test_capacity_overrun_is_rejected_before_writes():
+    runner, output_tokens = _runner(16, num_tokens=17)
+    block = torch.arange(16, dtype=torch.int32).reshape(1, 16)
+
+    with pytest.raises(ValueError, match="exceed the max model length"):
+        TTModelRunner._apply_sampled_tokens_to_state(runner, block)
+
+    assert runner.input_batch.num_tokens.tolist() == [17]
+    assert not runner.input_batch.token_ids_cpu.any()
+    assert output_tokens == []
+
+
+def test_dp_packing_preserves_block_width_for_empty_rank():
+    runner = SimpleNamespace(
+        tt_data_parallel_size=2,
+        tt_per_lane_max_num_seqs=1,
+        _output_tokens_per_step=16,
+    )
+    block = torch.arange(16, dtype=torch.int32).reshape(1, 16)
+
+    packed, logprobs = TTModelRunner.pack_dp_results(
+        runner,
+        [block, torch.empty((0, 16), dtype=torch.int32)],
+        [None, None],
+    )
+
+    assert packed.shape == (2, 1, 16)
+    assert packed[0, 0].tolist() == list(range(16))
+    assert not packed[1].any()
+    assert logprobs == [None, None]
+
+
+def test_ar_k1_output_shape_is_unchanged():
+    runner, output_tokens = _runner(1)
+    token = torch.tensor([[7]], dtype=torch.int32)
+
+    TTModelRunner._apply_sampled_tokens_to_state(runner, token)
+    output = TTModelRunner._build_runner_output(runner, token)
+
+    assert output_tokens == [7]
+    assert output.sampled_token_ids == [[7]]
+
+
+def test_worker_024_draft_token_rpc_returns_none():
+    assert TTWorker.take_draft_token_ids(TTWorker.__new__(TTWorker)) is None
+
+
+def test_worker_shutdown_releases_persistent_capture_once():
+    releases = []
+    runner = TTModelRunner.__new__(TTModelRunner)
+    runner._persistent_capture_released = False
+    runner.model = SimpleNamespace(
+        release_persistent_capture=lambda: releases.append("released")
+    )
+    worker = SimpleNamespace(model_runner=runner)
+
+    TTWorker.shutdown(worker)
+    runner.shutdown()
+
+    assert releases == ["released"]

--- a/tests/test_block_model_runner.py
+++ b/tests/test_block_model_runner.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import torch
+from vllm.v1.core.sched.output import SchedulerOutput
 
 from vllm_tt_plugin.model_runner import TTModelRunner
 from vllm_tt_plugin.worker import TTWorker
@@ -96,6 +97,26 @@ def test_ar_k1_output_shape_is_unchanged():
 
 def test_worker_024_draft_token_rpc_returns_none():
     assert TTWorker.take_draft_token_ids(TTWorker.__new__(TTWorker)) is None
+
+
+def test_update_states_accepts_absent_preemption_metadata():
+    scheduler_output = SchedulerOutput.make_empty()
+    assert scheduler_output.preempted_req_ids is None
+
+    refreshed = []
+    runner = SimpleNamespace(
+        requests={},
+        encoder_cache={},
+        input_batch=SimpleNamespace(
+            req_id_to_index={},
+            refresh_logitsprocs=lambda: refreshed.append(True),
+        ),
+        _decode_layout_changed_since_last_decode=False,
+    )
+
+    TTModelRunner._update_states(runner, scheduler_output)
+
+    assert refreshed == [True]
 
 
 def test_worker_shutdown_releases_persistent_capture_once():

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -126,6 +126,7 @@ def _config(*, max_num_seqs=1, data_parallel_size=1, async_scheduling=False):
             data_parallel_size=data_parallel_size,
             worker_cls="auto",
         ),
+        diffusion_config=SimpleNamespace(canvas_length=256),
         speculative_config=None,
         lora_config=None,
     )
@@ -168,6 +169,7 @@ def test_startup_stores_block_capability_and_enforces_contract(monkeypatch):
     assert config.scheduler_config.enable_chunked_prefill is False
     assert config.scheduler_config.long_prefill_token_threshold == 0
     assert config.model_config.generation_config == "vllm"
+    assert config.diffusion_config is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -52,13 +52,22 @@ def test_platform_default_is_clamped_to_whole_canvases():
         ("repetition_penalty", 1.1),
     ],
 )
-def test_non_neutral_sampling_controls_are_rejected_without_mutation(field, value):
+def test_non_neutral_sampling_controls_are_accepted_and_neutralized(field, value):
     params = SamplingParams(max_tokens=16, **{field: value})
 
-    with pytest.raises(ValueError, match=field):
-        _validate(params)
+    _validate(params)
 
-    assert getattr(params, field) == value
+    expected = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "top_k": 0,
+        "min_p": 0.0,
+        "seed": None,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "repetition_penalty": 1.0,
+    }
+    assert getattr(params, field) == expected[field]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+
+from vllm_tt_plugin.config import get_tt_output_tokens_per_step
+from vllm_tt_plugin.platform import TTPlatform
+
+
+@pytest.fixture(autouse=True)
+def block_contract(monkeypatch):
+    monkeypatch.setattr(TTPlatform, "output_tokens_per_step", 256)
+    monkeypatch.setattr(TTPlatform, "block_model_max_len", 1024)
+
+
+def _validate(params: SamplingParams, prompt_len: int = 32) -> None:
+    prompt = {"prompt_token_ids": [1] * prompt_len}
+    TTPlatform.validate_request(prompt, params)
+
+
+def test_short_logical_request_reserves_one_physical_canvas():
+    _validate(SamplingParams(max_tokens=16), prompt_len=768)
+
+
+def test_rounded_physical_capacity_is_enforced():
+    with pytest.raises(ValueError, match=r"requires 512 physical.*exceeding"):
+        _validate(SamplingParams(max_tokens=257), prompt_len=513)
+
+
+def test_platform_default_is_clamped_to_whole_canvases():
+    platform = TTPlatform()
+
+    assert platform.get_max_output_tokens(32) == 768
+    assert platform.get_max_output_tokens(768) == 256
+    with pytest.raises(ValueError, match="physical 256-token output canvases"):
+        platform.get_max_output_tokens(769)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("temperature", 0.5),
+        ("top_p", 0.9),
+        ("top_k", 10),
+        ("min_p", 0.1),
+        ("seed", 42),
+        ("presence_penalty", 0.5),
+        ("frequency_penalty", 0.5),
+        ("repetition_penalty", 1.1),
+    ],
+)
+def test_non_neutral_sampling_controls_are_rejected_without_mutation(field, value):
+    params = SamplingParams(max_tokens=16, **{field: value})
+
+    with pytest.raises(ValueError, match=field):
+        _validate(params)
+
+    assert getattr(params, field) == value
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field"),
+    [
+        ({"n": 2}, "n"),
+        ({"logprobs": 0}, "logprobs"),
+        ({"bad_words": ["forbidden"]}, "bad_words"),
+        (
+            {"structured_outputs": StructuredOutputsParams(json_object=True)},
+            "structured_outputs",
+        ),
+        ({"logit_bias": {2: -1.0}}, "logit_bias"),
+        ({"allowed_token_ids": [2, 3]}, "allowed_token_ids"),
+        ({"min_tokens": 1}, "min_tokens"),
+        ({"extra_args": {"custom_sampler": True}}, "extra_args"),
+    ],
+)
+def test_contract_changing_controls_are_rejected(kwargs, field):
+    with pytest.raises(ValueError, match=field):
+        _validate(SamplingParams(max_tokens=16, **kwargs))
+
+
+def test_ar_request_validation_is_unchanged(monkeypatch):
+    monkeypatch.setattr(TTPlatform, "output_tokens_per_step", 1)
+    params = SamplingParams(max_tokens=16, temperature=0.5, n=2)
+
+    _validate(params)
+
+    assert params.temperature == 0.5
+    assert params.n == 2
+
+
+def _config(*, max_num_seqs=1, data_parallel_size=1, async_scheduling=False):
+    return SimpleNamespace(
+        additional_config={"tt": {"sample_on_device_mode": "all"}},
+        model_config=SimpleNamespace(
+            model="test-model",
+            hf_config=SimpleNamespace(
+                architectures=["FutureBlockModel"],
+                model_type="gemma4",
+            ),
+            max_model_len=1024,
+            original_max_model_len=None,
+            max_logprobs=20,
+            is_moe=False,
+            generation_config="auto",
+            logits_processors=None,
+            get_sliding_window=lambda: None,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=1024,
+            enable_chunked_prefill=True,
+            long_prefill_token_threshold=128,
+            async_scheduling=async_scheduling,
+            scheduler_cls=None,
+            verify_max_model_len=lambda _max_model_len: None,
+        ),
+        cache_config=SimpleNamespace(enable_prefix_caching=False),
+        structured_outputs_config=SimpleNamespace(disable_any_whitespace=False),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=1,
+            pipeline_parallel_size=1,
+            data_parallel_size=data_parallel_size,
+            worker_cls="auto",
+        ),
+        speculative_config=None,
+        lora_config=None,
+    )
+
+
+class BlockModel:
+    model_capabilities = {
+        "output_tokens_per_step": 256,
+        "supports_sample_on_device": True,
+        "supports_async_decode": False,
+        "supports_prefix_caching": False,
+    }
+
+
+def _patch_model_resolution(monkeypatch, model_class=BlockModel):
+    monkeypatch.setattr(
+        "vllm_tt_plugin.platform.register_tt_models", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "vllm_tt_plugin.platform._resolve_standard_dp_visible_device_groups",
+        lambda _config: None,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.registry.ModelRegistry.get_supported_archs",
+        lambda: ["TTFutureBlockModel"],
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.utils.get_model_architecture",
+        lambda _model_config: (model_class, None),
+    )
+
+
+def test_startup_stores_block_capability_and_enforces_contract(monkeypatch):
+    config = _config()
+    _patch_model_resolution(monkeypatch)
+
+    TTPlatform.check_and_update_config(config)
+
+    assert get_tt_output_tokens_per_step(config) == 256
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+    assert config.model_config.generation_config == "vllm"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"max_num_seqs": 2}, "max-num-seqs 1"),
+        ({"data_parallel_size": 2}, "data parallelism"),
+        ({"async_scheduling": True}, "synchronous serving only"),
+    ],
+)
+def test_startup_rejects_unsupported_block_modes(monkeypatch, overrides, message):
+    config = _config(**overrides)
+    _patch_model_resolution(monkeypatch)
+
+    with pytest.raises(ValueError, match=message):
+        TTPlatform.check_and_update_config(config)

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -195,3 +195,22 @@ def test_startup_rejects_unsupported_block_modes(monkeypatch, overrides, message
 
     with pytest.raises(ValueError, match=message):
         TTPlatform.check_and_update_config(config)
+
+
+def test_offline_unresolved_max_tokens_gets_whole_canvas_default():
+    """Offline callers can reach validation with max_tokens=None; mirror the
+    server-side whole-canvas default instead of failing opaquely."""
+    params = SamplingParams(max_tokens=16)
+    params.max_tokens = None
+
+    _validate(params, prompt_len=200)
+
+    assert params.max_tokens == 768
+
+
+def test_offline_unresolved_max_tokens_rejected_when_no_canvas_fits():
+    params = SamplingParams(max_tokens=16)
+    params.max_tokens = None
+
+    with pytest.raises(ValueError, match="physical 256-token output canvases"):
+        _validate(params, prompt_len=1000)

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+import torch
+from vllm.config import (
+    CacheConfig,
+    DeviceConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+from vllm_tt_plugin.config import store_tt_output_tokens_per_step
+from vllm_tt_plugin.scheduler import TTScheduler
+
+BLOCK_SIZE = 16
+CANVAS = 16
+MAX_MODEL_LEN = 256
+
+
+def _scheduler(output_width: int = CANVAS) -> TTScheduler:
+    model_config = ModelConfig(
+        model="Qwen/Qwen2-0.5B-Instruct",
+        dtype="float16",
+        seed=42,
+    )
+    model_config.max_model_len = MAX_MODEL_LEN
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=1,
+        max_num_batched_tokens=MAX_MODEL_LEN,
+        max_model_len=MAX_MODEL_LEN,
+        enable_chunked_prefill=False,
+        async_scheduling=False,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    cache_config = CacheConfig(
+        block_size=BLOCK_SIZE,
+        gpu_memory_utilization=0.9,
+        cache_dtype="auto",
+        enable_prefix_caching=False,
+    )
+    config = VllmConfig(
+        scheduler_config=scheduler_config,
+        model_config=model_config,
+        cache_config=cache_config,
+        parallel_config=ParallelConfig(),
+        device_config=DeviceConfig(device="cpu"),
+    )
+    config.scheduler_config.async_scheduling = False
+    store_tt_output_tokens_per_step(config, output_width)
+    num_blocks = MAX_MODEL_LEN // BLOCK_SIZE + 2
+    cache_config.num_gpu_blocks = num_blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=BLOCK_SIZE,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+    return TTScheduler(
+        vllm_config=config,
+        kv_cache_config=kv_cache_config,
+        block_size=BLOCK_SIZE,
+        log_stats=True,
+        structured_output_manager=StructuredOutputManager(config),
+    )
+
+
+def _request(max_tokens: int, *, ignore_eos: bool = True) -> Request:
+    init_none_hash(sha256)
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        ignore_eos=ignore_eos,
+    )
+    sampling_params.update_from_generation_config({}, eos_token_id=2)
+    return Request(
+        request_id="req-0",
+        prompt_token_ids=[1] * 32,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(BLOCK_SIZE, sha256),
+    )
+
+
+def _runner_output(
+    scheduler_output: SchedulerOutput, tokens: list[int]
+) -> ModelRunnerOutput:
+    req_id = next(iter(scheduler_output.num_scheduled_tokens))
+    return ModelRunnerOutput(
+        req_ids=[req_id],
+        req_id_to_index={req_id: 0},
+        sampled_token_ids=[tokens],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def test_scheduler_reserves_and_reconciles_full_canvas():
+    scheduler = _scheduler()
+    request = _request(CANVAS * 2)
+    scheduler.add_request(request)
+
+    prefill = scheduler.schedule()
+
+    assert prefill.num_scheduled_tokens == {"req-0": 32}
+    assert request.num_output_placeholders == CANVAS
+    assert request.num_computed_tokens == 32
+
+    outputs = scheduler.update_from_output(
+        prefill, _runner_output(prefill, list(range(CANVAS)))
+    )
+    assert outputs[0].outputs[0].new_token_ids == list(range(CANVAS))
+    assert request.num_output_placeholders == 0
+
+    decode = scheduler.schedule()
+    assert decode.num_scheduled_tokens == {"req-0": CANVAS}
+    assert request.num_output_placeholders == CANVAS
+    assert request.num_computed_tokens == 32 + CANVAS
+
+
+def test_max_tokens_trims_canvas_and_consumes_physical_reservation():
+    scheduler = _scheduler()
+    request = _request(3)
+    scheduler.add_request(request)
+    prefill = scheduler.schedule()
+
+    outputs = scheduler.update_from_output(
+        prefill, _runner_output(prefill, list(range(CANVAS)))
+    )
+
+    assert outputs[0].outputs[0].new_token_ids == [0, 1, 2]
+    assert list(request.output_token_ids) == [0, 1, 2]
+    assert request.num_output_placeholders == 0
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+
+def test_eos_trims_canvas_and_consumes_physical_reservation():
+    scheduler = _scheduler()
+    request = _request(CANVAS, ignore_eos=False)
+    scheduler.add_request(request)
+    prefill = scheduler.schedule()
+
+    outputs = scheduler.update_from_output(
+        prefill, _runner_output(prefill, [0, 2, *range(2, CANVAS)])
+    )
+
+    assert outputs[0].outputs[0].new_token_ids == [0, 2]
+    assert request.num_output_placeholders == 0
+    assert request.status == RequestStatus.FINISHED_STOPPED
+
+
+def test_k1_delegates_to_upstream_async_scheduler():
+    scheduler = _scheduler(output_width=1)
+    request = _request(2)
+    scheduler.add_request(request)
+    prefill = scheduler.schedule()
+    cache_calls = []
+    scheduler.kv_cache_manager.cache_blocks = lambda *args: cache_calls.append(args)
+
+    outputs = scheduler.update_from_output(prefill, _runner_output(prefill, [7]))
+
+    assert outputs[0].outputs[0].new_token_ids == [7]
+    assert request.num_output_placeholders == 0
+    assert cache_calls

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -31,7 +31,9 @@ CANVAS = 16
 MAX_MODEL_LEN = 256
 
 
-def _scheduler(output_width: int = CANVAS) -> TTScheduler:
+def _scheduler(
+    output_width: int = CANVAS, *, diffusion_checkpoint: bool = False
+) -> TTScheduler:
     model_config = ModelConfig(
         model="Qwen/Qwen2-0.5B-Instruct",
         dtype="float16",
@@ -60,6 +62,12 @@ def _scheduler(output_width: int = CANVAS) -> TTScheduler:
         device_config=DeviceConfig(device="cpu"),
     )
     config.scheduler_config.async_scheduling = False
+    if diffusion_checkpoint:
+        # A real DiffusionGemma checkpoint flags is_diffusion through
+        # hf_config.canvas_length (num_sampled_tokens_per_step becomes 0).
+        # The platform hook clears the upstream auto-created DiffusionConfig,
+        # so config.diffusion_config stays None here — the post-hook state.
+        config.model_config.hf_config.canvas_length = output_width
     store_tt_output_tokens_per_step(config, output_width)
     num_blocks = MAX_MODEL_LEN // BLOCK_SIZE + 2
     cache_config.num_gpu_blocks = num_blocks
@@ -184,3 +192,44 @@ def test_k1_delegates_to_upstream_async_scheduler():
     assert outputs[0].outputs[0].new_token_ids == [7]
     assert request.num_output_placeholders == 0
     assert cache_calls
+
+
+def test_diffusion_checkpoint_books_exactly_one_canvas():
+    """Regression for the canvas-as-spec double booking: upstream 0.24 turns
+    an uncleared DiffusionConfig into num_spec_tokens=canvas_length, stacking
+    256 speculative placeholders on the plugin's physical reservation until
+    long generations park unfinished. With the platform hook clearing it, a
+    diffusion-flagged config must book exactly one canvas per step."""
+    from vllm.config.diffusion import DiffusionConfig
+
+    scheduler = _scheduler(diffusion_checkpoint=True)
+
+    assert scheduler.num_sampled_tokens_per_step == 0
+    assert scheduler.num_spec_tokens == 0
+    # The live property chain the platform hook must keep broken: an
+    # uncleared DiffusionConfig resurrects canvas-as-spec accounting.
+    assert scheduler.vllm_config.num_speculative_tokens == 0
+    scheduler.vllm_config.diffusion_config = DiffusionConfig(canvas_length=CANVAS)
+    assert scheduler.vllm_config.num_speculative_tokens == CANVAS
+    scheduler.vllm_config.diffusion_config = None
+
+    request = _request(CANVAS * 2)
+    scheduler.add_request(request)
+    prefill = scheduler.schedule()
+
+    assert prefill.num_scheduled_tokens == {"req-0": 32}
+    assert prefill.num_spec_tokens_to_schedule == 0
+    assert list(request.spec_token_ids) == []
+    assert request.num_output_placeholders == CANVAS
+
+    scheduler.update_from_output(prefill, _runner_output(prefill, list(range(CANVAS))))
+    assert request.num_output_placeholders == 0
+
+    decode = scheduler.schedule()
+    assert decode.num_scheduled_tokens == {"req-0": CANVAS}
+    assert decode.num_spec_tokens_to_schedule == 0
+    assert request.num_output_placeholders == CANVAS
+
+    scheduler.update_from_output(decode, _runner_output(decode, list(range(CANVAS))))
+    assert request.num_output_placeholders == 0
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,3 +108,19 @@ def test_store_tt_lane_count_rejects_zero():
 
     with pytest.raises(ValueError, match="lane count must be >= 1"):
         tt_config.store_tt_lane_count(config, 0)
+
+
+def test_output_tokens_per_step_defaults_to_ar_and_round_trips():
+    config = _vllm_config()
+
+    assert tt_config.get_tt_output_tokens_per_step(config) == 1
+
+    tt_config.store_tt_output_tokens_per_step(config, 256)
+
+    assert tt_config.get_tt_output_tokens_per_step(config) == 256
+
+
+@pytest.mark.parametrize("invalid", [True, 0, -1, 1.5, "256"])
+def test_output_tokens_per_step_rejects_invalid_values(invalid):
+    with pytest.raises(ValueError, match="integer >= 1"):
+        tt_config.store_tt_output_tokens_per_step(_vllm_config(), invalid)

--- a/tests/test_diffusion_gemma_registration.py
+++ b/tests/test_diffusion_gemma_registration.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+from vllm.parser.parser_manager import ParserManager
+from vllm.reasoning import ReasoningParserManager
+
+from tests.test_gemma4_reasoning_parser import FakeTokenizer
+from vllm_tt_plugin import platform
+from vllm_tt_plugin.entrypoints import _register_tt_reasoning_parsers
+from vllm_tt_plugin.gemma4_reasoning_parser import Gemma4ReasoningParser
+
+
+def test_diffusion_gemma_reasoning_parser_alias(monkeypatch):
+    registrations = []
+    monkeypatch.setattr(
+        ReasoningParserManager,
+        "register_lazy_module",
+        staticmethod(lambda *args: registrations.append(args)),
+    )
+
+    _register_tt_reasoning_parsers()
+
+    assert (
+        "diffusion_gemma",
+        "vllm_tt_plugin.gemma4_reasoning_parser",
+        "Gemma4ReasoningParser",
+    ) in registrations
+
+
+def test_diffusion_gemma_model_architecture_aliases(monkeypatch):
+    registrations = []
+    monkeypatch.setattr(
+        platform,
+        "_register_model_if_missing",
+        lambda _registry, arch, target: registrations.append((arch, target)),
+    )
+
+    platform.register_tt_models()
+
+    expected_target = (
+        "models.experimental.diffusion_gemma.tt.generator_vllm:"
+        "DiffusionGemmaForCausalLM"
+    )
+    registered = dict(registrations)
+    for arch in (
+        "DiffusionGemmaForBlockDiffusion",
+        "DiffusionGemmaForCausalLM",
+        "TTDiffusionGemmaForBlockDiffusion",
+        "TTDiffusionGemmaForCausalLM",
+    ):
+        assert registered[arch] == expected_target
+
+
+def test_non_streaming_parser_adapter_uses_raw_token_ids():
+    ReasoningParserManager.register_module(
+        name="diffusion_gemma",
+        module=Gemma4ReasoningParser,
+    )
+    _register_tt_reasoning_parsers()
+    parser_cls = ParserManager.get_parser(
+        reasoning_parser_name="diffusion_gemma",
+    )
+    assert parser_cls is not None
+
+    parser = parser_cls(FakeTokenizer())
+    reasoning, content, tool_calls = parser.parse(
+        "thought\nReason.Answer.",
+        request=None,
+        model_output_token_ids=[1, 10, 2, 11],
+    )
+
+    assert reasoning == "Reason."
+    assert content == "Answer."
+    assert tool_calls == []

--- a/tests/test_diffusion_gemma_registration.py
+++ b/tests/test_diffusion_gemma_registration.py
@@ -72,3 +72,30 @@ def test_non_streaming_parser_adapter_uses_raw_token_ids():
     assert reasoning == "Reason."
     assert content == "Answer."
     assert tool_calls == []
+
+
+def test_non_streaming_parser_prefers_text_when_markers_visible():
+    """When the request kept special tokens (the tool parser's adjust_request
+    forces skip_special_tokens=False whenever tools are enabled), the text
+    path must be used so literal <|tool_call> frames survive for the tool
+    parser instead of being stripped by segment re-decoding."""
+    ReasoningParserManager.register_module(
+        name="diffusion_gemma",
+        module=Gemma4ReasoningParser,
+    )
+    _register_tt_reasoning_parsers()
+    parser_cls = ParserManager.get_parser(
+        reasoning_parser_name="diffusion_gemma",
+    )
+    assert parser_cls is not None
+
+    parser = parser_cls(FakeTokenizer())
+    reasoning, content, tool_calls = parser.parse(
+        "<|channel>thought\nReason.<channel|><|tool_call>call:get_weather{}",
+        request=None,
+        model_output_token_ids=[1, 10, 2, 4, 14],
+    )
+
+    assert reasoning == "Reason."
+    assert content is not None and "<|tool_call>" in content
+    assert tool_calls == []

--- a/tests/test_dp_modes.py
+++ b/tests/test_dp_modes.py
@@ -67,6 +67,7 @@ class TestDPModes:
             speculative_config=None,
             lora_config=None,
             cache_config=SimpleNamespace(enable_prefix_caching=False),
+            structured_outputs_config=SimpleNamespace(disable_any_whitespace=False),
         )
 
     @pytest.fixture
@@ -479,14 +480,11 @@ class TestDPModes:
             ["24,25,26,27,3,2,1,0", "16,17,18,19,20,21,22,23"],
         )
 
-        assert (
-            engine_utils.get_device_indices(
-                TTPlatform.device_control_env_var,
-                local_dp_rank=1,
-                world_size=1,
-            )
-            == "16,17,18,19,20,21,22,23"
-        )
+        assert engine_utils.get_physical_gpu_ids_for_local_dp_rank(
+            TTPlatform.device_control_env_var,
+            local_dp_rank=1,
+            world_size=1,
+        ) == ["16,17,18,19,20,21,22,23"]
 
     def test_legacy_gathered_override_is_ignored_by_platform(
         self,

--- a/tests/test_gemma4_reasoning_parser.py
+++ b/tests/test_gemma4_reasoning_parser.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+from vllm_tt_plugin.gemma4_reasoning_parser import Gemma4ReasoningParser
+
+
+class FakeTokenizer:
+    pieces = {
+        10: "thought\nReason.",
+        11: "Answer.",
+        12: "thought\nPart ",
+        13: "two.",
+    }
+
+    def get_vocab(self):
+        return {
+            "<|channel>": 1,
+            "<channel|>": 2,
+            "<|turn>": 3,
+            "<|tool_call>": 4,
+            "<|tool_response>": 5,
+        }
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        del skip_special_tokens
+        return "".join(self.pieces.get(token_id, "") for token_id in token_ids)
+
+
+def _parser() -> Gemma4ReasoningParser:
+    return Gemma4ReasoningParser(FakeTokenizer())
+
+
+def test_whole_canvas_markers_and_content_in_one_delta():
+    result = _parser().extract_reasoning_streaming(
+        "",
+        "thought\nReason.Answer.",
+        "thought\nReason.Answer.",
+        [],
+        [1, 10, 2, 11],
+        [1, 10, 2, 11],
+    )
+
+    assert result is not None
+    assert result.reasoning == "Reason."
+    assert result.content == "Answer."
+
+
+def test_stripped_marker_ids_split_reasoning_across_deltas():
+    parser = _parser()
+    first = parser.extract_reasoning_streaming(
+        "", "thought\nPart ", "thought\nPart ", [], [1, 12], [1, 12]
+    )
+    second = parser.extract_reasoning_streaming(
+        "thought\nPart ",
+        "thought\nPart two.Answer.",
+        "two.Answer.",
+        [1, 12],
+        [1, 12, 13, 2, 11],
+        [13, 2, 11],
+    )
+
+    assert first is not None and first.reasoning == "Part "
+    assert second is not None
+    assert second.reasoning == "two."
+    assert second.content == "Answer."
+
+
+def test_literal_marker_can_split_across_text_deltas():
+    parser = _parser()
+
+    assert (
+        parser.extract_reasoning_streaming("", "<|chan", "<|chan", [], [], []) is None
+    )
+    middle = parser.extract_reasoning_streaming(
+        "<|chan",
+        "<|channel>thought\nReason.<chan",
+        "nel>thought\nReason.<chan",
+        [],
+        [],
+        [],
+    )
+    final = parser.extract_reasoning_streaming(
+        "<|channel>thought\nReason.<chan",
+        "<|channel>thought\nReason.<channel|>Answer.",
+        "nel|>Answer.",
+        [],
+        [],
+        [],
+    )
+
+    assert middle is not None and middle.reasoning == "Reason."
+    assert final is not None and final.content == "Answer."
+
+
+def test_literal_marker_split_after_visible_prefix():
+    parser = _parser()
+
+    first = parser.extract_reasoning_streaming(
+        "", "Preface <|chan", "Preface <|chan", [], [], []
+    )
+    second = parser.extract_reasoning_streaming(
+        "Preface <|chan",
+        "Preface <|channel>thought\nReason.<channel|>Answer.",
+        "nel>thought\nReason.<channel|>Answer.",
+        [],
+        [],
+        [],
+    )
+
+    assert first is not None and first.content == "Preface "
+    assert second is not None
+    assert second.reasoning == "Reason."
+    assert second.content == "Answer."
+
+
+def test_no_marker_output_remains_content():
+    parser = _parser()
+    streamed = parser.extract_reasoning_streaming(
+        "", "Plain answer.", "Plain answer.", [], [99], [99]
+    )
+    reasoning, content = _parser().extract_reasoning("Plain answer.", request=None)
+
+    assert streamed is not None and streamed.content == "Plain answer."
+    assert reasoning is None
+    assert content == "Plain answer."
+
+
+def test_non_streaming_markers_split_reasoning_and_content():
+    reasoning, content = _parser().extract_reasoning(
+        "<|channel>thought\nReason.<channel|>Answer.", request=None
+    )
+
+    assert reasoning == "Reason."
+    assert content == "Answer."
+
+
+def test_non_streaming_stripped_markers_split_from_token_ids():
+    reasoning, content = _parser().extract_reasoning_from_token_ids(
+        [1, 10, 2, 11],
+        "thought\nReason.Answer.",
+    )
+
+    assert reasoning == "Reason."
+    assert content == "Answer."

--- a/tests/test_gemma4_reasoning_parser.py
+++ b/tests/test_gemma4_reasoning_parser.py
@@ -10,6 +10,7 @@ class FakeTokenizer:
         11: "Answer.",
         12: "thought\nPart ",
         13: "two.",
+        14: "call:get_weather{}",
     }
 
     def get_vocab(self):
@@ -142,3 +143,25 @@ def test_non_streaming_stripped_markers_split_from_token_ids():
 
     assert reasoning == "Reason."
     assert content == "Answer."
+
+
+def test_token_id_extraction_ends_reasoning_at_tool_call():
+    """A tool call terminates an open thinking channel; its payload must not
+    be swallowed into the reasoning field."""
+    reasoning, content = _parser().extract_reasoning_from_token_ids(
+        [1, 10, 4, 14], "thought\nReason.call:get_weather{}"
+    )
+
+    assert reasoning == "Reason."
+    assert content == "call:get_weather{}"
+
+
+def test_token_id_extraction_without_channel_keeps_content_intact():
+    """No thinking channel: a bare tool call (or plain content) must pass
+    through as content, not be reinterpreted as reasoning."""
+    reasoning, content = _parser().extract_reasoning_from_token_ids(
+        [4, 14, 11], "call:get_weather{}Answer."
+    )
+
+    assert reasoning is None
+    assert content == "call:get_weather{}Answer."

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -125,11 +125,11 @@ def test_streaming_assembles_name_and_args(parser: Gemma4ToolParser):
             prev, cur, chunk, [], [], [], request=None
         )
         if delta is not None and delta.tool_calls:
-            fn = delta.tool_calls[0].function or {}
-            if fn.get("name"):
-                name = fn["name"]
-            if fn.get("arguments"):
-                args_acc += fn["arguments"]
+            fn = delta.tool_calls[0].function
+            if fn is not None and fn.name:
+                name = fn.name
+            if fn is not None and fn.arguments:
+                args_acc += fn.arguments
         prev = cur
 
     assert name == "get_weather"


### PR DESCRIPTION
## Summary
- register the DiffusionGemma adapter and reasoning parser in the standalone TT plugin
- preserve 256-token model-owned outputs through request validation, runner state updates, synchronous scheduling, and model-owned request release
- disable upstream vLLM 0.24 `DiffusionConfig` speculative placeholders so each physical canvas is accounted exactly once
- preserve existing lane-DP execution when optional preemption metadata is absent
- accept and ignore OpenAI transport sampling controls while rejecting response-shaping and host-logits parameters

## Test plan
- [x] Full host suite against installed vLLM 0.24 on bhqb: 160 passed
- [x] Focused block/scheduler/lane regression suite: 50 passed
- [x] Ruff check and format
- [x] Plugin pre-commit and security checks
- [x] Standalone-plugin image installation/build path
- [ ] P300X2 live server and inference-server release validation: https://github.com/tenstorrent/tt-shield/actions/runs/31348632121

## Cross-repository pairing
- tt-metal adapter: `e37613fd2973d969c362a127b2d0c401a5e145d6`
- inference-server migration: https://github.com/tenstorrent/tt-inference-server/pull/4897 (`3fd203b1`)

The PR remains draft until the P300X2 server workflow completes.
