### PR TITLE
install: install vLLM's empty-target dep list instead of the CUDA one

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ The script installs vLLM with
 at runtime. It then installs the plugin with a few dependencies.
 Most dependencies come from the active tt-metal env.
 
+The script also installs vLLM's dependency list itself, fetched from
+`requirements/common.txt` at the pinned vLLM tag, and installs vLLM with
+`--no-deps`. Resolving them the usual way pulls vLLM's CUDA dependency set
+(torch pinned, `flashinfer`, `tilelang`, `nvidia-*`), which would fight the
+tt-metal env over `torch` and add several GB. This means the script needs network
+access to `raw.githubusercontent.com` beyond the package index. When installing
+inside a container, also set `UV_NO_CACHE=1` to keep the uv cache out of the
+image layer.
+
 To install or refresh only the plugin package:
 
 ```bash

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -1,7 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-VLLM_TARGET_DEVICE=empty uv pip install --no-binary vllm \
-    --override docs/vllm-overrides.txt vllm==0.24.0   # see that file for why. Must read when bumping vllm version!
-uv pip uninstall torchaudio   # CUDA wheel, unloadable next to CPU torch; transformers>=5.12 imports it if merely installed
+# vLLM's PyPI metadata is generated on a CUDA machine, and uv takes resolver
+# metadata from the published wheel even when the package is built from source.
+# A plain `uv pip install vllm` therefore resolves requirements/cuda.txt (torch,
+# torchaudio, numba, flashinfer, tilelang, tokenspeed-mla, nvidia-*) no matter
+# what VLLM_TARGET_DEVICE says. The empty target declares requirements/common.txt
+# instead, so fetch that list and install it explicitly, then give vLLM itself
+# --no-deps so the CUDA list is never consulted. This script owns the dependency
+# set as a result: re-read common.txt when bumping the version below.
+# In a container, set UV_NO_CACHE=1 so the sdist and the wheel built from it do
+# not stay behind in the image layer.
+VLLM_COMMON_REQUIREMENTS=$(mktemp)
+curl -fsSL \
+    https://raw.githubusercontent.com/vllm-project/vllm/v0.24.0/requirements/common.txt \
+    -o "$VLLM_COMMON_REQUIREMENTS" ||
+    # `return`, not `exit`: this script is sourced into the caller's shell.
+    { echo "install-vllm-tt: cannot fetch vLLM common.txt"; return 1; }
+uv pip install --override docs/vllm-overrides.txt \
+    -r "$VLLM_COMMON_REQUIREMENTS"   # see that file for why. Must read when bumping vllm version!
+rm -f "$VLLM_COMMON_REQUIREMENTS"
+# --no-binary-package: the published wheel is the CUDA build, kernels included.
+# vLLM ends up declaring no torch dependency, which is intended; torch belongs to
+# the tt-metal env this plugin runs inside.
+VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary-package vllm vllm==0.24.0
 uv pip install -e .

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -20,8 +20,8 @@ curl -fsSL \
 uv pip install --override docs/vllm-overrides.txt \
     -r "$VLLM_COMMON_REQUIREMENTS"   # see that file for why. Must read when bumping vllm version!
 rm -f "$VLLM_COMMON_REQUIREMENTS"
-# --no-binary-package: the published wheel is the CUDA build, kernels included.
-# vLLM ends up declaring no torch dependency, which is intended; torch belongs to
-# the tt-metal env this plugin runs inside.
-VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary-package vllm vllm==0.24.0
+# --no-binary vllm: the published wheel is the CUDA build, kernels included, so
+# vLLM has to come from source. vLLM ends up declaring no torch dependency, which
+# is intended; torch belongs to the tt-metal env this plugin runs inside.
+VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary vllm vllm==0.24.0
 uv pip install -e .


### PR DESCRIPTION
## Problem

`VLLM_TARGET_DEVICE=empty` has never affected which dependencies get installed.

vLLM's `setup.py` selects `requirements/common.txt` for the `empty` target, and
that file names no `torch`, `numba`, `flashinfer`, `tilelang`, `tokenspeed`, or
`nvidia-*`. But uv resolves a package's dependencies before building it, and it
takes that metadata from the published wheel even under `--no-binary`
([uv reference](https://docs.astral.sh/uv/reference/cli/#uv-pip-install): *"The
resolver will still use pre-built wheels to extract package metadata, if
available."*). vLLM's published metadata is generated on a CUDA machine, so every
install so far resolved `requirements/cuda.txt`:

```
torch==2.11.0  torchaudio==2.11.0  torchvision==0.26.0  numba==0.65.0
flashinfer-python==0.6.12  flashinfer-cubin==0.6.12  tilelang==0.1.9
tokenspeed-mla==0.1.2  nvidia-cudnn-frontend>=1.19.1  nvidia-cutlass-dsl[cu13]==4.5.2
```

Consequences:

- Several GB of CUDA wheels installed into an environment that cannot use them,
  which is what surfaced as Docker image and disk growth.
- `numba` gets moved to `0.65.0`, below what the tt-metal env resolves. `numba`
  exists only in `cuda.txt`, so this is the clearest proof the CUDA list is the
  one being applied.
- `torch` is held at an exact `==` pin. It happens to be satisfied today because
  tt-metal installs `2.11.0+cpu` and a pin without a local label accepts any
  local label. Once tt-metal moves to torch 2.12, uv will pull torch back to
  2.11.0 from PyPI, meaning the CUDA build plus its `nvidia-*` tree, and
  `torchvision` will fail its import-time torch check.
- The existing `uv pip uninstall torchaudio` line was a symptom of this.
  `torchaudio` is `cuda.txt`-only.

The overrides file cannot address this: `--override` rewrites a version
constraint, it cannot remove a dependency.


## Change

- Fetch `requirements/common.txt` at the pinned vLLM tag and install it
  explicitly, with the existing numpy/opencv overrides applied to it.
- Install vLLM with `--no-deps`, so the CUDA metadata is never consulted, and
  with `--no-binary vllm`, so the source build still happens (the
  published wheel is the CUDA build).
- Drop the `torchaudio` uninstall.
- Guard the fetch with `return 1`, since the script is sourced and has no
  `set -e`. Without it a failed fetch falls through to a `--no-deps` install and
  leaves a silently incomplete environment.
- Document in the script comment and the README that containers should set
  `UV_NO_CACHE=1`, so the sdist and the wheel built from it do not stay in the
  image layer.

vLLM now declares no `torch` dependency at all. That is the point: torch comes
from the tt-metal env, with nothing pinning it from the vLLM side.

Trade-off: `--no-deps` makes this script the owner of the dependency set, so
bumping the vLLM version means re-reading `common.txt`, same as the existing note
on the overrides file. The install also now needs network access to
`raw.githubusercontent.com` in addition to the package index.

## Testing

What was verified:

- Upstream `v0.24.0` `common.txt` (59 lines) and `cuda.txt` fetched and compared;
  `cuda.txt` matches vLLM 0.24.0's published PyPI metadata one for one.
- The sdist's `PKG-INFO` carries the same 95 CUDA `Requires-Dist` lines with
  `Dynamic: requires-dist`, so the sdist path offers no escape either.
- Script syntax checked with `bash -n` and `zsh -n`; both the success path and
  the fetch-failure path exercised against a stubbed `uv`, confirming the
  59-line requirements file reaches `uv pip install` and that a failed fetch
  returns 1 without proceeding.
- CI run: https://github.com/tenstorrent/tt-metal/actions/runs/31373801704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

