### PR TITLE
[port tenstorrent/vllm#454] fix: bind device state to the request, not the batch row

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -214,6 +214,11 @@ class TTModelRunner:
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
 
+        # req_id -> device slot holding its per-slot state (GDN recurrent/conv, seed
+        # RNG, decode trace buffers). Needed because evict/re-add and condense move a
+        # request's ROW, not its state.
+        self._req_state_slot: dict[str, int] = {}
+
         # Every standard-DP rank owns its own mesh and therefore its own host
         # sampler state. Single-process modes also instantiate exactly one.
         self.host_sampler = Sampler()
@@ -606,6 +611,9 @@ class TTModelRunner:
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
+            # Only a FINISHED request releases its slot; an unscheduled one still
+            # owns its state even though the lines below drop it from the batch.
+            self._req_state_slot.pop(req_id, None)
 
         # Remove the finished requests from the persistent batch.
         # NOTE(woosuk): There could be an edge case where finished_req_ids and
@@ -801,6 +809,61 @@ class TTModelRunner:
             num_logprobs=num_logprobs,
             enable_log_probs=num_logprobs >= 0,
         )
+
+    # --- Per-request device state slots (see ``self._req_state_slot``) ---
+
+    def _alloc_prefill_state_slots(self, row_req_ids: list[str]) -> list[int]:
+        """Pick each prefilling request's state slot, skipping slots that live
+        off-batch requests own. Prefers its own row (where it decodes), so the
+        steady state moves nothing."""
+        n_slots = self.tt_per_lane_max_num_seqs
+        prefilling = set(row_req_ids)
+        held = {
+            slot
+            for req_id, slot in self._req_state_slot.items()
+            if req_id not in prefilling and req_id in self.requests
+        }
+        slots: list[int] = []
+        for row, req_id in enumerate(row_req_ids):
+            if row < n_slots and row not in held:
+                slot = row
+            else:
+                free = [s for s in range(n_slots) if s not in held]
+                assert free, (
+                    f"no free device state slot for {len(row_req_ids)} prefill(s): "
+                    f"held={sorted(held)}, capacity={n_slots}"
+                )
+                slot = free[0]
+            held.add(slot)
+            self._req_state_slot[req_id] = slot
+            slots.append(slot)
+        return slots
+
+    def _decode_state_slot_remap(self, row_req_ids: list[str]) -> torch.Tensor | None:
+        """Gather permutation taking each request's state to its decode row: row
+        ``i`` reads slot ``remap[i]``. Always full slot width (no OOB gather); None
+        means identity, so skip it."""
+        n_slots = self.tt_per_lane_max_num_seqs
+        row_req_ids = row_req_ids[:n_slots]
+        want = [self._req_state_slot.get(r, row) for row, r in enumerate(row_req_ids)]
+        # post-gather: state sits at its row
+        settled = {r: row for row, r in enumerate(row_req_ids)}
+        if len(set(want)) != len(want) or any(not 0 <= s < n_slots for s in want):
+            # Never hand a non-permutation to a gather: one incoherent response beats
+            # an out-of-bounds device read.
+            logger.warning(
+                "TT decode state slots are not a permutation (%s); skipping the state "
+                "remap for this step -- one response may be incoherent.",
+                want,
+            )
+            self._req_state_slot.update(settled)
+            return None
+        taken = set(want)
+        remap = want + [s for s in range(n_slots) if s not in taken]
+        self._req_state_slot.update(settled)
+        if all(remap[i] == i for i in range(n_slots)):
+            return None
+        return torch.tensor(remap, dtype=torch.int32)
 
     def _prepare_model_inputs(
         self,
@@ -1132,7 +1195,18 @@ class TTModelRunner:
 
         block_tables_per_group = [bt.contiguous() for bt in block_tables_per_group]
         block_tables = block_tables_per_group[0]
-        slot_remap = input_batch.pop_slot_remap() if capture_slot_remap else None
+        # State follows the request, not the row (``self._req_state_slot``). That
+        # subsumes the batch's condense-move remap, so pop and discard it.
+        input_batch.pop_slot_remap()
+        row_req_ids = [input_batch.req_ids[i] for i in req_indices]
+        if is_prompt:
+            prefill_empty_slots = self._alloc_prefill_state_slots(row_req_ids)
+            slot_remap = None
+        else:
+            prefill_empty_slots = None
+            slot_remap = self._decode_state_slot_remap(row_req_ids)
+        if not capture_slot_remap:
+            slot_remap = None
 
         return TTModelInput(
             input_tokens=input_tokens,
@@ -1156,6 +1230,10 @@ class TTModelRunner:
             max_num_logprobs=[input_batch.max_num_logprobs],
             logitsprocs_list=[logitsprocs],
             generators_list=[generators],
+            # Destination state slot per row. Without it a stateful model falls
+            # back to ``range(N)`` and a prefill overwrites a decoding request's
+            # state. Stateless models ignore it.
+            prefill_empty_slots=prefill_empty_slots,
         )
 
     def build_model_input(
@@ -2399,16 +2477,18 @@ class TTModelRunner:
                 for s in sampling_param_dict["seed"]
             ]
             kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
-        if len(batch_size_per_dp) > 1:
-            empty_slots = model_input.prefill_empty_slots
-            if empty_slots is None:
-                # TODO: the model should only require DP ranks, but passing
-                # "global" user ids instead for backwards compatibility.
-                stride = self.tt_per_lane_max_num_seqs
-                empty_slots = []
-                for dp_rank, sz in enumerate(batch_size_per_dp):
-                    for i in range(int(sz)):
-                        empty_slots.append(dp_rank * stride + i)
+        # The slots go to the model whenever the build supplied them: a stateful
+        # model's ``range(N)`` default clobbers live state, DP=1 included.
+        empty_slots = model_input.prefill_empty_slots
+        if empty_slots is None and len(batch_size_per_dp) > 1:
+            # TODO: the model should only require DP ranks, but passing
+            # "global" user ids instead for backwards compatibility.
+            stride = self.tt_per_lane_max_num_seqs
+            empty_slots = []
+            for dp_rank, sz in enumerate(batch_size_per_dp):
+                for i in range(int(sz)):
+                    empty_slots.append(dp_rank * stride + i)
+        if empty_slots is not None:
             kwargs["empty_slots"] = list(empty_slots)
 
         if self.request_specific_rope:

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -873,7 +873,6 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
         grammar_output: GrammarOutput | None,
-        capture_slot_remap: bool = True,
     ) -> TTModelInput:
         """Build a ``TTModelInput`` for one prefill or decode step.
 
@@ -891,10 +890,6 @@ class TTModelRunner:
                 structured-output bitmasks.
             grammar_output: Structured-output bitmasks for this step, or
                 ``None`` when no request uses guided decoding.
-            capture_slot_remap: Whether this build will carry the decode state
-                remap. False skips computing it, because building it also advances
-                the ownership map to the post-gather layout. Prefill slots are
-                attached either way.
 
         Returns:
             A ``TTModelInput`` with tokens, positions, block tables, sampling
@@ -1210,13 +1205,11 @@ class TTModelRunner:
         prefill_empty_slots = None
         slot_remap = None
         if is_prompt:
-            # Not gated on ``capture_slot_remap``: a prefill always needs its slots,
-            # or the model falls back to ``range(N)`` over live state.
             prefill_empty_slots = self._alloc_prefill_state_slots(row_req_ids)
-        elif capture_slot_remap:
-            # Only when the caller will carry the remap. Building it advances the
-            # ownership map to the post-gather layout, so computing it for a build
-            # that drops it would leave the map claiming a move that never happened.
+        else:
+            # Advances the ownership map to the post-gather layout, so the returned
+            # remap has to reach the device: dropping it would leave the map claiming
+            # a move that never happened.
             slot_remap = self._decode_state_slot_remap(row_req_ids)
 
         return TTModelInput(

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -829,10 +829,14 @@ class TTModelRunner:
                 slot = row
             else:
                 free = [s for s in range(n_slots) if s not in held]
-                assert free, (
-                    f"no free device state slot for {len(row_req_ids)} prefill(s): "
-                    f"held={sorted(held)}, capacity={n_slots}"
-                )
+                if not free:
+                    # A raise, not an assert: the message is the only way to tell a
+                    # capacity shortfall from a leak in the ownership map, and ``-O``
+                    # would drop an assert and leave an opaque IndexError below.
+                    raise RuntimeError(
+                        f"no free device state slot for {len(row_req_ids)} prefill(s): "
+                        f"held={sorted(held)}, capacity={n_slots}"
+                    )
                 slot = free[0]
             held.add(slot)
             self._req_state_slot[req_id] = slot
@@ -887,8 +891,10 @@ class TTModelRunner:
                 structured-output bitmasks.
             grammar_output: Structured-output bitmasks for this step, or
                 ``None`` when no request uses guided decoding.
-            capture_slot_remap: Whether to pop and attach the input batch's
-                pending slot remap.
+            capture_slot_remap: Whether this build will carry the decode state
+                remap. False skips computing it, because building it also advances
+                the ownership map to the post-gather layout. Prefill slots are
+                attached either way.
 
         Returns:
             A ``TTModelInput`` with tokens, positions, block tables, sampling
@@ -1195,18 +1201,23 @@ class TTModelRunner:
 
         block_tables_per_group = [bt.contiguous() for bt in block_tables_per_group]
         block_tables = block_tables_per_group[0]
-        # State follows the request, not the row (``self._req_state_slot``). That
-        # subsumes the batch's condense-move remap, so pop and discard it.
+        # State follows the request, not the row (``self._req_state_slot``), which
+        # subsumes the batch's condense-move remap. Drain it on every build: it is
+        # dead information now, and leaving it pending would let it accumulate moves
+        # the state map has already accounted for.
         input_batch.pop_slot_remap()
         row_req_ids = [input_batch.req_ids[i] for i in req_indices]
+        prefill_empty_slots = None
+        slot_remap = None
         if is_prompt:
+            # Not gated on ``capture_slot_remap``: a prefill always needs its slots,
+            # or the model falls back to ``range(N)`` over live state.
             prefill_empty_slots = self._alloc_prefill_state_slots(row_req_ids)
-            slot_remap = None
-        else:
-            prefill_empty_slots = None
+        elif capture_slot_remap:
+            # Only when the caller will carry the remap. Building it advances the
+            # ownership map to the post-gather layout, so computing it for a build
+            # that drops it would leave the map claiming a move that never happened.
             slot_remap = self._decode_state_slot_remap(row_req_ids)
-        if not capture_slot_remap:
-            slot_remap = None
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/tests/test_state_slots.py
+++ b/tests/test_state_slots.py
@@ -80,10 +80,9 @@ def test_state_follows_the_request_across_row_moves():
 def test_building_the_decode_remap_advances_the_ownership_map():
     """Not a pure query: it records the post-gather layout.
 
-    This is why ``_prepare_model_inputs`` computes it only when the build will carry
-    it. Computing it for a build that drops the remap would leave the map claiming a
-    move the device never performed, and every later step would then read the wrong
-    slot and see an identity remap.
+    So the remap it returns has to reach the device. A caller that built it and then
+    dropped it would leave the map claiming a move that never happened, and every
+    later step would read the wrong slot behind an identity remap.
     """
     r = _runner()
     r._req_state_slot.update({"A": 3, "B": 1})

--- a/tests/test_state_slots.py
+++ b/tests/test_state_slots.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-only tests for per-request device state slots.
+
+A persistent-batch ROW is not stable for a request: ``_update_states`` evicts a
+running request the step does not schedule (every prefill step does) and re-adds it
+at whatever row is free, and ``condense`` moves rows down when a request finishes.
+Device state indexed by slot (Qwen3.6 GDN recurrent+conv, the per-slot seed RNG, the
+decode trace's token/position buffers) does not follow, so
+``_alloc_prefill_state_slots`` and ``_decode_state_slot_remap`` say where each
+request's state is. No device execution: both are pure index bookkeeping, run here
+against a fake runner.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_tt_plugin import model_runner as model_runner_module
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+SLOTS = 8
+
+
+def _runner(slots=SLOTS):
+    """Fake runner: the state-slot map, the live-request set and the slot capacity."""
+    return SimpleNamespace(
+        tt_per_lane_max_num_seqs=slots, _req_state_slot={}, requests={}
+    )
+
+
+def _prefill(runner, row_req_ids):
+    out = TTModelRunner._alloc_prefill_state_slots(runner, list(row_req_ids))
+    runner.requests.update(dict.fromkeys(row_req_ids))
+    return out
+
+
+def _decode(runner, row_req_ids):
+    remap = TTModelRunner._decode_state_slot_remap(runner, list(row_req_ids))
+    return None if remap is None else remap.tolist()
+
+
+def test_state_follows_the_request_across_row_moves():
+    """The full lifecycle: fresh prefill, eviction, return at a new row, re-prefill."""
+    r = _runner()
+    # Empty server: fresh slots equal fresh rows, so no state has to move.
+    assert _prefill(r, ["A"]) == [0]
+    assert _decode(r, ["A"]) is None  # identity -> consumers skip the gather
+
+    # THE BUG. A is live but unscheduled, so vLLM gives its row 0 to a new request.
+    # A prefill into slot 0 destroys A's recurrent state and A then emits garbage.
+    incoming = [f"B{i}" for i in range(7)]
+    slots = _prefill(r, incoming)
+    assert 0 not in slots, f"prefill took A's live slot: {slots}"
+    assert len(set(slots)) == 7 and all(0 < s < SLOTS for s in slots)
+
+    # vLLM re-adds A at the first free row (7). The remap must fetch A's state from
+    # the slot it sits in, and every other row from its own.
+    rows = incoming + ["A"]
+    remap = _decode(r, rows)
+    assert remap is not None, "a returning request needs its state moved"
+    assert len(remap) == SLOTS and sorted(remap) == list(range(SLOTS)), (
+        "must be a permutation"
+    )
+    assert remap[7] == 0, f"row 7 (A) must read A's slot 0, got {remap[7]}"
+    for row, s in enumerate(slots):
+        assert remap[row] == s, (
+            f"row {row} must read {rows[row]}'s slot {s}, got {remap[row]}"
+        )
+    # State now sits at each request's row, so the next step is free again.
+    assert _decode(r, rows) is None
+
+    # A preempted request is re-prefilled while it still owns its slot: it must keep
+    # that slot, not move and leave the old one stranded.
+    assert _prefill(r, ["B0"]) == [0], (
+        "a re-prefilled live request must keep its own slot"
+    )
+
+
+def test_capacity_and_slot_width_are_enforced():
+    """More prefills than slots is a caller bug; rows past capacity are dropped."""
+    r = _runner(slots=2)
+    _prefill(r, ["A"])
+    _decode(r, ["A"])
+    with pytest.raises(AssertionError, match="no free device state slot"):
+        _prefill(r, ["B", "C"])
+
+    # Rows beyond the slot width are truncated, so an over-long batch still yields a
+    # permutation of the real slots instead of an out-of-range source index.
+    r = _runner(slots=2)
+    r._req_state_slot.update({"A": 1, "B": 0})
+    assert _decode(r, ["A", "B", "C"]) == [1, 0]
+
+
+def test_non_permutation_is_refused_and_a_clean_map_is_silent(monkeypatch):
+    """A duplicated source slot would make a device gather read one slot twice.
+
+    The warning is captured by replacing the module logger; the plugin's logger does not
+    propagate to pytest's root handler.
+    """
+    warned: list[str] = []
+    monkeypatch.setattr(
+        model_runner_module.logger,
+        "warning",
+        lambda msg, *a, **k: warned.append(str(msg)),
+    )
+
+    # A request the allocator never saw is assumed to sit at its own row, which keeps
+    # the remap the identity instead of guessing. Nothing wrong, so nothing logged.
+    r = _runner()
+    assert _decode(r, ["X", "Y"]) is None
+    assert not warned, f"the clean path must not warn: {warned}"
+
+    # Skip the move -- one incoherent response beats an OOB device read -- and say so.
+    r._req_state_slot.update({"X": 3, "Y": 3})
+    assert _decode(r, ["X", "Y"]) is None
+    assert any("not a permutation" in w for w in warned), warned
+    # The map is still repaired to the rows, so the next step is consistent.
+    assert r._req_state_slot == {"X": 0, "Y": 1}

--- a/tests/test_state_slots.py
+++ b/tests/test_state_slots.py
@@ -77,12 +77,29 @@ def test_state_follows_the_request_across_row_moves():
     )
 
 
+def test_building_the_decode_remap_advances_the_ownership_map():
+    """Not a pure query: it records the post-gather layout.
+
+    This is why ``_prepare_model_inputs`` computes it only when the build will carry
+    it. Computing it for a build that drops the remap would leave the map claiming a
+    move the device never performed, and every later step would then read the wrong
+    slot and see an identity remap.
+    """
+    r = _runner()
+    r._req_state_slot.update({"A": 3, "B": 1})
+    r.requests.update(dict.fromkeys(["A", "B"]))
+
+    assert _decode(r, ["A", "B"]) == [3, 1, 0, 2, 4, 5, 6, 7]
+    assert r._req_state_slot["A"] == 0 and r._req_state_slot["B"] == 1
+
+
 def test_capacity_and_slot_width_are_enforced():
     """More prefills than slots is a caller bug; rows past capacity are dropped."""
     r = _runner(slots=2)
     _prefill(r, ["A"])
     _decode(r, ["A"])
-    with pytest.raises(AssertionError, match="no free device state slot"):
+    # A raise, not an assert, so the diagnostic survives ``python -O``.
+    with pytest.raises(RuntimeError, match="no free device state slot"):
         _prefill(r, ["B", "C"])
 
     # Rows beyond the slot width are truncated, so an over-long batch still yields a


### PR DESCRIPTION
Port of [tenstorrent/vllm#454](https://github.com/tenstorrent/vllm/pull/454) (merged) into the standalone plugin.

## The bug

A persistent-batch **row** is not stable for a request:

- `_update_states` evicts a running request the step does not schedule (every prefill step does) and re-adds it at whatever row is free.
- `condense` moves rows down when a request finishes.

Device state indexed by **slot** does not follow the row: Qwen3.6 GDN recurrent+conv state, the per-slot seed RNG, and the decode trace's token/position buffers. So a prefill lands on a live request's state and that request emits garbage from then on.

Second half of the bug: `submit_prefill` only sent `empty_slots` to the model when `len(batch_size_per_dp) > 1`. At DP=1 it sent nothing, so a stateful model fell back to its `range(N)` default and clobbered live state.

## The fix

`self._req_state_slot: dict[str, int]` tracks which device slot holds each request's state. Only a **finished** request releases its slot; an unscheduled one keeps it.

- `_alloc_prefill_state_slots` picks a prefilling request's slot, skipping slots owned by live off-batch requests. It prefers the request's own row, so the steady state moves nothing.
- `_decode_state_slot_remap` returns the gather permutation taking each request's state to its decode row. Always full slot width (no out-of-bounds gather); `None` means identity so consumers skip the gather. A non-permutation is refused with a warning rather than handed to a device gather.
- The batch's own condense-move `slot_remap` is now subsumed by this map, so it is popped and discarded.
- `submit_prefill` sends the slots whenever the build supplied them, DP=1 included.

### Scope: which execution path this touches

Both new methods are called only from `TTModelRunner._prepare_model_inputs`, which is the **non-lane** build path. Single-process lane-DP builds its inputs through `TTLaneInputBatch.build_model_input` instead and already carries stable slots from the step plan (`plan.prefill_empty_slots`, `slot_remap=None`), so it is unaffected apart from `submit_prefill` now forwarding those plan slots at `num_lanes == 1`, which is the intended fix.

In the non-lane path `tt_per_lane_max_num_seqs == tt_max_batch_size == max_num_seqs`, and the batch is `InputBatch(max_num_reqs=tt_max_batch_size)`, so the slot count equals the batch's row capacity exactly.

The multi-rank DP merge still passes `prefill_empty_slots=None` and falls back to the range-based global slots, exactly as in the upstream PR. The decode `slot_remap` does survive the merge (each rank's values get offset to global indices).

## Testing

`tests/test_state_slots.py` (new, host-only, no device): both functions are pure index bookkeeping, exercised against a fake runner. Covers the full lifecycle (prefill, eviction, return at a new row, re-prefill of a live request), capacity exhaustion, row truncation past slot width, and the non-permutation refusal.

Run on a Wormhole Galaxy host with the plugin installed:

- `pytest tests/test_state_slots.py` -> 3 passed.
- Host-only suite (`tests/`, excluding `tests/tt` device tests and `tests/test_dp_modes.py`, which fails to import on `vllm==0.24.0`): 71 passed / 12 failed on this branch vs 68 passed / 12 failed on `main`. Same 12 pre-existing failures, +3 new tests, no regressions.

## (No longer) blocked on a tt-metal fix

This PR is the first caller to hand tt-metal non-identity prefill slots, which exposes a latent index-space bug in the batched-prefill path: it places request `i` at device row `empty_slots[i]` but writes the returned token at that slot instead of at `i`, sizes its slot-indexed buffers by the request count, and feeds the device prefill-ordered sampling params for slot-indexed rows. The result is `IndexError: index 7 is out of bounds for dimension 0 with size 7` on `vllm-tests / Llama-3.1-8B-Instruct DP=4 [wh_galaxy_perf]` ([run 31467940142](https://github.com/tenstorrent/tt-metal/actions/runs/31467940142/job/93710695971)); the same job is green on this repo's `main` ([run 31137103537](https://github.com/tenstorrent/tt-metal/actions/runs/31137103537)).

Fixed by **[tenstorrent/tt-metal#52808](https://github.com/tenstorrent/tt-metal/pull/52808)**. - Merged

## Validation

* VLLM CI: https://github.com/tenstorrent/tt-metal/actions/runs/31479124493 (all failures seem unrelated - infra, timeouts)

## Known follow-up, deliberately not fixed here

A preempted request keeps its state slot even though preemption frees its KV and forces a full re-prefill, so the slot's contents are already dead. That shrinks effective slot capacity and can trip `_alloc_prefill_state_slots`' bare `assert free`, which kills the engine core. Filed as #35, which also records that `tenstorrent/vllm` `dev` needs the same fix.

This is upstream's behaviour, not something the port introduces, so this PR stays a faithful port and leaves it alone.

For the record, an earlier version of this description claimed a lane-DP interaction here. That was wrong: lane-DP never reaches this code (see *Scope* above), and the `row_req_ids[:n_slots]` truncation in `_decode_state_slot_remap` is unreachable defensive code, not a restriction to the first lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
