### PR TITLE
Enable token-chunked prefill for Gemma 4 (port of tenstorrent/vllm#448)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ selects the TT-owned runtime classes through vLLM's extension points:
 The execution model matches TT hardware characteristics:
 
 - A TT step is either prefill-only or decode-only.
-- Chunked prefill is not (yet) used.
+- Token-chunked prefill is available for Gemma 4: a long prompt is split across
+  prefill steps and only the chunk that completes the prompt emits a token.
+  Every other model type keeps prefill unsplit.
 - Async scheduling overlaps decode submission with host-side scheduling when
   the model declares support.
 - For Galaxy-generator models (Llama3 70B, Qwen3-32B) and GPT-OSS,
@@ -429,7 +431,9 @@ clear error before anything reaches the device:
 - Tensor parallel and pipeline parallel execution are not supported.
 - Speculative decoding is not currently supported.
 - LoRA is not currently supported.
-- Chunked prefill is disabled.
+- Chunked prefill is disabled for every model type except Gemma 4, and
+  `max_num_batched_tokens` is bumped to `max_model_len` when it is disabled.
+- Multimodal inputs are never split across chunk boundaries.
 - Prompt logprobs are rejected at request validation time.
 - Prefix caching is enabled only for models that declare TT support for it.
 - Async decode overlap is enabled only for models that declare the capability.

--- a/README.md
+++ b/README.md
@@ -433,7 +433,8 @@ clear error before anything reaches the device:
 - LoRA is not currently supported.
 - Chunked prefill is disabled for every model type except Gemma 4, and
   `max_num_batched_tokens` is bumped to `max_model_len` when it is disabled.
-- Multimodal inputs are never split across chunk boundaries.
+- Where chunked prefill is active, multimodal inputs are never split across a
+  chunk boundary.
 - Prompt logprobs are rejected at request validation time.
 - Prefix caching is enabled only for models that declare TT support for it.
 - Async decode overlap is enabled only for models that declare the capability.

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -20,7 +20,9 @@ The current TT path is more specialized than upstream vLLM:
 
 - A TT step is treated as either all-prefill or all-decode.
 - TT does not support mixed prefill+decode batches.
-- TT does not support chunked prefill at the scheduling level.
+- Token-chunked prefill is supported, but only for model types whose tt-metal
+  generator can resume a prefill; a chunk continuation is prefill work and only
+  ever runs in a prefill step.
 - CPU-device work overlap is a decode optimization.
 - Standard multi-process DP runs independent per-rank engines.
 - Single-process lane-DP coordinates lanes within one process and executes one
@@ -43,14 +45,18 @@ There are three important scheduler-side collections:
 - `running`: requests already admitted and holding active scheduler state
 
 TT treats `waiting` and `skipped_waiting` together when checking for pending
-prefill work. What TT changes is not the existence of these collections, but
-the rules for choosing what kind of work a step may contain and how that
-scheduled work is executed afterward.
+prefill work. A partly prefilled request sits in `running` with
+`is_prefill_chunk` set; TT counts it as pending prefill work too, because only
+a prefill step can advance it. What TT changes is not the existence of these
+collections, but the rules for choosing what kind of work a step may contain
+and how that scheduled work is executed afterward.
 
 For TT, it is useful to think in terms of two batch types:
 
-- prefill batch: admits ready work from the pending prefill queues
-- decode batch: advances already-running work from `running`
+- prefill batch: admits ready work from the pending prefill queues and advances
+  partial-prefill continuations from `running`
+- decode batch: advances already-running work from `running`, with partial
+  prefills hidden
 
 That is a simplification compared with upstream vLLM, but it matches how the TT path is intentionally organized today.
 
@@ -58,8 +64,7 @@ TT still performs continuous batching in the broad sense: requests arrive in
 `waiting`, may be held in `skipped_waiting`, are admitted while other requests
 remain active, can be preempted back to `waiting`, and leave independently as
 they finish. The restriction is within each device step: TT does not mix
-prefill and decode work or make incremental chunked-prefill progress in the
-same way as upstream.
+prefill and decode work in the same batch.
 
 ## Current TT Execution Flow
 
@@ -71,10 +76,9 @@ The TT scheduler prefers to admit waiting work first, because TT wants to form a
 
 ### 2. Scheduler decision
 
-The current TT scheduler enforces two important rules:
-
-- no mixed prefill+decode batch
-- no chunked prefill
+The current TT scheduler enforces one important rule: no mixed prefill+decode
+batch. A chunked prefill stays on the prefill side of that split, so its
+continuations are scheduled by prefill steps only.
 
 So each TT scheduling step picks one of:
 
@@ -140,17 +144,45 @@ That lag is intentional and is what creates host/device overlap.
 
 The TT scheduler behaves like this:
 
-- if `waiting` or `skipped_waiting` contains pending prefill work, run the prefill scheduling pass so newly ready requests can be promoted and admitted.
+- if `waiting` or `skipped_waiting` contains pending prefill work, or any
+  running request is a partial-prefill continuation, run the prefill scheduling
+  pass so newly ready requests can be promoted and admitted and continuations
+  can advance.
 - otherwise, advance decode work
 - if pending prefill work cannot be admitted, fall back to decode to free
-  capacity
+  capacity. Partial prefills do not make this fallback viable: a decode step
+  cannot advance them, so only genuine running decodes count.
 
-The reason for this policy is simple: TT currently wants a homogeneous batch type per step, and it wants full-prefill admission rather than upstream-style incremental prefill progress.
+The reason for this policy is simple: TT wants a homogeneous batch type per
+step.
 
-At configuration time the platform turns requested chunked prefill off. If
-`max_num_batched_tokens` is then smaller than `max_model_len`, it raises that
-token budget to `max_model_len` so a full prompt can be admitted instead of
-leaving an unschedulable request in `waiting`.
+At configuration time the platform turns requested chunked prefill off for
+every model type whose tt-metal generator cannot resume a prefill, and zeroes
+`long_prefill_token_threshold` (the base scheduler applies that cap before it
+consults `enable_chunked_prefill`, so leaving it set would still split a
+prefill). When chunked prefill is off and `max_num_batched_tokens` is smaller
+than `max_model_len`, it raises that token budget to `max_model_len` so a full
+prompt can be admitted instead of leaving an unschedulable request in
+`waiting`.
+
+### Chunked prefill
+
+For a model type that supports it, the base scheduler may give a long prompt
+only part of the token budget. The request then moves to `running` with
+`is_prefill_chunk` set, and later prefill steps schedule the next chunk until
+the prompt is fully computed.
+
+Two things follow for the TT execution path:
+
+- The value handed to the generator as `prompt_lens` is the *end position of
+  the scheduled chunk* (`num_computed_tokens + num_scheduled_tokens`), not the
+  sequence length. The generator processes `tokens[start_pos:prompt_lens]`.
+- A chunk that does not finish the prompt is *intermediate*: its forward writes
+  KV state but emits no token. Those rows are marked in
+  `TTModelInput.intermediate_prefill_mask`, force the step onto host sampling
+  (device sampling would advance device RNG state for them), get a generator
+  clone so the request's RNG does not drift, and report `[]` in the
+  `ModelRunnerOutput` instead of a sampled token.
 
 ### Why TT uses an async-style scheduler even in TT-specific flows
 
@@ -413,7 +445,8 @@ The current TT path is more constrained:
 
 - it treats prefill and decode as separate batch modes
 - it avoids mixed prefill+decode batches
-- it avoids chunked prefill
+- it allows chunked prefill only for model types validated for it, and always
+  on the prefill side of the split
 
 ### 2. Async queueing model
 

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -105,6 +105,13 @@ def apply_cached_req_state_update(
             block_ids.extend(new_ids)
 
 
+def clone_torch_generator(generator: torch.Generator) -> torch.Generator:
+    """Copy a generator so the sampler advances the copy, not the original."""
+    clone = torch.Generator(device=generator.device)
+    clone.set_state(generator.get_state())
+    return clone
+
+
 class SamplingInputBatch:
     # Default values for padding sampling parameters in decode mode.
     DEFAULTS = {
@@ -936,7 +943,9 @@ class TTLaneInputBatch(InputBatch):
             logit_proc.update_state(batch_update)
 
     def build_merged_sampling_metadata(
-        self, scheduled_rows: list[int] | None = None
+        self,
+        scheduled_rows: list[int] | None = None,
+        non_sampling_rows: list[int] | None = None,
     ) -> SamplingMetadata:
         """Build one :class:`SamplingMetadata` over every slot row.
 
@@ -960,6 +969,11 @@ class TTLaneInputBatch(InputBatch):
         prefill-only step) must not have its RNG advanced, or its token stream
         would drift by one draw per step it sat out. ``None`` advances all live
         generators (whole-batch fallback / tests).
+
+        ``non_sampling_rows`` are scheduled intermediate-prefill rows: they
+        occupy a row in the fixed slot layout the sampler runs over, but their
+        token is discarded, so they are handed a generator clone and the
+        request's real RNG state stays put.
         """
         n = self.max_num_reqs
         sampling = self.sampling
@@ -1003,8 +1017,11 @@ class TTLaneInputBatch(InputBatch):
             generators = dict(sampling.generators)
         else:
             scheduled = set(scheduled_rows)
+            non_sampling = set(non_sampling_rows or ())
             generators = {
-                row: gen for row, gen in sampling.generators.items() if row in scheduled
+                row: clone_torch_generator(gen) if row in non_sampling else gen
+                for row, gen in sampling.generators.items()
+                if row in scheduled
             }
         return SamplingMetadata(
             temperature=temperature if not all_greedy else None,
@@ -1191,10 +1208,22 @@ class TTLaneInputBatch(InputBatch):
         lane_batch = self
         rows = list(plan.input_rows)
         rows_np = np.asarray(rows, dtype=np.int64)
-        input_positions = torch.from_numpy(
-            lane_batch.num_computed_tokens_cpu[rows_np].astype(np.int32)
+        input_positions_np = lane_batch.num_computed_tokens_cpu[rows_np]
+        input_positions = torch.from_numpy(input_positions_np.astype(np.int32))
+        # The generator processes ``tokens[start_pos:prompt_lens]``, so
+        # ``prompt_lens`` is the end position of the chunk scheduled this step,
+        # not the full sequence length. They coincide for an unchunked prefill.
+        chunk_lens = np.asarray(
+            [
+                scheduler_output.num_scheduled_tokens[lane_batch.req_ids[row]]
+                for row in rows
+            ],
+            dtype=np.int64,
         )
-        prompt_lens = lane_batch.num_tokens[rows_np]
+        prompt_lens = input_positions_np + chunk_lens
+        intermediate_prefill_mask = torch.from_numpy(
+            prompt_lens < lane_batch.num_tokens[rows_np]
+        )
         max_prefill = int(prompt_lens.max())
         input_tokens = lane_batch.token_ids_cpu_tensor[rows_np, :max_prefill]
 
@@ -1213,6 +1242,11 @@ class TTLaneInputBatch(InputBatch):
         perform_device_sampling = runner.check_perform_device_sampling(
             is_decode=False, has_structured_outputs=has_structured
         )
+        if intermediate_prefill_mask.any():
+            # Device sampling advances device RNG state for every row it reads,
+            # which an intermediate chunk must not do. Host sampling can hand
+            # those rows a generator clone instead.
+            perform_device_sampling = False
 
         # Device-side penalties only; host sampling rebuilds these in
         # ``build_merged_sampling_metadata`` (over the full slot batch), so
@@ -1256,6 +1290,7 @@ class TTLaneInputBatch(InputBatch):
                 if plan.prefill_empty_slots is not None
                 else None
             ),
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
 
     def extract_output(
@@ -1279,7 +1314,27 @@ class TTLaneInputBatch(InputBatch):
         """
         n = len(scheduled_rows)
         rows_t = torch.as_tensor(scheduled_rows, dtype=torch.long)
+        intermediate_rows: list[int] = []
+        # The mask is prefill-only; a decode step never carries one.
+        if not is_decode and model_input.intermediate_prefill_mask is not None:
+            mask = model_input.intermediate_prefill_mask
+            assert mask.numel() == n
+            intermediate_rows = [
+                row
+                for row, is_intermediate in zip(
+                    scheduled_rows, mask.tolist(), strict=True
+                )
+                if is_intermediate
+            ]
+            if len(intermediate_rows) == n:
+                # Nothing to sample: every row is mid-prompt. The placeholder
+                # tokens are dropped by the caller.
+                return torch.zeros((n, 1), dtype=torch.int32), None
         if model_input.perform_device_sampling:
+            assert not intermediate_rows, (
+                "Intermediate prefill rows must use host sampling so their "
+                "device RNG state is not advanced."
+            )
             tokens = tt_out.reshape(-1) if isinstance(tt_out, torch.Tensor) else tt_out
             # Decode reads each scheduled slot; prefill returns one token per
             # scheduled request, already in row order.
@@ -1296,7 +1351,9 @@ class TTLaneInputBatch(InputBatch):
         bitmask = model_input.grammar_bitmask[0]
         if bitmask is not None:
             runner.apply_grammar_bitmask(logits, bitmask)
-        sampling_metadata = self.build_merged_sampling_metadata(scheduled_rows)
+        sampling_metadata = self.build_merged_sampling_metadata(
+            scheduled_rows, non_sampling_rows=intermediate_rows
+        )
         sampler_output = runner.host_sampler(
             logits=logits, sampling_metadata=sampling_metadata
         )

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -356,6 +356,10 @@ class TTLaneCoordinator(SchedulerInterface):
         running (so it must prefill to make progress) or spare capacity to admit
         more alongside its running decodes.
 
+        A partial prefill continuation always wants to prefill, even with the
+        lane at capacity: it already holds one of those slots and only a
+        prefill step can advance it.
+
         ``skipped_waiting`` holds prefill requests blocked on grammar
         compilation. We want to try to schedule them, because otherwise the
         base scheduler won't revisit and promote them - decode intent hides
@@ -363,8 +367,11 @@ class TTLaneCoordinator(SchedulerInterface):
         """
         has_waiting = bool(sched.waiting) or bool(sched.skipped_waiting)
         has_running = bool(sched.running)
+        has_partial_prefill = any(r.is_prefill_chunk for r in sched.running)
         has_capacity = len(sched.running) < self._per_lane_max
-        return int(has_waiting and ((not has_running) or has_capacity))
+        return int(
+            has_partial_prefill or (has_waiting and ((not has_running) or has_capacity))
+        )
 
     def _negotiate_forced_mode(self) -> TTSchedulingMode:
         """Pick the single mode (prefill- or decode-only) all lanes will run.
@@ -500,16 +507,20 @@ class TTLaneCoordinator(SchedulerInterface):
         lane_outputs = self._schedule_all_lanes(forced_mode)
         merged = merge_lane_scheduler_outputs(lane_outputs)
 
-        # Decode fallback: a forced prefill step can schedule zero tokens (no
-        # chunked prefill + KV pressure means no full prefill fits). If any lane
-        # has running decodes, falling back to a decode-only step keeps them
-        # advancing — without this the step makes no global progress and the
-        # engine livelocks. Mirrors the base scheduler's DEFAULT-mode fallback,
-        # which the forced mode bypasses.
+        # Decode fallback: a forced prefill step can schedule zero tokens (KV
+        # pressure means no prefill fits). If any lane has running decodes,
+        # falling back to a decode-only step keeps them advancing - without
+        # this the step makes no global progress and the engine livelocks.
+        # Mirrors the base scheduler's DEFAULT-mode fallback, which the forced
+        # mode bypasses. Partial prefills do not count: a decode step cannot
+        # advance them, so falling back on their account would livelock too.
         if (
             forced_mode == TTSchedulingMode.PREFILL_ONLY
             and merged.total_num_scheduled_tokens == 0
-            and any(sched.running for sched in self.lanes)
+            and any(
+                any(not r.is_prefill_chunk for r in sched.running)
+                for sched in self.lanes
+            )
         ):
             # The discarded prefill pass already drained each lane's
             # finished/freed-encoder bookkeeping; carry it onto the decode pass

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -125,3 +125,8 @@ class TTModelInput:
     # Single-process DP prefill only: global stable slots supplied by the
     # scheduler-owned step plan. ``None`` for non-DP and for decode.
     prefill_empty_slots: list[int] | None = None
+
+    # Prefill only: rows whose forward writes KV state but must not emit a
+    # sampled token, because more prompt tokens remain after this chunk.
+    # ``None`` for decode.
+    intermediate_prefill_mask: torch.Tensor | None = None

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -49,6 +49,7 @@ from vllm_tt_plugin.input_batch import (
     TTLaneInputBatch,
     apply_cached_req_state_update,
     build_cached_request_state,
+    clone_torch_generator,
 )
 from vllm_tt_plugin.lane_scheduler import get_tt_step_plan
 from vllm_tt_plugin.loader import TTModelLoader
@@ -141,9 +142,6 @@ class TTModelRunner:
         self.request_specific_rope = bool(self.model_config.uses_mrope)
         if self.request_specific_rope:
             self.previous_req_ids: set[str] = set()
-
-        # Currently, TT model runner doesn't support chunked prefill.
-        assert self.scheduler_config.enable_chunked_prefill is False
 
         self.mesh_device = mesh_device
         self.trace_mode = trace_mode
@@ -891,6 +889,43 @@ class TTModelRunner:
             return None
         return torch.tensor(remap, dtype=torch.int32)
 
+    @staticmethod
+    def _build_host_generators(
+        input_batch: InputBatch,
+        req_indices: list[int],
+        intermediate_prefill_mask: torch.Tensor | None,
+    ) -> dict[int, torch.Generator]:
+        """Re-key generators (batch row -> Generator) to this build's rows.
+
+        The host sampler draws once per generator it is handed, so each request
+        must appear exactly once per step: this build's generators are advanced
+        here, and lane builds pass only their own ``req_indices`` so a generator
+        advances once per step rather than once per lane.
+
+        An intermediate-prefill row's token is discarded, so it gets a clone
+        and its request's real RNG state is left untouched.
+        """
+        intermediate_rows = (
+            set(intermediate_prefill_mask.nonzero().view(-1).tolist())
+            if intermediate_prefill_mask is not None
+            else set()
+        )
+        generators: dict[int, torch.Generator] = {}
+        rows_to_advance: list[int] = []
+        for local_row, batch_row in enumerate(req_indices):
+            generator = input_batch.sampling.generators.get(batch_row)
+            if generator is None:
+                continue
+            if local_row in intermediate_rows:
+                generators[local_row] = clone_torch_generator(generator)
+            else:
+                generators[local_row] = generator
+                rows_to_advance.append(batch_row)
+        # Technically this advances the generator before it is copied, but it's
+        # ok because this happens consistently.
+        input_batch.advance_generators(rows_to_advance)
+        return generators
+
     def _prepare_model_inputs(
         self,
         scheduler_output: SchedulerOutput,
@@ -953,24 +988,46 @@ class TTModelRunner:
         # NOTE: We assume that all sequences in the group are all prompts or
         # all decodes.
         cached_reqs = scheduler_output.scheduled_cached_reqs
+        num_scheduled = scheduler_output.num_scheduled_tokens
+
+        def _is_still_prefilling(req_id: str) -> bool:
+            row = input_batch.req_id_to_index[req_id]
+            return (
+                input_batch.num_computed_tokens_cpu[row]
+                < input_batch.num_prompt_tokens[row]
+            )
+
         # A "prefill" step can contain:
         # - brand new requests (scheduled_new_reqs), and/or
         # - resumed-from-preemption requests (scheduled_cached_reqs with
-        #   resumed_req_ids set) that need to replay tokens to rebuild KV.
-        is_prompt = (len(scheduler_output.scheduled_new_reqs) > 0) or bool(
-            cached_reqs.resumed_req_ids
+        #   resumed_req_ids set) that need to replay tokens to rebuild KV,
+        #   and/or
+        # - chunked-prefill continuations: cached requests that have not
+        #   computed all their prompt tokens yet.
+        has_chunked_continuation = any(
+            _is_still_prefilling(req_id)
+            for req_id in cached_reqs.req_ids
+            if req_id not in cached_reqs.resumed_req_ids
+        )
+        is_prompt = (
+            len(scheduler_output.scheduled_new_reqs) > 0
+            or bool(cached_reqs.resumed_req_ids)
+            or has_chunked_continuation
         )
         sample_params = input_batch.sampling
+        intermediate_prefill_mask: torch.Tensor | None = None
         if is_prompt:
             # NOTE: In SchedulerOutput, "cached" means "request data already
             # cached on the worker", not necessarily "decode". During a prefill
             # step we can legitimately see cached requests if they are resumed
-            # from preemption (still prefill work).
+            # from preemption or are chunked-prefill continuations (both still
+            # prefill work).
             if cached_reqs.num_reqs > 0:
                 running_req_ids = {
                     req_id
                     for req_id in cached_reqs.req_ids
                     if req_id not in cached_reqs.resumed_req_ids
+                    and not _is_still_prefilling(req_id)
                 }
                 if running_req_ids:
                     # Mixed prefill+decode batch detected. This should not
@@ -1002,13 +1059,24 @@ class TTModelRunner:
             # num_computed_tokens for each request is the input position
             # (=computed previously and cached)
             input_positions = input_batch.num_computed_tokens_cpu[req_indices]
-            # Prefill length in tokens for each request:
-            # - For new requests: equals prompt length.
-            # - For resumed-from-preemption requests: includes any generated
-            #   output tokens so far, so we can replay the full sequence to
-            #   rebuild KV after preemption freed the cache blocks.
-            prompt_lens = input_batch.num_tokens[req_indices]
-            max_prefill_tokens = max(prompt_lens)
+            # The generator slices ``tokens[start_pos:prompt_lens]``, so
+            # ``prompt_lens`` is the end position of the chunk scheduled this
+            # step, not the sequence length:
+            # - Full prefill: start_pos=0, chunk=prompt_len => prompt_len.
+            # - APC hit: start_pos=cached, chunk=prompt_len-cached => prompt_len.
+            # - Resumed from preemption: the chunk spans the generated output
+            #   tokens too, so the full sequence is replayed to rebuild KV.
+            # - Chunked continuation: start_pos=computed, chunk=budget =>
+            #   computed + budget, i.e. this chunk's end.
+            chunk_lens = np.array(
+                [num_scheduled[input_batch.req_ids[i]] for i in req_indices],
+                dtype=np.int64,
+            )
+            prompt_lens = input_positions + chunk_lens
+            intermediate_prefill_mask = torch.from_numpy(
+                prompt_lens < input_batch.num_tokens[req_indices]
+            )
+            max_prefill_tokens = int(prompt_lens.max())
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
             ]
@@ -1103,6 +1171,11 @@ class TTModelRunner:
             is_decode=not is_prompt,
             has_structured_outputs=has_structured,
         )
+        if intermediate_prefill_mask is not None and intermediate_prefill_mask.any():
+            # Device sampling advances device RNG state for every row it reads,
+            # which an intermediate chunk must not do. Host sampling can hand
+            # those rows a generator clone instead.
+            perform_device_sampling = False
 
         # Populate prompt_tokens and output_tokens if penalties are needed
         # (decode only).
@@ -1171,27 +1244,11 @@ class TTModelRunner:
         # local batch, so the host sampler reuses them as-is.
         logitsprocs = input_batch.sampling.logitsprocs
 
-        generators = dict()
+        generators: dict[int, torch.Generator] = {}
         if not perform_device_sampling:
-            # Re-key generators (req_index -> Generator) to lane-local rows.
-            # The values are the same Generator objects advanced just below, so
-            # advancing via the shared ``input_batch`` keeps them in step.
-            src_generators = input_batch.sampling.generators
-            generators = {
-                local: src_generators[g]
-                for local, g in enumerate(req_indices)
-                if g in src_generators
-            }
-            # Technically this advances the generator before it is copied,
-            # but it's ok because this happens consistently.
-            #
-            # Each generator belongs to exactly one request (one lane), so we
-            # advance only this build's generators. Non-lane builds take the
-            # whole batch once per step, so all generators advance exactly
-            # once; lane builds run once per lane, and passing the lane's
-            # ``req_indices`` keeps each generator advancing exactly once per
-            # step instead of once per lane.
-            input_batch.advance_generators(req_indices)
+            generators = self._build_host_generators(
+                input_batch, req_indices, intermediate_prefill_mask
+            )
             # NOTE: Our sampling paths are different between host and device.
             # Whether a request is sampled on device or host
             # depends also on other requests in the batch.
@@ -1242,6 +1299,7 @@ class TTModelRunner:
             # back to ``range(N)`` and a prefill overwrites a decoding request's
             # state. Stateless models ignore it.
             prefill_empty_slots=prefill_empty_slots,
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
 
     def build_model_input(
@@ -1424,6 +1482,23 @@ class TTModelRunner:
         # ``scheduled_rows`` are persistent slots; their req_ids in row order are
         # the canonical merged output order.
         req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
+
+        if not is_decode and model_input.prompt_lens is not None:
+            lane_batch = self.lane_batch
+            prompt_lens = np.asarray(model_input.prompt_lens)
+            num_tokens = np.array(
+                [lane_batch.num_tokens[row] for row in scheduled_rows],
+                dtype=np.int64,
+            )
+            intermediate_mask = prompt_lens < num_tokens
+            if intermediate_mask.any():
+                return self._build_chunked_prefill_output(
+                    req_ids=req_ids,
+                    sampled_token_ids=sampled,
+                    logprobs=logprobs,
+                    intermediate_mask=intermediate_mask,
+                )
+
         return self.apply_and_build_runner_output(sampled, logprobs, req_ids=req_ids)
 
     @torch.no_grad()
@@ -1567,7 +1642,66 @@ class TTModelRunner:
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
+
+        if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
+            num_reqs = self.input_batch.num_reqs
+            prompt_lens = np.asarray(fwd.model_input.prompt_lens)
+            # A row-count mismatch means the forward ran on a filtered subset;
+            # leave it to the output builder below to report.
+            if len(prompt_lens) == num_reqs:
+                intermediate_mask = prompt_lens < self.input_batch.num_tokens[:num_reqs]
+                if intermediate_mask.any():
+                    return self._build_chunked_prefill_output(
+                        req_ids=list(self.input_batch.req_ids[:num_reqs]),
+                        sampled_token_ids=sampled_token_ids,
+                        logprobs=logprobs,
+                        intermediate_mask=intermediate_mask,
+                    )
+
         return self.apply_and_build_runner_output(sampled_token_ids, logprobs)
+
+    def _build_chunked_prefill_output(
+        self,
+        req_ids: list[str],
+        sampled_token_ids: torch.Tensor,
+        logprobs: LogprobsLists | None,
+        intermediate_mask: np.ndarray,
+        req_id_to_index: dict[str, int] | None = None,
+    ) -> ModelRunnerOutput:
+        """Build a prefill output that emits no token for intermediate chunks.
+
+        A request mid-prompt gets ``[]`` so the engine advances its computed
+        tokens without appending output; only rows whose chunk ended the prompt
+        emit a token and are applied to runner state.
+        """
+        final_idx_np = np.where(~intermediate_mask)[0]
+        if final_idx_np.shape[0] > 0:
+            final_idx_tensor = torch.from_numpy(final_idx_np.astype(np.int64))
+            final_tokens = sampled_token_ids[final_idx_tensor]
+            final_req_ids = [req_ids[int(i)] for i in final_idx_np]
+            self._apply_sampled_tokens_to_state(final_tokens, req_ids=final_req_ids)
+
+        num_reqs = len(req_ids)
+        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        if sampled_token_ids_np.dtype != np.int32:
+            sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
+        sampled_token_id_lists = [
+            [] if intermediate_mask[i] else [int(sampled_token_ids_np[i])]
+            for i in range(num_reqs)
+        ]
+
+        return ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index=(
+                dict(req_id_to_index)
+                if req_id_to_index is not None
+                else {req_id: idx for idx, req_id in enumerate(req_ids)}
+            ),
+            sampled_token_ids=sampled_token_id_lists,
+            logprobs=logprobs,
+            prompt_logprobs_dict=dict.fromkeys(req_ids, None),
+            pooler_output=[],
+        )
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
@@ -1822,7 +1956,16 @@ class TTModelRunner:
             def _take(tensor: torch.Tensor, _rows: torch.Tensor = rows) -> torch.Tensor:
                 return tensor[_rows]
 
-            if not perform_device_sampling:
+            if (
+                not is_decode
+                and model_input.intermediate_prefill_mask is not None
+                and bool(model_input.intermediate_prefill_mask[rows].all())
+            ):
+                # Every row is mid-prompt; there is nothing to sample and the
+                # placeholders are dropped when the output is built.
+                next_token_ids = torch.zeros(sz, dtype=torch.int32)
+                logprobs_per_dp.append(None)
+            elif not perform_device_sampling:
                 logits = tt_out[rows, -1, :]
 
                 grammar_bitmask = model_input.grammar_bitmask[dp_rank]

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -64,6 +64,11 @@ def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
     model_type = getattr(model_config.hf_config, "model_type", None)
 
     if model_type in _CHUNKED_PREFILL_MODEL_TYPES:
+        # A chunk boundary inside a multimodal item would split its embeddings
+        # from their positions. Only meaningful while prefill can be split, and
+        # vLLM rejects the flag outright when one item exceeds the token budget,
+        # so it stays off for every model type below.
+        scheduler_config.disable_chunked_mm_input = True
         return
 
     if scheduler_config.enable_chunked_prefill:
@@ -839,10 +844,6 @@ class TTPlatform(Platform):
         cls._standard_dp_visible_device_groups = None
         cls._standard_dp_mesh_grids = {}
         _apply_chunked_prefill_policy(vllm_config)
-
-        # A chunk boundary inside a multimodal item would split its embeddings
-        # from their positions, so encoder inputs always go in one piece.
-        vllm_config.scheduler_config.disable_chunked_mm_input = True
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -52,6 +52,46 @@ _GALAXY_GENERATOR_VERSIONS = {
     "TT_QWEN3_TEXT_VER": "qwen3_32b_galaxy",
 }
 
+# HF ``model_type`` values whose tt-metal generator accepts a ``chunk_start_idx``
+# prefill, i.e. the ones token-chunked prefill has been validated against.
+_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4", "gemma4_unified"}
+
+
+def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
+    """Restrict token-chunked prefill to the model types that support it."""
+    scheduler_config = vllm_config.scheduler_config
+    model_config = vllm_config.model_config
+    model_type = getattr(model_config.hf_config, "model_type", None)
+
+    if model_type in _CHUNKED_PREFILL_MODEL_TYPES:
+        return
+
+    if scheduler_config.enable_chunked_prefill:
+        logger.info(
+            "Chunked prefill is not supported for `model_type=%s`; disabling it.",
+            model_type,
+        )
+        scheduler_config.enable_chunked_prefill = False
+
+        # vLLM does this bump silently earlier if chunked prefill is already
+        # disabled and max_num_batched_tokens is not explicitly set. We can't
+        # know if it was specified or the default, hence the warning.
+        max_num_batched_tokens = scheduler_config.max_num_batched_tokens
+        max_model_len = model_config.max_model_len
+        if max_num_batched_tokens < max_model_len:
+            logger.warning(
+                "max_num_batched_tokens=%d < max_model_len=%d with chunked "
+                "prefill disabled, bumping max_num_batched_tokens to match.",
+                max_num_batched_tokens,
+                max_model_len,
+            )
+            scheduler_config.max_num_batched_tokens = max_model_len
+
+    # The base scheduler caps a prefill at this threshold before it consults
+    # ``enable_chunked_prefill``, so leaving it nonzero still splits prefills
+    # for a model that cannot resume one.
+    scheduler_config.long_prefill_token_threshold = 0
+
 
 def _galaxy_generator_version() -> str | None:
     """Return the active Galaxy-generator model version, or None.
@@ -798,27 +838,11 @@ class TTPlatform(Platform):
         _install_tt_harmony_truncation_patch()
         cls._standard_dp_visible_device_groups = None
         cls._standard_dp_mesh_grids = {}
-        if vllm_config.scheduler_config.enable_chunked_prefill:
-            logger.info("Chunked prefill is not yet supported for TT backend")
-            vllm_config.scheduler_config.enable_chunked_prefill = False
-            # vLLM does this bump silently earlier
-            # if chunked prefill is already disabled,
-            # and max_num_batched_tokens is not explicitly set.
-            # We can't know if it was specified
-            # or the default, hence the warning.
-            if (
-                vllm_config.scheduler_config.max_num_batched_tokens
-                < vllm_config.model_config.max_model_len
-            ):
-                logger.warning(
-                    "max_num_batched_tokens=%d < max_model_len=%d with chunked prefill "
-                    "disabled, bumping max_num_batched_tokens to match.",
-                    vllm_config.scheduler_config.max_num_batched_tokens,
-                    vllm_config.model_config.max_model_len,
-                )
-                vllm_config.scheduler_config.max_num_batched_tokens = (
-                    vllm_config.model_config.max_model_len
-                )
+        _apply_chunked_prefill_policy(vllm_config)
+
+        # A chunk boundary inside a multimodal item would split its embeddings
+        # from their positions, so encoder inputs always go in one piece.
+        vllm_config.scheduler_config.disable_chunked_mm_input = True
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-import time
 from enum import Enum
 from typing import cast
 
@@ -54,8 +53,16 @@ class TTScheduler(AsyncScheduler):
     - with async_scheduling=True, placeholders allow decode requests to be
       re-scheduled before update_from_output processes the previous step's
       results, enabling host/device overlap
-    - under async scheduling, preemption invalidates the request's
-      scheduled-but-unreturned outputs (see ``_preempt_request``)
+    - under async scheduling a preempted request keeps the tokens it had
+      already scheduled but not yet received, and needs no TT-side handling
+      for them. Those tokens are valid: the forward that produced them ran to
+      completion before the preempt freed any block, device submits form a
+      strict queue, and every async op is forced to complete before the next
+      prefill, so no later write can reach the KV they were computed against.
+      The base class appends them on arrival and the resumed prefill replays
+      them. ``Request.async_tokens_to_discard`` serves the wholesale
+      ``reset_prefix_cache`` teardown only; wiring ordinary preemption into it
+      drops valid tokens and silently truncates the response.
 
     Supports ``set_forced_mode`` for lane coordination:
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
@@ -197,59 +204,3 @@ class TTScheduler(AsyncScheduler):
             if partial_prefills:
                 self.running.extend(partial_prefills)
         return result
-
-    def _preempt_request(self, request: Request, timestamp: float) -> None:
-        """Preempt a request and invalidate its in-flight async outputs.
-
-        The base class frees the request's KV cache and queues it to redo its
-        prefill from scratch.  Under async scheduling the tokens it already
-        scheduled are still on their way back, and they were computed against
-        the now-freed cache, so mark them to be dropped on arrival.
-        ``num_output_placeholders`` is exactly that in-flight count, and
-        ``AsyncScheduler._update_request_with_output`` drops one frame per
-        pending discard.
-        """
-        super()._preempt_request(request, timestamp)
-
-        if not self.scheduler_config.async_scheduling:
-            return
-
-        request.async_tokens_to_discard += request.num_output_placeholders
-        request.num_output_placeholders = 0
-
-    def reset_prefix_cache(
-        self, reset_running_requests: bool = False, reset_connector: bool = False
-    ) -> bool:
-        """Reset the KV prefix cache.
-
-        vLLM 0.24.0's base implementation already discards stale async outputs
-        for the reset-prefix-cache path *after* calling ``_preempt_request``.
-        TT broadens stale-output invalidation to every preemption inside
-        ``_preempt_request`` itself, so reusing the base method verbatim would
-        overwrite that discard count with zero.
-        """
-        if not (reset_running_requests and self.scheduler_config.async_scheduling):
-            return super().reset_prefix_cache(
-                reset_running_requests, reset_connector
-            )
-
-        timestamp = time.monotonic()
-        while self.running:
-            request = self.running.pop()
-            self._preempt_request(request, timestamp)
-
-        self.prev_step_scheduled_req_ids.clear()
-
-        reset_successful = self.kv_cache_manager.reset_prefix_cache()
-        if not reset_successful:
-            raise RuntimeError(
-                "Failed to reset KV cache even when all the running requests are "
-                "preempted and moved to the waiting queue. This is likely due to "
-                "the presence of running requests waiting for remote KV transfer, "
-                "which is not supported yet."
-            )
-
-        if reset_connector:
-            reset_successful = self.reset_connector_cache() and reset_successful
-
-        return reset_successful

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
+import time
 from enum import Enum
 from typing import cast
 
@@ -215,3 +216,40 @@ class TTScheduler(AsyncScheduler):
 
         request.async_tokens_to_discard += request.num_output_placeholders
         request.num_output_placeholders = 0
+
+    def reset_prefix_cache(
+        self, reset_running_requests: bool = False, reset_connector: bool = False
+    ) -> bool:
+        """Reset the KV prefix cache.
+
+        vLLM 0.24.0's base implementation already discards stale async outputs
+        for the reset-prefix-cache path *after* calling ``_preempt_request``.
+        TT broadens stale-output invalidation to every preemption inside
+        ``_preempt_request`` itself, so reusing the base method verbatim would
+        overwrite that discard count with zero.
+        """
+        if not (reset_running_requests and self.scheduler_config.async_scheduling):
+            return super().reset_prefix_cache(
+                reset_running_requests, reset_connector
+            )
+
+        timestamp = time.monotonic()
+        while self.running:
+            request = self.running.pop()
+            self._preempt_request(request, timestamp)
+
+        self.prev_step_scheduled_req_ids.clear()
+
+        reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if not reset_successful:
+            raise RuntimeError(
+                "Failed to reset KV cache even when all the running requests are "
+                "preempted and moved to the waiting queue. This is likely due to "
+                "the presence of running requests waiting for remote KV transfer, "
+                "which is not supported yet."
+            )
+
+        if reset_connector:
+            reset_successful = self.reset_connector_cache() and reset_successful
+
+        return reset_successful

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -53,6 +53,8 @@ class TTScheduler(AsyncScheduler):
     - with async_scheduling=True, placeholders allow decode requests to be
       re-scheduled before update_from_output processes the previous step's
       results, enabling host/device overlap
+    - under async scheduling, preemption invalidates the request's
+      scheduled-but-unreturned outputs (see ``_preempt_request``)
 
     Supports ``set_forced_mode`` for lane coordination:
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
@@ -194,3 +196,22 @@ class TTScheduler(AsyncScheduler):
             if partial_prefills:
                 self.running.extend(partial_prefills)
         return result
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        """Preempt a request and invalidate its in-flight async outputs.
+
+        The base class frees the request's KV cache and queues it to redo its
+        prefill from scratch.  Under async scheduling the tokens it already
+        scheduled are still on their way back, and they were computed against
+        the now-freed cache, so mark them to be dropped on arrival.
+        ``num_output_placeholders`` is exactly that in-flight count, and
+        ``AsyncScheduler._update_request_with_output`` drops one frame per
+        pending discard.
+        """
+        super()._preempt_request(request, timestamp)
+
+        if not self.scheduler_config.async_scheduling:
+            return
+
+        request.async_tokens_to_discard += request.num_output_placeholders
+        request.num_output_placeholders = 0

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -34,7 +34,11 @@ class TTScheduler(AsyncScheduler):
     TT constraints:
     - No mixed prefill+decode batches: each batch is either all-prefill
       or all-decode.
-    - No chunked prefill: each prefill must be scheduled in full.
+    - Token-chunked prefill is allowed: a long prefill may be split across
+      steps. After a partial chunk the base scheduler keeps the request in
+      ``running`` with ``is_prefill_chunk=True``; later prefill steps schedule
+      the next chunk until the prompt is fully computed. Those continuations
+      count as prefill work here, never as decodes.
 
     The base scheduler holds temporarily blocked prefill requests (e.g. while
     a structured-output grammar compiles) in ``skipped_waiting`` rather than
@@ -54,10 +58,10 @@ class TTScheduler(AsyncScheduler):
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
       queue is non-empty).
     - ``TTSchedulingMode.PREFILL_ONLY`` forces prefill-only (and may return an
-      empty batch when waiting is empty).
+      empty batch when there is no pending prefill work).
     - ``TTSchedulingMode.DEFAULT`` uses the default policy: prefer prefill
-      when waiting is non-empty, but fall back to decode-only if prefill
-      cannot admit any request and running decode requests exist.
+      when pending prefill work exists, but fall back to decode-only if
+      prefill cannot make progress and running decode requests exist.
     """
 
     waiting: RequestQueue
@@ -72,20 +76,31 @@ class TTScheduler(AsyncScheduler):
         self._forced_mode = mode
 
     def _has_pending_prefill(self) -> bool:
-        """Whether any request is waiting to be prefilled.
+        """Whether any request still needs prefill work.
 
         A request in ``skipped_waiting`` still needs a future prefill pass:
         that is where the base scheduler retries promotion after its dependency
         becomes ready. In decode-only mode this check also ensures both waiting
         queues are hidden from the base scheduler.
+
+        A running ``is_prefill_chunk`` request is a partial prefill whose next
+        chunk can only be scheduled by a prefill step.
         """
-        return bool(self.waiting) or bool(getattr(self, "skipped_waiting", False))
+        return (
+            bool(self.waiting)
+            or bool(getattr(self, "skipped_waiting", False))
+            or any(request.is_prefill_chunk for request in self.running)
+        )
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         # NOTE: `throttle_prefills` accepted for interface compatibility with the base
         #        scheduler but unused - TT separates prefill/decode explicitly.
-        has_waiting = self._has_pending_prefill()
-        has_running = bool(self.running)
+        has_pending_prefill = self._has_pending_prefill()
+        # A partial prefill occupies ``running`` but cannot produce a decode
+        # token, so it must not make the decode fallback below look viable.
+        has_running_decode = any(
+            not request.is_prefill_chunk for request in self.running
+        )
         mode = self._forced_mode
 
         if mode == TTSchedulingMode.PREFILL_ONLY:
@@ -95,28 +110,29 @@ class TTScheduler(AsyncScheduler):
             result = self._schedule_prefill_only()
             return self._finalize_scheduler_output(result)
         if mode == TTSchedulingMode.DECODE_ONLY:
-            if has_waiting:
-                # Hide waiting so base scheduler cannot admit prefill.
+            if has_pending_prefill:
+                # Hide the waiting queues and partial prefills so the base
+                # scheduler cannot admit prefill work.
                 result = self._schedule_decode_only()
                 return self._finalize_scheduler_output(result)
-            # No waiting requests: base scheduler naturally runs decode-only.
+            # No pending prefill: base scheduler naturally runs decode-only.
             result = super().schedule()
             return self._finalize_scheduler_output(result)
 
         # Default mode:
-        # Prefer prefill whenever waiting is non-empty to admit new requests.
-        if has_waiting:
+        # Prefer prefill whenever prefill work is pending, so new requests are
+        # admitted and partial prefills advance.
+        if has_pending_prefill:
             prefill_result = self._schedule_prefill_only()
-            # If waiting is non-empty but prefill cannot be admitted (e.g. KV
-            # pressure and no chunked prefill), do not stall decode progress.
-            # Fall back to decode-only so running requests can advance and free
-            # capacity for later full-prefill admission.
-            if prefill_result.total_num_scheduled_tokens == 0 and has_running:
+            # If prefill cannot make progress (e.g. KV pressure), do not stall
+            # decode. Fall back to decode-only so running requests can advance
+            # and free capacity for a later prefill admission.
+            if prefill_result.total_num_scheduled_tokens == 0 and has_running_decode:
                 result = self._schedule_decode_only()
                 return self._finalize_scheduler_output(result)
             return self._finalize_scheduler_output(prefill_result)
 
-        # No waiting requests in default mode: run decode-only naturally.
+        # No pending prefill work in default mode: run decode-only naturally.
         result = super().schedule()
         return self._finalize_scheduler_output(result)
 
@@ -126,38 +142,45 @@ class TTScheduler(AsyncScheduler):
         return scheduler_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
-        """Schedule only waiting (prefill) requests.
+        """Schedule prefill work: waiting requests and partial continuations.
 
-        Temporarily hides the running (decode) requests so the base
-        scheduler's running loop iterates zero times and only the
-        waiting loop executes.  Adjusts max_num_running_reqs so the
-        waiting loop respects the true capacity.
+        Temporarily hides the running *decode* requests so the base scheduler's
+        running loop only advances partial prefills, and its waiting loop
+        admits new ones.  Adjusts max_num_running_reqs so the waiting loop
+        respects the true capacity with the decodes hidden.
         """
-        saved_running = self.running
+        pure_decodes = [r for r in self.running if not r.is_prefill_chunk]
+        partial_prefills = [r for r in self.running if r.is_prefill_chunk]
+
         saved_max = self.max_num_running_reqs
-        self.running = cast(list[Request], [])
-        self.max_num_running_reqs = max(0, saved_max - len(saved_running))
+        self.running = cast(list[Request], partial_prefills)
+        self.max_num_running_reqs = max(0, saved_max - len(pure_decodes))
         try:
             result = super().schedule()
         finally:
-            self.running = saved_running + self.running
+            self.running.extend(pure_decodes)
             self.max_num_running_reqs = saved_max
         return result
 
     def _schedule_decode_only(self) -> SchedulerOutput:
-        """Schedule only running (decode) requests.
+        """Schedule only running decode requests.
 
         Temporarily hides both the ``waiting`` and ``skipped_waiting`` queues
         so the base scheduler's waiting loop is a no-op and cannot promote a
-        grammar-ready structured-output request into this decode step.  Any
-        requests that get preempted during decode scheduling are merged back
-        into the original queues afterwards.
+        grammar-ready structured-output request into this decode step, and
+        hides partial prefills so their next chunk is not scheduled into it
+        either.  Any requests that get preempted during decode scheduling are
+        merged back into the original queues afterwards.
         """
+        partial_prefills = [r for r in self.running if r.is_prefill_chunk]
+
         saved_waiting = self.waiting
         saved_skipped = getattr(self, "skipped_waiting", None)
         self.waiting = create_request_queue(self.policy)
         if saved_skipped is not None:
             self.skipped_waiting = create_request_queue(self.policy)
+        if partial_prefills:
+            self.running = [r for r in self.running if not r.is_prefill_chunk]
         try:
             result = super().schedule()
         finally:
@@ -168,4 +191,6 @@ class TTScheduler(AsyncScheduler):
                     saved_skipped.prepend_requests(self.skipped_waiting)
                 self.skipped_waiting = saved_skipped
             self.waiting = saved_waiting
+            if partial_prefills:
+                self.running.extend(partial_prefills)
         return result

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -25,6 +25,7 @@ def _vllm_config(
             enable_chunked_prefill=enable_chunked_prefill,
             max_num_batched_tokens=max_num_batched_tokens,
             long_prefill_token_threshold=long_prefill_token_threshold,
+            disable_chunked_mm_input=False,
         ),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(model_type=model_type),
@@ -41,6 +42,7 @@ def test_gemma4_keeps_chunked_prefill_and_its_token_budget():
     assert config.scheduler_config.enable_chunked_prefill is True
     assert config.scheduler_config.max_num_batched_tokens == 2048
     assert config.scheduler_config.long_prefill_token_threshold == 512
+    assert config.scheduler_config.disable_chunked_mm_input is True
 
 
 def test_unified_gemma4_checkpoint_also_keeps_chunked_prefill():
@@ -58,6 +60,20 @@ def test_other_model_type_loses_chunked_prefill_and_gets_a_full_prompt_budget():
 
     assert config.scheduler_config.enable_chunked_prefill is False
     assert config.scheduler_config.max_num_batched_tokens == 16384
+
+
+def test_unsplit_prefill_leaves_chunked_mm_input_enabled():
+    # vLLM raises outright when this is set and one mm item is larger than
+    # max_num_batched_tokens, e.g. a VL model pinned to a short max_model_len.
+    # With prefill never split the flag is inert, so it must stay off.
+    config = _vllm_config(
+        model_type="qwen2_5_vl", max_num_batched_tokens=2048, max_model_len=2048
+    )
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.disable_chunked_mm_input is False
 
 
 def test_other_model_type_zeroes_the_long_prefill_threshold():

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -4,6 +4,11 @@
 
 from types import SimpleNamespace
 
+# vLLM's own bootstrap resolves the platform plugin, which imports this module.
+# Letting the plugin module trigger that bootstrap deadlocks the cycle on a
+# half-built module, so let vLLM finish importing itself first.
+import vllm  # noqa: F401
+
 from vllm_tt_plugin.platform import _apply_chunked_prefill_policy
 
 

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+"""Which model types keep token-chunked prefill, and what is forced off."""
+
+from types import SimpleNamespace
+
+from vllm_tt_plugin.platform import _apply_chunked_prefill_policy
+
+
+def _vllm_config(
+    *,
+    model_type: str,
+    enable_chunked_prefill: bool = True,
+    max_num_batched_tokens: int = 2048,
+    max_model_len: int = 16384,
+    long_prefill_token_threshold: int = 512,
+):
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=enable_chunked_prefill,
+            max_num_batched_tokens=max_num_batched_tokens,
+            long_prefill_token_threshold=long_prefill_token_threshold,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+            max_model_len=max_model_len,
+        ),
+    )
+
+
+def test_gemma4_keeps_chunked_prefill_and_its_token_budget():
+    config = _vllm_config(model_type="gemma4")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+    assert config.scheduler_config.long_prefill_token_threshold == 512
+
+
+def test_unified_gemma4_checkpoint_also_keeps_chunked_prefill():
+    config = _vllm_config(model_type="gemma4_unified")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+
+
+def test_other_model_type_loses_chunked_prefill_and_gets_a_full_prompt_budget():
+    config = _vllm_config(model_type="llama")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.max_num_batched_tokens == 16384
+
+
+def test_other_model_type_zeroes_the_long_prefill_threshold():
+    # The base scheduler applies this cap before it consults
+    # enable_chunked_prefill, so leaving it set would still split a prefill.
+    config = _vllm_config(model_type="llama", enable_chunked_prefill=False)
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+    # Chunked prefill was already off, so the token budget is left alone.
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+
+
+def test_token_budget_is_left_alone_when_it_already_covers_the_model_len():
+    config = _vllm_config(model_type="llama", max_num_batched_tokens=32768)
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.max_num_batched_tokens == 32768

--- a/tests/test_lane_input_batch.py
+++ b/tests/test_lane_input_batch.py
@@ -243,6 +243,49 @@ def test_apply_step_plan_finished_request_releases_slot():
     assert b.occupied_rows() == []
 
 
+def test_lane_prefill_input_ends_at_scheduled_chunk_boundary():
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    from vllm_tt_plugin.lane_scheduler import TTStepPlan
+
+    batch = _lane_batch(num_lanes=1, per_lane=1)
+    request = _make_req("request", list(range(8)), [], dict(temperature=0.0))
+    row = _add_to_lane(batch, request, lane=0)
+    # Two prompt tokens already computed; this step schedules one more, so the
+    # chunk ends at position 3 while the prompt runs to 8.
+    batch.num_computed_tokens_cpu[row] = 2
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"request": 1}
+    scheduler_output.total_num_scheduled_tokens = 1
+    plan = TTStepPlan(
+        is_decode=False,
+        capacity=1,
+        scheduled_req_ids=("request",),
+        scheduled_rows=(row,),
+        input_rows=(row,),
+        req_id_to_row={"request": row},
+        batch_size_per_dp=(1,),
+        prefill_empty_slots=(row,),
+    )
+    runner = SimpleNamespace(
+        max_num_blocks_per_req=MAX_MODEL_LEN // BLOCK,
+        _block_tables_per_layer=lambda _: None,
+        check_perform_device_sampling=lambda **_: True,
+        model_config=SimpleNamespace(is_multimodal_model=False),
+        requests={"request": request},
+    )
+
+    model_input = batch.build_model_input(runner, scheduler_output, None, plan)
+
+    assert model_input.input_positions.tolist() == [2]
+    assert model_input.prompt_lens.tolist() == [3]
+    assert model_input.input_tokens.tolist() == [[0, 1, 2]]
+    assert model_input.intermediate_prefill_mask.tolist() == [True]
+    # An intermediate chunk must not advance device RNG state.
+    assert model_input.perform_device_sampling is False
+
+
 def test_lane_full_raises():
     b = _lane_batch(num_lanes=1, per_lane=2)
     _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.0)), 0)
@@ -475,6 +518,24 @@ def test_merged_sampling_metadata_filters_generators_to_scheduled_rows():
 
     assert set(metadata.generators) == {row4}
     assert metadata.generators[row4] is b.sampling.generators[row4]
+
+
+def test_merged_sampling_metadata_clones_intermediate_generators():
+    # A scheduled intermediate-prefill row must keep its slot in the sampler's
+    # fixed layout without spending one of the request's RNG draws.
+    b = _lane_batch(num_lanes=1, per_lane=1, with_custom=False)
+    row = _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.7), seed=11), 0)
+    generator = b.sampling.generators[row]
+    before = generator.get_state().clone()
+
+    metadata = b.build_merged_sampling_metadata(
+        scheduled_rows=[row], non_sampling_rows=[row]
+    )
+
+    assert metadata.generators[row] is not generator
+    assert torch.equal(metadata.generators[row].get_state(), before)
+    Sampler()(torch.randn(1, VOCAB), metadata)
+    assert torch.equal(generator.get_state(), before)
 
 
 def test_scheduled_seeded_row_isolated_from_unscheduled_random_row():

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -126,6 +126,7 @@ def test_extract_output_device_prefill_returns_front_packed_tokens():
             enable_log_probs=torch.zeros(2, dtype=torch.bool)
         ),
         max_num_logprobs=[None],
+        intermediate_prefill_mask=None,
     )
 
     sampled, logprobs = batch.extract_output(
@@ -144,7 +145,9 @@ def test_extract_output_device_prefill_returns_front_packed_tokens():
 def test_extract_output_host_decode_samples_full_slot_then_picks_rows():
     captured: dict = {}
     batch = _lane_batch()
-    batch.build_merged_sampling_metadata = lambda rows: None  # sampler ignores it
+    batch.build_merged_sampling_metadata = (
+        lambda rows, non_sampling_rows=None: None
+    )  # sampler ignores it
     runner = SimpleNamespace(host_sampler=_capturing_host_sampler(captured))
     # Full slot logits: row r's argmax is token r (vocab>=5).
     logits = torch.full((5, VOCAB), -10.0)
@@ -164,13 +167,17 @@ def test_extract_output_host_decode_samples_full_slot_then_picks_rows():
 def test_extract_output_host_prefill_scatters_logits_to_stable_rows():
     captured: dict = {}
     batch = _lane_batch()
-    batch.build_merged_sampling_metadata = lambda rows: None
+    batch.build_merged_sampling_metadata = lambda rows, non_sampling_rows=None: None
     runner = SimpleNamespace(host_sampler=_capturing_host_sampler(captured))
     # Prefill logits: one row per scheduled request (front-packed, plan order).
     prefill_logits = torch.full((2, VOCAB), -10.0)
     prefill_logits[0, 3] = 5.0  # scheduled request 0 -> token 3
     prefill_logits[1, 6] = 5.0  # scheduled request 1 -> token 6
-    model_input = SimpleNamespace(perform_device_sampling=False, grammar_bitmask=[None])
+    model_input = SimpleNamespace(
+        perform_device_sampling=False,
+        grammar_bitmask=[None],
+        intermediate_prefill_mask=None,
+    )
 
     sampled, _ = batch.extract_output(
         runner,
@@ -188,6 +195,127 @@ def test_extract_output_host_prefill_scatters_logits_to_stable_rows():
     for gap in (0, 2, 3):
         assert torch.all(full[gap] == 0)  # unscheduled rows left empty
     assert sampled.tolist() == [[3], [6]]
+
+
+# --------------------------------------------------------------------------
+# Chunked prefill: intermediate chunks emit no token
+# --------------------------------------------------------------------------
+
+
+def test_extract_output_skips_all_intermediate_prefill_rows():
+    batch = _lane_batch()
+    runner = SimpleNamespace(
+        host_sampler=lambda *args, **kwargs: pytest.fail("sampler must not run")
+    )
+    model_input = SimpleNamespace(
+        perform_device_sampling=False,
+        grammar_bitmask=[None],
+        intermediate_prefill_mask=torch.tensor([True]),
+    )
+
+    sampled, logprobs = batch.extract_output(
+        runner,
+        torch.zeros((1, VOCAB)),
+        None,
+        model_input,
+        scheduled_rows=[0],
+        is_decode=False,
+    )
+
+    assert sampled.tolist() == [[0]]
+    assert logprobs is None
+
+
+def test_build_host_generators_preserves_intermediate_request_rng():
+    intermediate = torch.Generator().manual_seed(11)
+    final = torch.Generator().manual_seed(22)
+    intermediate_before = intermediate.get_state().clone()
+    final_before = final.get_state().clone()
+
+    class FakeInputBatch:
+        sampling = SimpleNamespace(generators={0: intermediate, 1: final})
+
+        def advance_generators(self, rows):
+            for row in rows:
+                torch.rand(1, generator=self.sampling.generators[row])
+
+    generators = TTModelRunner._build_host_generators(
+        FakeInputBatch(), [0, 1], torch.tensor([True, False])
+    )
+
+    assert generators[0] is not intermediate
+    assert torch.equal(generators[0].get_state(), intermediate_before)
+    assert generators[1] is final
+    assert torch.equal(intermediate.get_state(), intermediate_before)
+    assert not torch.equal(final.get_state(), final_before)
+
+
+def test_get_output_tokens_skips_all_intermediate_prefill_rows():
+    runner = SimpleNamespace(
+        host_sampler=lambda *args, **kwargs: pytest.fail("sampler must not run")
+    )
+    model_input = SimpleNamespace(intermediate_prefill_mask=torch.tensor([True]))
+
+    sampled, logprobs = TTModelRunner._get_output_tokens(
+        runner,
+        torch.zeros((1, 1, VOCAB)),
+        None,
+        SimpleNamespace(),
+        model_input,
+        [1],
+        False,
+        False,
+    )
+
+    assert sampled[0].tolist() == [[0]]
+    assert logprobs == [None]
+
+
+def test_finish_lane_sync_suppresses_intermediate_prefill_output():
+    # The chunk ends at position 3 but the request has 8 tokens, so the step
+    # contributes KV state only.
+    model_input = SimpleNamespace(prompt_lens=[3])
+
+    def extract_output(
+        runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
+    ):
+        assert is_decode is False
+        return torch.tensor([[42]], dtype=torch.int32), None
+
+    def unexpected_final_output(*args, **kwargs):
+        raise AssertionError("intermediate prefill must not emit a sampled token")
+
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=lambda model_input,
+        grammar_output,
+        *,
+        lane_total: model_input,
+        lane_batch=SimpleNamespace(
+            extract_output=extract_output,
+            req_ids={0: "request"},
+            num_tokens=[8],
+        ),
+        apply_and_build_runner_output=unexpected_final_output,
+    )
+
+    def build_chunked_prefill_output(**kwargs):
+        return TTModelRunner._build_chunked_prefill_output(runner, **kwargs)
+
+    runner._build_chunked_prefill_output = build_chunked_prefill_output
+
+    output = TTModelRunner._finish_lane_sync(
+        runner,
+        None,
+        tt_out=object(),
+        tt_log_probs=None,
+        model_input=model_input,
+        scheduled_rows=[0],
+        is_decode=False,
+        lane_total=1,
+    )
+
+    assert output.req_ids == ["request"]
+    assert output.sampled_token_ids == [[]]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -32,10 +32,19 @@ class FakeLane:
     fallback.
     """
 
-    def __init__(self, waiting=0, running=0, skipped_waiting=0, pending_finished=()):
+    def __init__(
+        self,
+        waiting=0,
+        running=0,
+        skipped_waiting=0,
+        partial_prefills=0,
+        pending_finished=(),
+    ):
         self.waiting = [object()] * waiting
         self.skipped_waiting = [object()] * skipped_waiting
-        self.running = [object()] * running
+        self.running = [
+            SimpleNamespace(is_prefill_chunk=False) for _ in range(running)
+        ] + [SimpleNamespace(is_prefill_chunk=True) for _ in range(partial_prefills)]
         self._pending_finished = set(pending_finished)
         self._mode = TTSchedulingMode.DEFAULT
         self.scheduled_modes: list[TTSchedulingMode] = []
@@ -51,9 +60,10 @@ class FakeLane:
         self._pending_finished = set()
         out = SchedulerOutput.make_empty()
         out.finished_req_ids = set(finished)
-        if self._mode == TTSchedulingMode.DECODE_ONLY and self.running:
-            out.num_scheduled_tokens = {f"dec-{id(self)}": len(self.running)}
-            out.total_num_scheduled_tokens = len(self.running)
+        pure_decodes = [r for r in self.running if not r.is_prefill_chunk]
+        if self._mode == TTSchedulingMode.DECODE_ONLY and pure_decodes:
+            out.num_scheduled_tokens = {f"dec-{id(self)}": len(pure_decodes)}
+            out.total_num_scheduled_tokens = len(pure_decodes)
         return out
 
     def update_from_output(self, scheduler_output, model_runner_output):
@@ -100,6 +110,14 @@ def test_negotiate_prefill_when_lane_has_only_grammar_blocked_request():
     # held in skipped_waiting (waiting is empty). It must still force prefill so
     # the base scheduler can revisit and promote it after the grammar is ready.
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(skipped_waiting=1)])
+    assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
+
+
+def test_negotiate_prefill_for_running_continuation_at_lane_capacity():
+    # The lane's only work is a partial prefill occupying its one slot: nothing
+    # waiting and no spare capacity, yet only a prefill step can advance it.
+    coordinator = _make_coordinator([FakeLane(partial_prefills=1)], per_lane_max=1)
+
     assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
 
 
@@ -154,6 +172,19 @@ def test_no_fallback_when_no_running_requests():
     assert get_tt_step_plan(output).is_decode is False
     # Only the prefill pass ran (no decode fallback).
     assert lane0.scheduled_modes == [TTSchedulingMode.PREFILL_ONLY]
+
+
+def test_no_decode_fallback_when_only_continuations_are_running():
+    # The only running request is a partial prefill. A decode step cannot
+    # advance it, so falling back to decode would just burn a step.
+    lane = FakeLane(partial_prefills=1)
+    coordinator = _make_coordinator([lane])
+
+    output = coordinator.schedule()
+
+    assert output.total_num_scheduled_tokens == 0
+    assert get_tt_step_plan(output).is_decode is False
+    assert lane.scheduled_modes == [TTSchedulingMode.PREFILL_ONLY]
 
 
 def test_update_from_output_routes_and_merges_per_lane():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -167,3 +167,25 @@ def test_preempt_leaves_outputs_alone_without_async_scheduling(monkeypatch):
 
     assert request.async_tokens_to_discard == 0
     assert request.num_output_placeholders == 2
+
+
+def test_reset_prefix_cache_keeps_tt_preempt_discard_count(monkeypatch):
+    scheduler = TTScheduler.__new__(TTScheduler)
+    scheduler.scheduler_config = SimpleNamespace(async_scheduling=True)
+    scheduler.running = [
+        SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0),
+        SimpleNamespace(num_output_placeholders=1, async_tokens_to_discard=0),
+    ]
+    scheduler.prev_step_scheduled_req_ids = {"req-1"}
+    scheduler.kv_cache_manager = SimpleNamespace(reset_prefix_cache=lambda: True)
+    scheduler.reset_connector_cache = lambda: True
+
+    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
+
+    requests = list(scheduler.running)
+    assert scheduler.reset_prefix_cache(reset_running_requests=True) is True
+
+    assert scheduler.running == []
+    assert scheduler.prev_step_scheduled_req_ids == set()
+    assert [request.async_tokens_to_discard for request in requests] == [2, 1]
+    assert [request.num_output_placeholders for request in requests] == [0, 0]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
-from vllm.v1.core.sched.scheduler import Scheduler
 
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
@@ -139,53 +138,3 @@ def test_decode_only_hides_continuations_and_restores_them(monkeypatch):
 
     assert seen["running"] == [decode]
     assert scheduler.running == [decode, continuation]
-
-
-def test_preempt_marks_in_flight_async_outputs_stale(monkeypatch):
-    scheduler = TTScheduler.__new__(TTScheduler)
-    scheduler.scheduler_config = SimpleNamespace(async_scheduling=True)
-    request = SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0)
-
-    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
-
-    scheduler._preempt_request(request, 0.0)
-
-    # The two tokens already in flight were computed against the freed KV
-    # blocks, so the base class must drop them when they come back.
-    assert request.async_tokens_to_discard == 2
-    assert request.num_output_placeholders == 0
-
-
-def test_preempt_leaves_outputs_alone_without_async_scheduling(monkeypatch):
-    scheduler = TTScheduler.__new__(TTScheduler)
-    scheduler.scheduler_config = SimpleNamespace(async_scheduling=False)
-    request = SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0)
-
-    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
-
-    scheduler._preempt_request(request, 0.0)
-
-    assert request.async_tokens_to_discard == 0
-    assert request.num_output_placeholders == 2
-
-
-def test_reset_prefix_cache_keeps_tt_preempt_discard_count(monkeypatch):
-    scheduler = TTScheduler.__new__(TTScheduler)
-    scheduler.scheduler_config = SimpleNamespace(async_scheduling=True)
-    scheduler.running = [
-        SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0),
-        SimpleNamespace(num_output_placeholders=1, async_tokens_to_discard=0),
-    ]
-    scheduler.prev_step_scheduled_req_ids = {"req-1"}
-    scheduler.kv_cache_manager = SimpleNamespace(reset_prefix_cache=lambda: True)
-    scheduler.reset_connector_cache = lambda: True
-
-    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
-
-    requests = list(scheduler.running)
-    assert scheduler.reset_prefix_cache(reset_running_requests=True) is True
-
-    assert scheduler.running == []
-    assert scheduler.prev_step_scheduled_req_ids == set()
-    assert [request.async_tokens_to_discard for request in requests] == [2, 1]
-    assert [request.num_output_placeholders for request in requests] == [0, 0]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -116,7 +116,8 @@ def test_prefill_only_hides_decodes_but_keeps_continuations(monkeypatch):
     assert seen["running"] == [continuation]
     # One slot is held by the hidden decode, so the waiting loop sees 8 - 1.
     assert seen["max_num_running_reqs"] == 7
-    assert set(scheduler.running) == {decode, continuation}
+    # Restored: the hidden decodes are appended back after the base pass.
+    assert scheduler.running == [continuation, decode]
     assert scheduler.max_num_running_reqs == 8
 
 
@@ -137,7 +138,7 @@ def test_decode_only_hides_continuations_and_restores_them(monkeypatch):
     scheduler.schedule()
 
     assert seen["running"] == [decode]
-    assert set(scheduler.running) == {decode, continuation}
+    assert scheduler.running == [decode, continuation]
 
 
 def test_preempt_marks_in_flight_async_outputs_stale(monkeypatch):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.core.sched.scheduler import Scheduler
 
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
@@ -137,3 +138,31 @@ def test_decode_only_hides_continuations_and_restores_them(monkeypatch):
 
     assert seen["running"] == [decode]
     assert set(scheduler.running) == {decode, continuation}
+
+
+def test_preempt_marks_in_flight_async_outputs_stale(monkeypatch):
+    scheduler = TTScheduler.__new__(TTScheduler)
+    scheduler.scheduler_config = SimpleNamespace(async_scheduling=True)
+    request = SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0)
+
+    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
+
+    scheduler._preempt_request(request, 0.0)
+
+    # The two tokens already in flight were computed against the freed KV
+    # blocks, so the base class must drop them when they come back.
+    assert request.async_tokens_to_discard == 2
+    assert request.num_output_placeholders == 0
+
+
+def test_preempt_leaves_outputs_alone_without_async_scheduling(monkeypatch):
+    scheduler = TTScheduler.__new__(TTScheduler)
+    scheduler.scheduler_config = SimpleNamespace(async_scheduling=False)
+    request = SimpleNamespace(num_output_placeholders=2, async_tokens_to_discard=0)
+
+    monkeypatch.setattr(Scheduler, "_preempt_request", lambda *args: None)
+
+    scheduler._preempt_request(request, 0.0)
+
+    assert request.async_tokens_to_discard == 0
+    assert request.num_output_placeholders == 2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
+from types import SimpleNamespace
+
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
@@ -8,14 +10,30 @@ from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_qu
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
 
-def test_forced_prefill_does_not_fallback_to_decode_per_lane(monkeypatch):
+def _running(is_prefill_chunk=False):
+    """A stand-in for a running request, seen only through the fields TT reads."""
+    return SimpleNamespace(is_prefill_chunk=is_prefill_chunk)
+
+
+def _scheduler(*, running=(), waiting=0, skipped_waiting=0, mode):
     scheduler = TTScheduler.__new__(TTScheduler)
     scheduler.policy = SchedulingPolicy.FCFS
     scheduler.waiting = create_request_queue(scheduler.policy)
-    scheduler.waiting.add_request(object())
+    for _ in range(waiting):
+        scheduler.waiting.add_request(object())
     scheduler.skipped_waiting = create_request_queue(scheduler.policy)
-    scheduler.running = [object()]
-    scheduler._forced_mode = TTSchedulingMode.PREFILL_ONLY
+    for _ in range(skipped_waiting):
+        scheduler.skipped_waiting.add_request(object())
+    scheduler.running = list(running)
+    scheduler.max_num_running_reqs = 8
+    scheduler._forced_mode = mode
+    return scheduler
+
+
+def test_forced_prefill_does_not_fallback_to_decode_per_lane(monkeypatch):
+    scheduler = _scheduler(
+        running=[_running()], waiting=1, mode=TTSchedulingMode.PREFILL_ONLY
+    )
 
     monkeypatch.setattr(scheduler, "_schedule_prefill_only", SchedulerOutput.make_empty)
 
@@ -30,13 +48,9 @@ def test_forced_prefill_does_not_fallback_to_decode_per_lane(monkeypatch):
 
 
 def test_forced_decode_hides_and_restores_skipped_waiting(monkeypatch):
-    scheduler = TTScheduler.__new__(TTScheduler)
-    scheduler.policy = SchedulingPolicy.FCFS
-    scheduler.waiting = create_request_queue(scheduler.policy)
-    scheduler.skipped_waiting = create_request_queue(scheduler.policy)
-    scheduler.skipped_waiting.add_request(object())
-    scheduler.running = [object()]
-    scheduler._forced_mode = TTSchedulingMode.DECODE_ONLY
+    scheduler = _scheduler(
+        running=[_running()], skipped_waiting=1, mode=TTSchedulingMode.DECODE_ONLY
+    )
 
     saved_waiting = scheduler.waiting
     saved_skipped_waiting = scheduler.skipped_waiting
@@ -55,3 +69,71 @@ def test_forced_decode_hides_and_restores_skipped_waiting(monkeypatch):
     assert scheduler.waiting is saved_waiting
     assert scheduler.skipped_waiting is saved_skipped_waiting
     assert scheduler.skipped_waiting.peek_request() is skipped_request
+
+
+def test_running_continuation_alone_still_schedules_prefill(monkeypatch):
+    # Nothing waiting; the only work is a partial prefill in `running`. Only a
+    # prefill step can advance it, so DEFAULT mode must not pick decode.
+    scheduler = _scheduler(
+        running=[_running(is_prefill_chunk=True)], mode=TTSchedulingMode.DEFAULT
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        scheduler,
+        "_schedule_prefill_only",
+        lambda: calls.append("prefill") or SchedulerOutput.make_empty(),
+    )
+
+    def fail_decode_fallback():
+        raise AssertionError("a decode step cannot advance a partial prefill")
+
+    monkeypatch.setattr(scheduler, "_schedule_decode_only", fail_decode_fallback)
+
+    scheduler.schedule()
+
+    assert calls == ["prefill"]
+
+
+def test_prefill_only_hides_decodes_but_keeps_continuations(monkeypatch):
+    continuation = _running(is_prefill_chunk=True)
+    decode = _running()
+    scheduler = _scheduler(
+        running=[decode, continuation], waiting=1, mode=TTSchedulingMode.PREFILL_ONLY
+    )
+    seen = {}
+
+    def fake_base_schedule(self, throttle_prefills=False):
+        seen["running"] = list(self.running)
+        seen["max_num_running_reqs"] = self.max_num_running_reqs
+        return SchedulerOutput.make_empty()
+
+    monkeypatch.setattr(AsyncScheduler, "schedule", fake_base_schedule)
+
+    scheduler.schedule()
+
+    assert seen["running"] == [continuation]
+    # One slot is held by the hidden decode, so the waiting loop sees 8 - 1.
+    assert seen["max_num_running_reqs"] == 7
+    assert set(scheduler.running) == {decode, continuation}
+    assert scheduler.max_num_running_reqs == 8
+
+
+def test_decode_only_hides_continuations_and_restores_them(monkeypatch):
+    continuation = _running(is_prefill_chunk=True)
+    decode = _running()
+    scheduler = _scheduler(
+        running=[decode, continuation], mode=TTSchedulingMode.DECODE_ONLY
+    )
+    seen = {}
+
+    def fake_base_schedule(self, throttle_prefills=False):
+        seen["running"] = list(self.running)
+        return SchedulerOutput.make_empty()
+
+    monkeypatch.setattr(AsyncScheduler, "schedule", fake_base_schedule)
+
+    scheduler.schedule()
+
+    assert seen["running"] == [decode]
+    assert set(scheduler.running) == {decode, continuation}


### PR DESCRIPTION
## Purpose

Port [tenstorrent/vllm#448](https://github.com/tenstorrent/vllm/pull/448) to the standalone plugin. Enables token-chunked prefill for Gemma 4, so a long prompt is split across prefill steps instead of requiring `max_num_batched_tokens >= max_model_len`.

Not a 1:1 apply: gathered DP is gone from this repo, and upstream vLLM `0.24.0` already provides a mechanism the original PR had to build itself. See **Deviations** below.

## Modifications

**Config policy (`platform.py`)**
- `_apply_chunked_prefill_policy` replaces the unconditional force-disable. `gemma4` / `gemma4_unified` keep chunked prefill and their requested token budget; every other model type gets it turned off with the existing `max_num_batched_tokens` bump to `max_model_len`.
- Zero `long_prefill_token_threshold` for those other model types. The base scheduler applies that cap *before* it consults `enable_chunked_prefill`, so leaving it set still splits a prefill for a model whose generator cannot resume one.
- Set `disable_chunked_mm_input = True` so a chunk boundary never lands inside a multimodal item.

**Scheduling (`scheduler.py`, `lane_scheduler.py`)**
- A running `is_prefill_chunk` request is prefill work: `_has_pending_prefill` counts it, `_schedule_prefill_only` keeps it visible (hiding only pure decodes, and shrinking `max_num_running_reqs` by the hidden count), `_schedule_decode_only` hides it.
- Decode fallbacks now test for *running decodes*, not just a non-empty `running`. A partial prefill cannot be advanced by a decode step, so counting it would burn a step or livelock. Same fix in `TTLaneCoordinator.schedule` and `_local_prefill_intent`, where a continuation forces prefill intent even at lane capacity.

**Execution (`model_runner.py`, `input_batch.py`, `model_input.py`)**
- `is_prompt` detection recognises continuations (cached, not resumed, `num_computed < num_prompt_tokens`), and the mixed-batch decode filter no longer treats them as strays.
- `prompt_lens` is the *end position of the scheduled chunk* (`num_computed + num_scheduled`), not the sequence length, so the generator's `tokens[start_pos:prompt_lens]` slice processes exactly this chunk. Unchunked prefill, APC hits, and preemption replays are unchanged by this.
- New `TTModelInput.intermediate_prefill_mask` marks rows whose chunk does not finish the prompt. Those rows force host sampling (device sampling would advance device RNG state for them), get a generator clone via `_build_host_generators` / `build_merged_sampling_metadata(non_sampling_rows=...)` so a seeded request's stream does not drift, and report `[]` instead of a token via `_build_chunked_prefill_output`.
- Dropped the `assert enable_chunked_prefill is False` guard in the runner init.

**Docs**: `README.md` and `docs/SCHEDULING.md` updated; both previously stated chunked prefill was unsupported.

## Deviations from tenstorrent/vllm#448

1. **Gathered DP dropped.** `engine.py`'s `DPGatherHandle` / `dp_gather_*` and the `worker.py` / `model_runner.py` gather hooks are unreachable in this repo (`platform.py` points `dp_engine_core_proc_cls` at upstream's `DPEngineCoreProc`; nothing imports `vllm_tt_plugin.engine`). The PR's changes to those paths, and its `tests/test_dp_engine.py`, are not ported. Standard multi-process DP runs independent per-rank engines, so each rank handles its own chunking through the non-DP path.
2. **Preemption fix dropped entirely.** #448 carried a `_PendingOutputs` class that discarded a preempted request's in-flight async decode tokens. Not ported: on vLLM `0.24.0` those tokens are valid at preempt time (the forward completed before any block was freed, device submits form a strict queue, and every async op is forced to complete before the next prefill), the base class appends them and the resumed prefill replays them, so discarding them truncates the response by one token per preemption. `Request.async_tokens_to_discard` is written in exactly one place in `0.24.0`, inside `reset_prefix_cache`, and is not a general stale-output mechanism. The invariant is recorded in the `TTScheduler` docstring.
3. **Merged with this repo's local scheduler work.** `_has_pending_prefill` already existed here for `skipped_waiting` (grammar-blocked prefills); the two conditions are combined rather than one replacing the other.

## Test Plan

1. `pre-commit run --all-files`.
2. Plugin unit tests on a TT env (wh-17, vLLM 0.24.0), against an `origin/main` baseline.
3. Gemma 4 with chunked prefill on device.
4. A non-Gemma model, to confirm the disable path is unaffected.

## Test Result

- [x] `pre-commit run --all-files` passes.
- [x] Unit tests pass on wh-17. Run per-file, because the suite has a pre-existing cross-file pollution bug (something flips `vllm.utils.torch_utils.PIN_MEMORY`, after which every `build_logitsprocs` call dies with `pin_memory=True requires a CUDA or other accelerator backend`). That reproduces on `main` and is out of scope here.

  | | `origin/main` | this branch |
  |---|---|---|
  | passed | 71 | 98 |
  | failed | 1 | 1 |
  | collection errors | 1 | 1 |

  Both remaining failures are pre-existing on `main` and untouched by this PR:
  - `tests/test_dp_modes.py` fails to collect: `launcher.py` imports `CoreEngineLauncher` / `EngineLaunchPlan` from `vllm.v1.engine.utils`, and neither exists in vLLM `0.24.0` (verified against the upstream tag).
  - `tests/test_gemma4_tool_parser.py::test_streaming_assembles_name_and_args`: `DeltaFunctionCall` is a pydantic model in `0.24.0`, so the test's `fn.get("name")` raises.

  New coverage (+27): `tests/test_chunked_prefill_policy.py` (6), chunk-awareness and preempt-discard in `tests/test_scheduler.py` (+5), continuation handling in `tests/test_lane_scheduler.py` (+2), chunk-boundary `prompt_lens` and generator cloning in `tests/test_lane_input_batch.py` (+2), intermediate-row suppression in `tests/test_lane_model_runner.py` (+4).

- [x] CI **vLLM Model Tests**  https://github.com/tenstorrent/tt-metal/actions/runs/31705112002