### PR TITLE
fix: free a preempted request's lane-DP row on both sides

### DIFF
--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -844,16 +844,15 @@ class TTLaneInputBatch(InputBatch):
     ) -> bool:
         """Apply one lane step plan to this batch and the runner's request map.
 
-        This is the lane-DP variant of ``TTModelRunner._update_states``, which
-        frees the row of *every* request the step left unscheduled and re-places
-        it on a later step (harmless there: the front-packed layout is rebuilt
-        each step anyway, and the request's cached state is kept). Here a row is
-        the request's stable device slot, so it is held for the request's whole
-        lifetime and only released when its contents stop being authoritative:
-        on finish, and on preemption (KV freed, so the resume re-prefills from
-        zero), whether the preemption is reported this step or surfaces later as
-        a resume. A running decode left out of a prefill step keeps its row.
-        There is no condense.
+        The lane-DP counterpart of ``TTModelRunner._update_states``. Here a row
+        is the request's device state slot, so the request holds it for its
+        whole lifetime: being left out of a step -- as every running decode is
+        on a prefill step -- changes nothing, and ``condense`` is a no-op. A row
+        comes back only when its contents stop being authoritative: on finish,
+        and on preemption, which freed the KV and reset ``num_computed_tokens``
+        so the resume re-prefills from zero into whatever row it is given then.
+        A preempted request's ``CachedRequestState`` stays in ``requests`` for
+        that resume.
 
         ``requests`` (the runner's canonical ``req_id -> CachedRequestState``
         map) and ``encoder_cache`` are mutated in place. Placement rows come
@@ -870,14 +869,12 @@ class TTLaneInputBatch(InputBatch):
             if self.remove_request(req_id) is not None:
                 layout_changed = True
 
-        # Preempted requests release their slot too, in lockstep with the
-        # coordinator freeing the same row (``TTLaneCoordinator._build_step_plan``):
-        # the row is up for grabs by the next prefill, so leaving the preempted
-        # occupant here would let ``add_request_to_row`` stack a newcomer on a live
-        # row. Its ``CachedRequestState`` stays in ``requests`` -- the resume is a
-        # re-prefill of the same request, which re-adds it at whatever row the
-        # coordinator hands out then. ``preempted_req_ids`` is typed optional,
-        # hence the ``or ()``.
+        # Preempted requests release their row, in the same step as the
+        # coordinator returns it to the lane's free list
+        # (``TTLaneCoordinator._build_step_plan``). Both must give it up
+        # together, or the next ``add_request_to_row`` places a newcomer on top
+        # of the occupant still sitting here. ``preempted_req_ids`` is typed
+        # optional, hence the ``or ()``.
         for req_id in scheduler_output.preempted_req_ids or ():
             if self.remove_request(req_id) is not None:
                 layout_changed = True
@@ -903,10 +900,11 @@ class TTLaneInputBatch(InputBatch):
                 req_state, num_computed_tokens, new_block_ids, resumed_from_preemption
             )
             if resumed_from_preemption:
-                # KV was freed and is being rebuilt; re-add fresh (drop the
-                # stale slot first). The slot may differ afterwards --
-                # acceptable under the exceptional preemption path, which
-                # re-prefills the request anyway.
+                # A resume re-places the request wherever the coordinator's free
+                # list sent it, which is rarely the row it left. That row went
+                # back when the preemption was reported, so this removal only
+                # covers a resume whose preemption never was, keeping the
+                # request off two rows at once.
                 if self.remove_request(req_id) is not None:
                     layout_changed = True
                 req_ids_to_add.append(req_id)

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -844,14 +844,16 @@ class TTLaneInputBatch(InputBatch):
     ) -> bool:
         """Apply one lane step plan to this batch and the runner's request map.
 
-        This is the lane-DP variant of ``TTModelRunner._update_states``. Unlike
-        the front-packed batch it does **not** evict merely-unscheduled
-        requests: a prefill step can leave running decodes unscheduled, and
-        freeing their stable device slot would disturb the on-device per-slot
-        seed RNG. Only requests whose slot content is no longer authoritative
-        release it: finished ones, and preempted ones (KV freed, so the resume
-        re-prefills from zero), whether the preemption is reported this step or
-        surfaces later as a resume. There is no condense.
+        This is the lane-DP variant of ``TTModelRunner._update_states``, which
+        frees the row of *every* request the step left unscheduled and re-places
+        it on a later step (harmless there: the front-packed layout is rebuilt
+        each step anyway, and the request's cached state is kept). Here a row is
+        the request's stable device slot, so it is held for the request's whole
+        lifetime and only released when its contents stop being authoritative:
+        on finish, and on preemption (KV freed, so the resume re-prefills from
+        zero), whether the preemption is reported this step or surfaces later as
+        a resume. A running decode left out of a prefill step keeps its row.
+        There is no condense.
 
         ``requests`` (the runner's canonical ``req_id -> CachedRequestState``
         map) and ``encoder_cache`` are mutated in place. Placement rows come

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -848,8 +848,10 @@ class TTLaneInputBatch(InputBatch):
         the front-packed batch it does **not** evict merely-unscheduled
         requests: a prefill step can leave running decodes unscheduled, and
         freeing their stable device slot would disturb the on-device per-slot
-        seed RNG. Only finished requests, and requests resumed from preemption
-        (whose KV was rebuilt), release their slot. There is no condense.
+        seed RNG. Only requests whose slot content is no longer authoritative
+        release it: finished ones, and preempted ones (KV freed, so the resume
+        re-prefills from zero), whether the preemption is reported this step or
+        surfaces later as a resume. There is no condense.
 
         ``requests`` (the runner's canonical ``req_id -> CachedRequestState``
         map) and ``encoder_cache`` are mutated in place. Placement rows come
@@ -863,6 +865,18 @@ class TTLaneInputBatch(InputBatch):
         # Finished requests release their slot.
         for req_id in scheduler_output.finished_req_ids:
             requests.pop(req_id, None)
+            if self.remove_request(req_id) is not None:
+                layout_changed = True
+
+        # Preempted requests release their slot too, in lockstep with the
+        # coordinator freeing the same row (``TTLaneCoordinator._build_step_plan``):
+        # the row is up for grabs by the next prefill, so leaving the preempted
+        # occupant here would let ``add_request_to_row`` stack a newcomer on a live
+        # row. Its ``CachedRequestState`` stays in ``requests`` -- the resume is a
+        # re-prefill of the same request, which re-adds it at whatever row the
+        # coordinator hands out then. ``preempted_req_ids`` is typed optional,
+        # hence the ``or ()``.
+        for req_id in scheduler_output.preempted_req_ids or ():
             if self.remove_request(req_id) is not None:
                 layout_changed = True
 

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -537,13 +537,14 @@ class TTLaneCoordinator(SchedulerInterface):
             )
         ):
             # The discarded prefill pass already drained each lane's
-            # finished/freed-encoder bookkeeping; carry it onto the decode pass
-            # so the runner still releases that state. There is no preemption to
-            # carry: a lane's prefill-only pass hides ``running``, so the base
-            # scheduler's running loop -- the only place that preempts -- never
-            # iterates.
+            # finished/freed-encoder bookkeeping and may have preempted a
+            # partial prefill (which a prefill pass keeps in ``running``, and
+            # ``_preempt_request`` frees the KV of before this pass is thrown
+            # away); carry all of it onto the decode pass so the runner still
+            # releases that state and the preempted row.
             carried_finished = merged.finished_req_ids
             carried_free_encoder = merged.free_encoder_mm_hashes
+            carried_preempted = merged.preempted_req_ids
             forced_mode = TTSchedulingMode.DECODE_ONLY
             lane_outputs = self._schedule_all_lanes(forced_mode)
             merged = merge_lane_scheduler_outputs(lane_outputs)
@@ -551,6 +552,10 @@ class TTLaneCoordinator(SchedulerInterface):
             merged.free_encoder_mm_hashes = (
                 carried_free_encoder + merged.free_encoder_mm_hashes
             )
+            if carried_preempted:
+                merged.preempted_req_ids = (
+                    merged.preempted_req_ids or set()
+                ) | carried_preempted
 
         is_decode = forced_mode == TTSchedulingMode.DECODE_ONLY
         plan = self._build_step_plan(lane_outputs, merged, is_decode)

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -461,17 +461,16 @@ class TTLaneCoordinator(SchedulerInterface):
             self._release_slot(req_id)
             self._req_to_lane.pop(req_id, None)
 
-        # A preempted request loses its row immediately, because it loses its
-        # running slot immediately: ``Scheduler._preempt_request`` pops it from
-        # ``running``, so its lane may admit a replacement on the next prefill
-        # step while the row is still claimed, and ``_assign_slot`` would then
-        # find no free slot and kill the engine core. Holding the row buys
-        # nothing: the preempted request's KV is freed and ``num_computed_tokens``
-        # reset, so the resume re-prefills and rewrites whatever row it lands on.
-        # The lane binding stays -- the request resumes in the lane whose KV
-        # manager and queues still hold it. ``TTLaneInputBatch.apply_step_plan``
-        # drops the same request from that row in this same step, so the row is
-        # free on both sides before anything can be placed there.
+        # A preempted request gives its row back at once, because its running
+        # slot is already back: ``Scheduler._preempt_request`` pops it from
+        # ``running``, so the lane admits a replacement on the next prefill step
+        # and ``_assign_slot`` finds no free row, killing the engine core.
+        # Holding the row buys nothing, its KV having been freed and
+        # ``num_computed_tokens`` reset, so the resume re-prefills and rewrites
+        # whatever row it lands on. The lane binding stays: the request resumes
+        # in the lane whose KV cache manager and queues still hold it.
+        # ``TTLaneInputBatch.apply_step_plan`` releases the same row in this same
+        # step, so the row is free on both sides before anything is placed there.
         # ``preempted_req_ids`` is typed optional, hence the ``or ()``.
         for req_id in merged.preempted_req_ids or ():
             self._release_slot(req_id)

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -470,7 +470,7 @@ class TTLaneCoordinator(SchedulerInterface):
         # reset, so the resume re-prefills and rewrites whatever row it lands on.
         # The lane binding stays -- the request resumes in the lane whose KV
         # manager and queues still hold it. ``TTLaneInputBatch.apply_step_plan``
-        # evicts the same request from the batch in this same step, so the row is
+        # drops the same request from that row in this same step, so the row is
         # free on both sides before anything can be placed there.
         # ``preempted_req_ids`` is typed optional, hence the ``or ()``.
         for req_id in merged.preempted_req_ids or ():

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -461,6 +461,21 @@ class TTLaneCoordinator(SchedulerInterface):
             self._release_slot(req_id)
             self._req_to_lane.pop(req_id, None)
 
+        # A preempted request loses its row immediately, because it loses its
+        # running slot immediately: ``Scheduler._preempt_request`` pops it from
+        # ``running``, so its lane may admit a replacement on the next prefill
+        # step while the row is still claimed, and ``_assign_slot`` would then
+        # find no free slot and kill the engine core. Holding the row buys
+        # nothing: the preempted request's KV is freed and ``num_computed_tokens``
+        # reset, so the resume re-prefills and rewrites whatever row it lands on.
+        # The lane binding stays -- the request resumes in the lane whose KV
+        # manager and queues still hold it. ``TTLaneInputBatch.apply_step_plan``
+        # evicts the same request from the batch in this same step, so the row is
+        # free on both sides before anything can be placed there.
+        # ``preempted_req_ids`` is typed optional, hence the ``or ()``.
+        for req_id in merged.preempted_req_ids or ():
+            self._release_slot(req_id)
+
         resumed_req_ids = set(merged.scheduled_cached_reqs.resumed_req_ids)
         for req_id in resumed_req_ids:
             self._release_slot(req_id)
@@ -524,7 +539,10 @@ class TTLaneCoordinator(SchedulerInterface):
         ):
             # The discarded prefill pass already drained each lane's
             # finished/freed-encoder bookkeeping; carry it onto the decode pass
-            # so the runner still releases that state.
+            # so the runner still releases that state. There is no preemption to
+            # carry: a lane's prefill-only pass hides ``running``, so the base
+            # scheduler's running loop -- the only place that preempts -- never
+            # iterates.
             carried_finished = merged.finished_req_ids
             carried_free_encoder = merged.free_encoder_mm_hashes
             forced_mode = TTSchedulingMode.DECODE_ONLY

--- a/tests/test_lane_input_batch.py
+++ b/tests/test_lane_input_batch.py
@@ -168,13 +168,36 @@ def _new_req(req_id, prompt):
     )
 
 
-def _step_output(new_reqs=(), finished=(), plan_rows=None):
+def _step_output(new_reqs=(), finished=(), plan_rows=None, preempted=None, cached=None):
     from vllm.v1.core.sched.output import SchedulerOutput
 
     out = SchedulerOutput.make_empty()
     out.scheduled_new_reqs = list(new_reqs)
     out.finished_req_ids = set(finished)
+    out.preempted_req_ids = None if preempted is None else set(preempted)
+    if cached is not None:
+        out.scheduled_cached_reqs = cached
     return out
+
+
+def _plan(req_id_to_row, *, is_decode=False, capacity=4, num_lanes=1):
+    from vllm_tt_plugin.lane_scheduler import TTStepPlan
+
+    rows = tuple(sorted(req_id_to_row.values()))
+    per_lane = capacity // num_lanes
+    per_lane_counts = [0] * num_lanes
+    for row in rows:
+        per_lane_counts[row // per_lane] += 1
+    return TTStepPlan(
+        is_decode=is_decode,
+        capacity=capacity,
+        scheduled_req_ids=tuple(sorted(req_id_to_row, key=req_id_to_row.get)),
+        scheduled_rows=rows,
+        input_rows=tuple(range(capacity)) if is_decode else rows,
+        req_id_to_row=dict(req_id_to_row),
+        batch_size_per_dp=tuple(per_lane_counts),
+        prefill_empty_slots=None if is_decode else rows,
+    )
 
 
 def test_apply_step_plan_places_new_requests_and_reports_layout_change():
@@ -284,6 +307,64 @@ def test_lane_prefill_input_ends_at_scheduled_chunk_boundary():
     assert model_input.intermediate_prefill_mask.tolist() == [True]
     # An intermediate chunk must not advance device RNG state.
     assert model_input.perform_device_sampling is False
+
+
+def test_apply_step_plan_preempted_request_frees_its_row_and_keeps_its_state():
+    from vllm.v1.core.sched.output import CachedRequestData
+
+    b = _lane_batch(num_lanes=1, per_lane=2)
+    requests: dict = {}
+    b.apply_step_plan(
+        _step_output(new_reqs=[_new_req("a", [1]), _new_req("b", [2])]),
+        _plan({"a": 0, "b": 1}, capacity=2),
+        requests,
+        {},
+    )
+    assert b.occupied_rows() == [0, 1]
+
+    # "a" is preempted: the coordinator hands its row back, so the batch must
+    # give the row up in the same step or the next placement would land on a
+    # live occupant. The request state survives -- the resume needs it.
+    changed = b.apply_step_plan(
+        _step_output(preempted=["a"]),
+        _plan({"b": 1}, is_decode=True, capacity=2),
+        requests,
+        {},
+    )
+
+    assert changed is True
+    assert "a" in requests
+    assert "a" not in b.req_id_to_index
+    assert b.occupied_rows() == [1]
+
+    # The freed row takes a newcomer without stacking it on the preempted one.
+    b.apply_step_plan(
+        _step_output(new_reqs=[_new_req("c", [3])]),
+        _plan({"c": 0}, capacity=2),
+        requests,
+        {},
+    )
+    assert b.req_id_to_index == {"c": 0, "b": 1}
+
+    # "c" finishes, and "a" resumes into the row it left: the resume re-prefills
+    # from the state kept above, so it never has to look the request up again.
+    resumed = CachedRequestData(
+        req_ids=["a"],
+        resumed_req_ids={"a"},
+        new_token_ids=[[]],
+        all_token_ids={"a": [1]},
+        new_block_ids=[([7],)],
+        num_computed_tokens=[0],
+        num_output_tokens=[0],
+    )
+    b.apply_step_plan(
+        _step_output(finished=["c"], cached=resumed),
+        _plan({"a": 0}, capacity=2),
+        requests,
+        {},
+    )
+    assert b.req_id_to_index == {"a": 0, "b": 1}
+    assert requests["a"].block_ids == ([7],)
 
 
 def test_lane_full_raises():

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -94,6 +94,12 @@ def _scheduled_output(req_ids):
     return out
 
 
+def _preempting_output(preempted, scheduled=()):
+    out = _scheduled_output(scheduled)
+    out.preempted_req_ids = set(preempted)
+    return out
+
+
 def test_negotiate_prefill_when_any_lane_wants_prefill():
     # Lane 1 has a queued request and nothing running -> wants prefill.
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(waiting=1)])
@@ -356,6 +362,57 @@ def test_prefill_step_plan_exposes_empty_slots_without_lane_metadata():
     assert plan.input_rows == (4,)
     assert plan.batch_size_per_dp == (0, 1)
     assert plan.prefill_empty_slots == (4,)
+
+
+def test_preempted_request_releases_its_row_to_its_lane():
+    # Lane 0 is full (capacity 2) with "a" and "b", then preempts "a" under KV
+    # pressure while decoding "b". The preempted request is neither finished nor
+    # resumed, so without an explicit release it would hold row 0 until it
+    # resumes -- yet its running slot is already back, so the lane can admit a
+    # replacement. Under --scheduling-policy priority a higher-priority arrival
+    # is admitted ahead of the preempted request and hits the empty free list.
+    lane0 = FakeLane(running=2)
+    coordinator = _make_coordinator([lane0, FakeLane()], per_lane_max=2)
+    coordinator._req_to_lane = {"a": 0, "b": 0}
+    assert coordinator._assign_slot("a", 0) == 0
+    assert coordinator._assign_slot("b", 0) == 1
+
+    lane0.schedule = lambda: _preempting_output(["a"], scheduled=["b"])
+    coordinator.schedule()
+
+    assert "a" not in coordinator._req_to_row
+    assert coordinator._free_slots_by_lane[0] == [0]
+    # The lane binding survives: the request resumes in the lane whose KV cache
+    # manager and queues still hold it.
+    assert coordinator._req_to_lane["a"] == 0
+
+    # The freed row is handed to the newcomer instead of raising "no free slot".
+    lane0.schedule = lambda: _scheduled_output(["c"])
+    coordinator._req_to_lane["c"] = 0
+    plan = get_tt_step_plan(coordinator.schedule())
+
+    assert plan.req_id_to_row["c"] == 0
+    assert "a" not in plan.req_id_to_row
+
+
+def test_preempted_and_finished_in_one_step_frees_the_row_once():
+    # A preempted request aborted in the same step is in both sets. The row must
+    # come back exactly once, or the lane's free list would hand it out twice.
+    lane0 = FakeLane(running=1)
+    coordinator = _make_coordinator([lane0, FakeLane()], per_lane_max=2)
+    coordinator._req_to_lane = {"a": 0}
+    coordinator._assign_slot("a", 0)
+
+    def _schedule():
+        out = _preempting_output(["a"])
+        out.finished_req_ids = {"a"}
+        return out
+
+    lane0.schedule = _schedule
+    coordinator.schedule()
+
+    assert coordinator._free_slots_by_lane[0] == [0, 1]
+    assert coordinator._req_to_lane == {}
 
 
 def test_per_lane_vllm_config_uses_per_lane_max_num_seqs():

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -193,6 +193,37 @@ def test_no_decode_fallback_when_only_continuations_are_running():
     assert lane.scheduled_modes == [TTSchedulingMode.PREFILL_ONLY]
 
 
+def test_preemption_in_a_discarded_prefill_pass_is_carried_to_the_decode_step():
+    # A prefill pass keeps partial prefills in ``running``, so its running loop
+    # can preempt one -- and that preemption stands even when the pass's
+    # schedule is thrown away for the decode fallback, because
+    # ``_preempt_request`` already freed the KV. Dropping the report would
+    # leave the row claimed by a request the lane has put back in its queue.
+    lane = FakeLane(running=1, partial_prefills=1)
+    coordinator = _make_coordinator([lane], per_lane_max=2)
+    coordinator._req_to_lane = {"p": 0}
+    coordinator._assign_slot("p", 0)
+    lane_schedule = lane.schedule
+
+    def _schedule():
+        out = lane_schedule()
+        if lane.scheduled_modes[-1] == TTSchedulingMode.PREFILL_ONLY:
+            out.preempted_req_ids = {"p"}
+        return out
+
+    lane.schedule = _schedule
+
+    output = coordinator.schedule()
+
+    assert lane.scheduled_modes == [
+        TTSchedulingMode.PREFILL_ONLY,
+        TTSchedulingMode.DECODE_ONLY,
+    ]
+    assert output.preempted_req_ids == {"p"}
+    assert "p" not in coordinator._req_to_row
+    assert "p" not in get_tt_step_plan(output).req_id_to_row
+
+
 def test_update_from_output_routes_and_merges_per_lane():
     lane0 = FakeLane()
     lane1 = FakeLane()


### PR DESCRIPTION
Fixes #38.

## The leak

`TTLaneCoordinator._build_step_plan` released a lane row on exactly two events: the request finished, or it resumed from preemption. A preempted request is neither, so it held its row from preemption until resume. Its *running* slot came back immediately (`Scheduler._preempt_request` pops it from `running`, and each lane caps its running set at `_per_lane_max`), so the lane could admit a replacement while the row was still claimed, and `_assign_slot` raised `lane N has no free slot` out of `schedule()`, killing the engine core. Same reachability as #35: benign under FCFS, hit under `--scheduling-policy priority`, where `prepend_request` is a `heappush` and a higher-priority arrival routed to the same lane is admitted ahead of the preempted request.

## The fix

In lane DP the row is both the device state slot and the persistent batch row, so releasing it in the scheduler alone would let the next `add_request_to_row` stack a newcomer on a live occupant. Both owners release in the same step:

- `TTLaneCoordinator._build_step_plan` returns the row to the lane's free list for every `preempted_req_ids` entry. The lane binding stays: the request resumes in the lane whose KV cache manager and queues still hold it.
- `TTLaneInputBatch.apply_step_plan` evicts the same request from the batch, leaving a neutral gap row. Its `CachedRequestState` stays in the runner's `requests` map, because the resume is a re-prefill of that same request and re-adds it at whatever row the coordinator hands out then.

Nothing reads the vacated slot: preemption freed the KV and reset `num_computed_tokens`, so the resume re-prefills the prompt plus every generated token and rewrites the row itself.

The decode-fallback path in `schedule()` carries the preemption too. Since #34, a prefill pass keeps partial prefills in `running`, so its running loop can preempt one; `_preempt_request` has already freed that KV by the time the coordinator discards the pass and re-schedules decode-only, and rebuilding the merged output would drop the report and leak the row.

## Tests

- `test_lane_scheduler.py`: a preempted request's row goes back to its lane's free list and is handed to the next arrival (raises `no free slot` without the fix); the lane binding survives; a request both preempted and finished in one step frees its row exactly once.
- `test_lane_scheduler.py`: a preemption reported by a discarded prefill pass survives the decode fallback.
- `test_lane_input_batch.py`: preemption frees the row and keeps the request state, a newcomer takes the freed row (raises `row 0 is already occupied` without the fix), and the later resume re-places the request from the state that was kept.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/31783242052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

