### PR TITLE
[fix] Reject '--device-ids' for standard TT DP; preserve discovered groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ The execution model matches TT hardware characteristics:
 - For other models, `--data_parallel_size N` uses standard multi-process DP:
   each DP rank runs an independent engine core with its own TT submesh,
   scheduler, and KV cache. Device groups are discovered at startup and assigned
-  via `TT_VISIBLE_DEVICES`. Do not pass `--device-ids`: its flat GPU-style
-  syntax cannot represent TT multi-chip groups and is rejected for standard
-  TT DP. This is upstream vLLM's standard DP mechanism (no gather/scatter;
-  ranks are fully independent).
+  via `TT_VISIBLE_DEVICES`. A per-rank assignment is accepted only when it
+  exactly matches the discovered group; a conflicting GPU-style `--device-ids`
+  assignment fails before mesh creation. This is upstream vLLM's standard DP
+  mechanism (no gather/scatter; ranks are fully independent).
 
 For a deeper walk-through of the scheduling and execution model, read
 `docs/SCHEDULING.md`.

--- a/README.md
+++ b/README.md
@@ -343,8 +343,10 @@ The execution model matches TT hardware characteristics:
 - For other models, `--data_parallel_size N` uses standard multi-process DP:
   each DP rank runs an independent engine core with its own TT submesh,
   scheduler, and KV cache. Device groups are discovered at startup and assigned
-  via `TT_VISIBLE_DEVICES`. This is upstream vLLM's standard DP mechanism
-  (no gather/scatter; ranks are fully independent).
+  via `TT_VISIBLE_DEVICES`. Do not pass `--device-ids`: its flat GPU-style
+  syntax cannot represent TT multi-chip groups and is rejected for standard
+  TT DP. This is upstream vLLM's standard DP mechanism (no gather/scatter;
+  ranks are fully independent).
 
 For a deeper walk-through of the scheduling and execution model, read
 `docs/SCHEDULING.md`.

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -20,8 +20,8 @@ from vllm_tt_plugin.config import (
 from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.utils.dp_discovery import (
     StandardDPAssignmentT,
-    _run_standard_dp_visible_device_group_discovery,
-    _split_standard_dp_discovery_result,
+    run_standard_dp_visible_device_group_discovery,
+    split_standard_dp_discovery_result,
 )
 
 if TYPE_CHECKING:
@@ -197,7 +197,7 @@ def _resolve_standard_dp_visible_device_groups(
     mp_ctx = multiprocessing.get_context("spawn")
     parent_conn, child_conn = mp_ctx.Pipe(duplex=False)
     proc = mp_ctx.Process(
-        target=_run_standard_dp_visible_device_group_discovery,
+        target=run_standard_dp_visible_device_group_discovery,
         args=(
             child_conn,
             os.environ.get("MESH_DEVICE"),
@@ -1025,7 +1025,7 @@ class TTPlatform(Platform):
                 (
                     cls._standard_dp_visible_device_groups,
                     resolved_mesh_grids,
-                ) = _split_standard_dp_discovery_result(discovery_result)
+                ) = split_standard_dp_discovery_result(discovery_result)
                 if resolved_mesh_grids:
                     cls._standard_dp_mesh_grids = resolved_mesh_grids
                     _store_standard_dp_mesh_grids(vllm_config, resolved_mesh_grids)

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -116,8 +116,7 @@ def _load_standard_dp_visible_groups(
     ``None`` means nothing was stored. An empty list means discovery stored
     nothing usable, which callers must not treat as "keep the inherited value".
     """
-    additional_config = getattr(vllm_config, "additional_config", None) or {}
-
+    additional_config = getattr(vllm_config, "additional_config", None)
     if not isinstance(additional_config, dict):
         return None
 
@@ -132,7 +131,7 @@ def _load_standard_dp_mesh_grids(
     vllm_config: "VllmConfig",
 ) -> dict[str, tuple[int, int]]:
     """Load stored mesh-grid hints from the vLLM config."""
-    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    additional_config = getattr(vllm_config, "additional_config", None)
     if not isinstance(additional_config, dict):
         return {}
 

--- a/src/vllm_tt_plugin/utils/__init__.py
+++ b/src/vllm_tt_plugin/utils/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-"""vLLM Tenstorrent plugin configuration utilities."""
+"""vLLM Tenstorrent plugin runtime and topology utilities."""

--- a/src/vllm_tt_plugin/utils/dp_discovery.py
+++ b/src/vllm_tt_plugin/utils/dp_discovery.py
@@ -1,10 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
-"""DP discovery utilities to support upstream vLLM's standard multi-process DP mode."""
+"""Spawn-safe topology discovery for vLLM standard multi-process DP."""
+
+__all__ = (
+    "format_tt_visible_devices",
+    "parse_mesh_grid",
+    "run_standard_dp_visible_device_group_discovery",
+    "split_standard_dp_discovery_result",
+    "StandardDPAssignmentT",
+)
 
 import ast
 import logging
+from collections.abc import Sequence
 from contextlib import suppress
 
 logger = logging.getLogger(__name__)
@@ -26,7 +35,7 @@ _MESH_GRID_PRESETS = {
 }
 
 
-def _parse_mesh_grid(
+def parse_mesh_grid(
     mesh_device_env: str | None,
     num_devices_available: int,
     *,
@@ -36,9 +45,9 @@ def _parse_mesh_grid(
 
     Examples
     --------
-    >>> _parse_mesh_grid("T3K", 8, tg_mesh_grid=(4, 8))
+    >>> parse_mesh_grid("T3K", 8, tg_mesh_grid=(4, 8))
     (1, 8)
-    >>> _parse_mesh_grid("(2, 4)", 8, tg_mesh_grid=(4, 8))
+    >>> parse_mesh_grid("(2, 4)", 8, tg_mesh_grid=(4, 8))
     (2, 4)
     """
     mesh_grid_dict = dict(_MESH_GRID_PRESETS)
@@ -77,7 +86,7 @@ def _resolve_parent_mesh_grid(
     >>> _resolve_parent_mesh_grid("T3K", 8)
     (1, 8)
     """
-    mesh_grid = _parse_mesh_grid(
+    mesh_grid = parse_mesh_grid(
         mesh_device_env,
         num_devices_available,
         tg_mesh_grid=(4, 8),
@@ -135,16 +144,16 @@ def _maybe_reorder_standard_dp_visible_device_groups(
     return device_groups
 
 
-def _split_standard_dp_discovery_result(
+def split_standard_dp_discovery_result(
     discovery_result: list[str] | list[StandardDPAssignmentT] | None,
 ) -> tuple[list[str] | None, dict[str, tuple[int, int]]]:
     """Splits discovery output into visible-device and mesh-grid views.
 
     Examples
     --------
-    >>> _split_standard_dp_discovery_result(None)
+    >>> split_standard_dp_discovery_result(None)
     (None, {})
-    >>> _split_standard_dp_discovery_result([("0,1", (1, 2))])
+    >>> split_standard_dp_discovery_result([("0,1", (1, 2))])
     (["0,1"], {"0,1": (1, 2)})
     """
     if discovery_result is None:
@@ -202,7 +211,7 @@ def _discover_standard_dp_visible_device_groups(
                 raise RuntimeError(f"TT DP rank {dp_rank} resolved to an empty submesh")
             device_groups.append(
                 (
-                    ",".join(str(device_id) for device_id in device_ids),
+                    format_tt_visible_devices(device_ids),
                     tuple(int(dim) for dim in submesh.shape),
                 )
             )
@@ -232,7 +241,12 @@ def _discover_standard_dp_visible_device_groups(
                 ttnn.close_mesh_device(mesh_device)
 
 
-def _run_standard_dp_visible_device_group_discovery(
+def format_tt_visible_devices(device_ids: Sequence[int | str]) -> str:
+    """Serialize device identifiers for ``TT_VISIBLE_DEVICES``."""
+    return ",".join(str(device_id) for device_id in device_ids)
+
+
+def run_standard_dp_visible_device_group_discovery(
     conn,
     mesh_device_env: str | None,
     data_parallel_size: int,

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -77,28 +77,22 @@ def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
     env var. tt-metal reads only the env var, so the worker materializes it here;
     otherwise every rank keeps the launcher's value and they share chips.
 
-    Discovery's stored groups are the fallback. MPI launches populate neither and
-    keep the inherited value.
+    Standard-DP discovery owns the rank-to-submesh topology. An upstream
+    assignment may only carry the exact discovered group for the local rank.
+    MPI launches populate neither and keep the inherited value.
 
     Raises:
-        RuntimeError: the fallback holds no group for this rank.
+        RuntimeError: discovery holds no group for this rank or an assignment
+            conflicts with its discovered group.
     """
     parallel_config = vllm_config.parallel_config
     # Absent on the fork vLLM that the explicit MPI launcher targets.
     assigned_physical_gpu_ids = getattr(
         parallel_config, "assigned_physical_gpu_ids", None
     )
+    groups = _load_standard_dp_visible_groups(vllm_config)
 
-    if assigned_physical_gpu_ids:
-        visible_devices = ",".join(str(d) for d in assigned_physical_gpu_ids)
-    else:
-        groups = _load_standard_dp_visible_groups(vllm_config)
-        if groups is None:
-            return
-
-        # Index the fallback the way upstream indexes the primary channel:
-        # device_id_to_physical_device_id(local_dp_rank) at world_size 1. Local
-        # equals global because discovery only runs on a single host.
+    if groups is not None:
         local_dp_rank = parallel_config.data_parallel_rank_local
         if local_dp_rank is None or not 0 <= local_dp_rank < len(groups):
             raise RuntimeError(
@@ -108,6 +102,25 @@ def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
             )
 
         visible_devices = groups[local_dp_rank]
+        if assigned_physical_gpu_ids:
+            assigned_visible_devices = ",".join(
+                str(device_id) for device_id in assigned_physical_gpu_ids
+            )
+            if assigned_visible_devices != visible_devices:
+                raise RuntimeError(
+                    "TT standard data parallelism does not support `--device-ids`: "
+                    f"local DP rank {local_dp_rank} was assigned "
+                    f"{assigned_visible_devices!r}, but discovery requires "
+                    f"{visible_devices!r}. Remove `--device-ids` and use "
+                    "`MESH_DEVICE` with `--data-parallel-size`, or use explicit "
+                    "MPI rank binding."
+                )
+    elif assigned_physical_gpu_ids:
+        visible_devices = ",".join(
+            str(device_id) for device_id in assigned_physical_gpu_ids
+        )
+    else:
+        return
 
     evar = TTPlatform.device_control_env_var
     inherited = os.environ.get(evar)

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -55,7 +55,10 @@ from vllm_tt_plugin.platform import (
     _should_pre_register_tt_test_models_from_cli,
     register_tt_models,
 )
-from vllm_tt_plugin.utils.dp_discovery import _parse_mesh_grid
+from vllm_tt_plugin.utils.dp_discovery import (
+    format_tt_visible_devices,
+    parse_mesh_grid,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -103,8 +106,8 @@ def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
 
         visible_devices = groups[local_dp_rank]
         if assigned_physical_gpu_ids:
-            assigned_visible_devices = ",".join(
-                str(device_id) for device_id in assigned_physical_gpu_ids
+            assigned_visible_devices = format_tt_visible_devices(
+                assigned_physical_gpu_ids
             )
             if assigned_visible_devices != visible_devices:
                 raise RuntimeError(
@@ -116,9 +119,7 @@ def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
                     "MPI rank binding."
                 )
     elif assigned_physical_gpu_ids:
-        visible_devices = ",".join(
-            str(device_id) for device_id in assigned_physical_gpu_ids
-        )
+        visible_devices = format_tt_visible_devices(assigned_physical_gpu_ids)
     else:
         return
 
@@ -140,7 +141,7 @@ def _resolve_mesh_grid(
     num_devices_available: int,
     visible_devices_env: str | None,
 ) -> tuple[int, int]:
-    mesh_grid = _parse_mesh_grid(
+    mesh_grid = parse_mesh_grid(
         mesh_device_env,
         num_devices_available,
         tg_mesh_grid=(8, 4),

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -75,14 +75,15 @@ register_tt_models(register_test_models=_should_pre_register_tt_test_models_from
 def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
     """Bind ``TT_VISIBLE_DEVICES`` to this rank's device group.
 
-    As of vLLM v0.24, ``set_assigned_physical_gpu_ids_for_dp_rank`` writes
-    ``parallel_config.assigned_physical_gpu_ids`` instead of exporting a per-rank
-    env var. tt-metal reads only the env var, so the worker materializes it here;
-    otherwise every rank keeps the launcher's value and they share chips.
+    As of vLLM v0.24, the engine-core launcher writes
+    ``parallel_config.assigned_physical_gpu_ids`` instead of exporting a
+    per-rank env var. tt-metal reads only the env var, so the worker
+    materializes it here; otherwise every rank keeps the launcher's value and
+    they share chips.
 
-    Standard-DP discovery owns the rank-to-submesh topology. An upstream
-    assignment may only carry the exact discovered group for the local rank.
-    MPI launches populate neither and keep the inherited value.
+    Standard-DP discovery owns the rank-to-submesh topology. A nonempty
+    assignment must agree with the discovered group for the local rank. MPI
+    launches populate neither and keep the inherited value.
 
     Raises:
         RuntimeError: discovery holds no group for this rank or an assignment
@@ -111,12 +112,10 @@ def _bind_visible_devices_env(vllm_config: VllmConfig) -> None:
             )
             if assigned_visible_devices != visible_devices:
                 raise RuntimeError(
-                    "TT standard data parallelism does not support `--device-ids`: "
+                    "TT standard-DP assignment conflicts with discovery: "
                     f"local DP rank {local_dp_rank} was assigned "
                     f"{assigned_visible_devices!r}, but discovery requires "
-                    f"{visible_devices!r}. Remove `--device-ids` and use "
-                    "`MESH_DEVICE` with `--data-parallel-size`, or use explicit "
-                    "MPI rank binding."
+                    f"{visible_devices!r}."
                 )
     elif assigned_physical_gpu_ids:
         visible_devices = format_tt_visible_devices(assigned_physical_gpu_ids)

--- a/tests/test_visible_devices.py
+++ b/tests/test_visible_devices.py
@@ -23,6 +23,7 @@ from vllm_tt_plugin.platform import (
 from vllm_tt_plugin.utils.dp_discovery import (
     _maybe_reorder_standard_dp_visible_device_groups,
     _resolve_parent_mesh_grid,
+    format_tt_visible_devices,
 )
 from vllm_tt_plugin.worker import _bind_visible_devices_env, _resolve_mesh_grid
 
@@ -57,9 +58,20 @@ def _discovered_groups_config(
 def test_standard_dp_discovery_target_uses_helper_module() -> None:
     """Keep the spawned discovery target outside the platform module."""
     assert (
-        tt_platform._run_standard_dp_visible_device_group_discovery.__module__
+        tt_platform.run_standard_dp_visible_device_group_discovery.__module__
         == "vllm_tt_plugin.utils.dp_discovery"
     )
+
+
+@pytest.mark.parametrize(
+    ("device_ids", "expected"),
+    [([0, 1, 2, 3], "0,1,2,3"), (["4,5,6,7"], "4,5,6,7")],
+)
+def test_format_tt_visible_devices_supports_device_ids_and_group_strings(
+    device_ids: list[int] | list[str],
+    expected: str,
+) -> None:
+    assert format_tt_visible_devices(device_ids) == expected
 
 
 def test_standard_dp_discovery_timeout_terminates_subprocess(

--- a/tests/test_visible_devices.py
+++ b/tests/test_visible_devices.py
@@ -338,7 +338,7 @@ def test_flat_assigned_device_ids_are_rejected_for_standard_dp(
 
     with pytest.raises(
         RuntimeError,
-        match=r"TT standard data parallelism does not support --device-ids",
+        match=r"TT standard data parallelism does not support `--device-ids`",
     ):
         _bind_visible_devices_env(
             _discovered_groups_config(

--- a/tests/test_visible_devices.py
+++ b/tests/test_visible_devices.py
@@ -315,7 +315,7 @@ def test_standard_dp_visible_device_groups_feed_upstream_gpu_id_assignment(
 
 
 @pytest.mark.parametrize("inherited", [None, "", "0,1,2,3,4,5,6,7", "9,9"])
-def test_matching_assigned_group_overrides_inherited_visible_devices(
+def test_matching_internal_assignment_binds_discovered_group(
     monkeypatch: pytest.MonkeyPatch,
     inherited: str | None,
 ) -> None:
@@ -341,7 +341,7 @@ def test_matching_assigned_group_overrides_inherited_visible_devices(
     ("local_dp_rank", "assigned_physical_gpu_ids"),
     [(0, ["0"]), (1, ["1"])],
 )
-def test_flat_assigned_device_ids_are_rejected_for_standard_dp(
+def test_conflicting_internal_assignment_fails_loudly(
     monkeypatch: pytest.MonkeyPatch,
     local_dp_rank: int,
     assigned_physical_gpu_ids: list[str],
@@ -350,7 +350,7 @@ def test_flat_assigned_device_ids_are_rejected_for_standard_dp(
 
     with pytest.raises(
         RuntimeError,
-        match=r"TT standard data parallelism does not support `--device-ids`",
+        match=r"TT standard-DP assignment conflicts with discovery",
     ):
         _bind_visible_devices_env(
             _discovered_groups_config(

--- a/tests/test_visible_devices.py
+++ b/tests/test_visible_devices.py
@@ -303,7 +303,7 @@ def test_standard_dp_visible_device_groups_feed_upstream_gpu_id_assignment(
 
 
 @pytest.mark.parametrize("inherited", [None, "", "0,1,2,3,4,5,6,7", "9,9"])
-def test_assigned_physical_gpu_ids_override_inherited_visible_devices(
+def test_matching_assigned_group_overrides_inherited_visible_devices(
     monkeypatch: pytest.MonkeyPatch,
     inherited: str | None,
 ) -> None:
@@ -317,12 +317,39 @@ def test_assigned_physical_gpu_ids_override_inherited_visible_devices(
         _discovered_groups_config(
             "0,1,2,3",
             "4,5,6,7",
-            local_dp_rank=0,
+            local_dp_rank=1,
             assigned_physical_gpu_ids=["4,5,6,7"],
         )
     )
 
     assert os.environ[EVAR] == "4,5,6,7"
+
+
+@pytest.mark.parametrize(
+    ("local_dp_rank", "assigned_physical_gpu_ids"),
+    [(0, ["0"]), (1, ["1"])],
+)
+def test_flat_assigned_device_ids_are_rejected_for_standard_dp(
+    monkeypatch: pytest.MonkeyPatch,
+    local_dp_rank: int,
+    assigned_physical_gpu_ids: list[str],
+) -> None:
+    monkeypatch.setenv(EVAR, "0,1,2,3,4,5,6,7")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"TT standard data parallelism does not support --device-ids",
+    ):
+        _bind_visible_devices_env(
+            _discovered_groups_config(
+                "0,1,2,3",
+                "4,5,6,7",
+                local_dp_rank=local_dp_rank,
+                assigned_physical_gpu_ids=assigned_physical_gpu_ids,
+            )
+        )
+
+    assert os.environ[EVAR] == "0,1,2,3,4,5,6,7"
 
 
 def test_discovered_group_binds_when_upstream_left_ids_unset(


### PR DESCRIPTION
Follow-up to #27 (`TT_VISIBLE_DEVICES` device-group binding in standard DP).

## Purpose

In standard DP, TT discovery determines each rank's complete device group and
submesh shape. vLLM's `--device-ids` option is a flat GPU device list. When it is supplied, vLLM slices that list per DP rank before it calls `TTPlatform.device_id_to_physical_device_id`.

TT runs standard DP with `tensor_parallel_size = 1` and `pipeline_parallel_size = 1`, so the upstream slice width is normally one. For example, a discovered rank group `"0,1,2,3"` can be replaced by `["0"]`. The previous worker logic accepted `assigned_physical_gpu_ids` ahead of the discovered group and silently bound a one-chip `TT_VISIBLE_DEVICES` value.

## Modifications

- Make stored standard-DP device groups authoritative for the local DP rank;
  see **worker.py**.
- Permit `assigned_physical_gpu_ids` only when it exactly matches the full
  discovered group. This preserves vLLM's internally generated TT group
  assignment when the user did not pass `--device-ids`.
- Reject a conflicting flat assignment before changing `TT_VISIBLE_DEVICES` or
  opening a TT mesh. The error directs users to `MESH_DEVICE` with
  `--data-parallel-size`, or to explicit MPI rank binding.
- Keep explicit MPI unchanged: it stores no standard-DP groups and continues
  to own its per-rank `TT_VISIBLE_DEVICES` binding.
- Keep discovery metadata loading explicit when `additional_config` is absent
  or not a dictionary.
- Add host tests for a matching full-group assignment and for rejection of the
  one-device-per-rank assignments produced by `--device-ids`.
- Document that standard TT DP rejects `--device-ids`.

Example:

```bash
MESH_DEVICE=T3K
--data-parallel-size 2
--tensor-parallel-size 1
--pipeline-parallel-size 1
# --device-ids absent
```

gives

```bash
world_size = tensor_parallel_size * pipeline_parallel_size = 1
local_world_size = 1

discovered_groups:
  local_dp_rank 0 -> "0,1,2,3"
  local_dp_rank 1 -> "4,5,6,7"
```

## Test Plan

1. Unit tests for matching discovered groups, rejected flat device-ID slices,
   missing group handling, and explicit MPI environment preservation.
2. Run standard DP = 2 on T3K and verify each rank receives its discovered
   four-chip group without `--device-ids`.

## Test Result

- [x] `pytest tests/test_visible_devices.py -q`: 21 passed.
- [x] DP > 1 (happy path) [job](https://github.com/tenstorrent/tt-metal/actions/runs/31709876871) is successful.