### PR TITLE
[test] Stabilize host-only lane, DP, and Gemma tests

### DIFF
--- a/tests/test_dp_modes.py
+++ b/tests/test_dp_modes.py
@@ -248,12 +248,16 @@ class TestDPModes:
         )
         monkeypatch.setattr(worker, "TTModelRunner", lambda **_kwargs: model_runner)
 
-        TTWorker.init_device(worker_instance)
+        try:
+            TTWorker.init_device(worker_instance)
 
-        assert worker_instance.mesh_device is mesh_device
-        assert worker_instance.device is mesh_device
-        assert worker_instance.device_config.device is mesh_device
-        assert worker_instance.model_runner is model_runner
+            assert worker_instance.mesh_device is mesh_device
+            assert worker_instance.device is mesh_device
+            assert worker_instance.device_config.device is mesh_device
+            assert worker_instance.model_runner is model_runner
+        finally:
+            # The test double cannot be passed to TT device cleanup.
+            worker_instance.mesh_device = None
 
     def test_legacy_tt_dp_override_is_ignored_by_platform(
         self,

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -125,11 +125,11 @@ def test_streaming_assembles_name_and_args(parser: Gemma4ToolParser):
             prev, cur, chunk, [], [], [], request=None
         )
         if delta is not None and delta.tool_calls:
-            fn = delta.tool_calls[0].function or {}
-            if fn.get("name"):
-                name = fn["name"]
-            if fn.get("arguments"):
-                args_acc += fn["arguments"]
+            fn = delta.tool_calls[0].function
+            if fn is not None and fn.name:
+                name = fn.name
+            if fn is not None and fn.arguments:
+                args_acc += fn.arguments
         prev = cur
 
     assert name == "get_weather"

--- a/tests/test_lane_input_batch.py
+++ b/tests/test_lane_input_batch.py
@@ -18,10 +18,14 @@ No device / ttnn execution required.
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from vllm.sampling_params import SamplingParams
+from vllm.utils import torch_utils
+from vllm.v1.sample import sampler as sampler_module
 from vllm.v1.sample.logits_processor import AdapterLogitsProcessor, build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops import penalties as penalties_module
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
@@ -31,6 +35,13 @@ from vllm_tt_plugin.input_batch import InputBatch, TTLaneInputBatch
 VOCAB = 64
 BLOCK = 16
 MAX_MODEL_LEN = 256
+
+
+@pytest.fixture(autouse=True)
+def _disable_pinned_memory(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch_utils, "PIN_MEMORY", False)
+    monkeypatch.setattr(sampler_module, "PIN_MEMORY", False)
+    monkeypatch.setattr(penalties_module, "PIN_MEMORY", False)
 
 
 class FirstPromptTokenBoost(AdapterLogitsProcessor):


### PR DESCRIPTION
## Summary

Make the host-only unit suite deterministic with the current vLLM API.

Previously, a full host-suite run could:

- inherit vLLM pinned-memory state and try CUDA pinned allocation on a runner without an NVIDIA driver;
- treat the typed `DeltaFunctionCall` streaming result as a dictionary;
- pass a mocked mesh device into `TTWorker.__del__`, causing an unraisable TTNN cleanup warning.

The tests now force CPU-safe pin-memory behavior where needed, read the typed tool-call result correctly, and clear the fake mesh before worker destruction.

## Tests

```bash
source /home/sa/tt-metal/.venv/bin/activate
cd /home/sa/vllm-tt-plugin

pytest tests/test_dp_modes.py::TestDPModes::test_init_device_tracks_mesh_as_worker_device \
  -q -W error::pytest.PytestUnraisableExceptionWarning
# 1 passed, 16 warnings

pytest tests --ignore=tests/tt -v \
  -W error::pytest.PytestUnraisableExceptionWarning
# 112 passed, 8 skipped, 16 warnings

pre-commit run --files tests/test_dp_modes.py
# passed
```

---

*Note*: we want to make sure that the default run is green before implementing #19 