### PR TITLE
[ci] Add unit-test PR trigger (refers to tt-metal workflows).

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: tenstorrent/tt-metal/.github/workflows/vllm-plugin-host-tests.yaml
+    uses: tenstorrent/tt-metal/.github/workflows/vllm-plugin-host-tests.yaml@sanjaradylov/ci.unit-test-events
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,9 @@ on:
 
 # Only lint runs here. The unit tests import vllm_tt_plugin, which imports the
 # locally built TT vLLM (`empty` target) that is not installable on a stock
-# GitHub runner, so pytest belongs on a TT environment (see tt-metal's
-# vllm-nightly-tests), not in this workflow.
+# GitHub runner. Pull requests from this repository call TT-metal's
+# artifact-backed host-test workflow, which provides the TTNN wheel without
+# allocating a device.
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -18,3 +19,14 @@ jobs:
         with:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.1
+  host-unit-tests:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: tenstorrent/tt-metal/.github/workflows/vllm-plugin-host-tests.yaml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      plugin-repository: ${{ github.repository }}
+      plugin-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,14 +2,18 @@ name: ci
 
 on:
   pull_request:
-  push:
-    branches: [dev]
+    types: [opened, reopened, ready_for_review, synchronize, converted_to_draft]
 
-# Only lint runs here. The unit tests import vllm_tt_plugin, which imports the
+# Host unit tests import vllm_tt_plugin, which imports the
 # locally built TT vLLM (`empty` target) that is not installable on a stock
 # GitHub runner. Pull requests from this repository call TT-metal's
 # artifact-backed host-test workflow, which provides the TTNN wheel without
 # allocating a device.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -22,6 +26,7 @@ jobs:
   host-unit-tests:
     if: >-
       github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     uses: tenstorrent/tt-metal/.github/workflows/vllm-plugin-host-tests.yaml@sanjaradylov/ci.unit-test-events
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     uses: tenstorrent/tt-metal/.github/workflows/vllm-plugin-host-tests.yaml@sanjaradylov/ci.unit-test-events
     permissions:
       contents: read
-      packages: read
+      packages: write
     with:
       plugin-repository: ${{ github.repository }}
       plugin-ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
### Summary

Adds a reference to new TT-Metal host tests in `ci.yaml`. Each PR will trigger unit tests from `tests/` excluding `tests/tt`.

tenstorrent/tt-metal#53366 introduces this file and needs to be merged first.