### PR TITLE
Register Muse-Glimmer-30B and allow an explicit fabric router payload

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -715,6 +715,23 @@ def register_tt_models(register_test_models=False) -> None:
     ):
         _register_model_if_missing(ModelRegistry, arch, _gemma4_target)
 
+    # Muse-Glimmer — text-only TT bridge. Same nested-config resolution problem as
+    # Gemma4 above: nested text/vision configs mean upstream resolves to
+    # ``TransformersMultiModalForCausalLM`` before the ``TT``-prefix logic runs, so we
+    # register the plain HF arch names too. The TT class is text-only and does not use
+    # ``SupportsMultiModal``, so the request path stays text-only.
+    _muse_glimmer_target = (
+        "models.autoports.meta_models_muse_glimmer_30b.tt.generator_vllm"
+        ":MuseGlimmerForConditionalGeneration"
+    )
+    for arch in (
+        "MuseGlimmerForConditionalGeneration",
+        "MuseGlimmerForCausalLM",
+        "TTMuseGlimmerForConditionalGeneration",
+        "TTMuseGlimmerForCausalLM",
+    ):
+        _register_model_if_missing(ModelRegistry, arch, _muse_glimmer_target)
+
     # DeepseekV3
     _register_model_if_missing(
         ModelRegistry,

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -666,16 +666,34 @@ def get_reliability_mode(tt_config):
 # Set fabric config to passed in value
 # Do nothing if not set
 # Must be called before creating the mesh device
+def get_fabric_router_config(tt_config):
+    # Override the router's max packet payload if specified in TT plugin config.
+    if not tt_config or "fabric_packet_payload_bytes" not in tt_config:
+        return None
+    payload = int(tt_config["fabric_packet_payload_bytes"])
+    assert payload > 0, f"fabric_packet_payload_bytes must be positive, got {payload}"
+    router_config = ttnn.FabricRouterConfig()
+    router_config.max_packet_payload_size_bytes = payload
+    return router_config
+
+
 def set_fabric(tt_config, num_devices):
     fabric_config = get_fabric_config(tt_config, num_devices)
     if fabric_config:
         reliability_mode = get_reliability_mode(tt_config)
+        router_config = get_fabric_router_config(tt_config)
         logger.info(
-            "Setting fabric config: %s, reliability mode: %s",
+            "Setting fabric config: %s, reliability mode: %s, router config: %s",
             fabric_config,
             reliability_mode,
+            router_config,
         )
-        ttnn.set_fabric_config(fabric_config, reliability_mode)
+        if router_config is not None:
+            ttnn.set_fabric_config(
+                fabric_config, reliability_mode, router_config=router_config
+            )
+        else:
+            ttnn.set_fabric_config(fabric_config, reliability_mode)
 
 
 # From tt-metal/conftest.py:


### PR DESCRIPTION
## What

Two changes, both needed to serve `meta-models/Muse-Glimmer-30B` through this plugin.

**1. `platform.py` — register the Muse-Glimmer architectures.**
Registers `MuseGlimmerForConditionalGeneration` / `MuseGlimmerForCausalLM` and their
`TT`-prefixed aliases against the tt-metal autoport's
`models.autoports.meta_models_muse_glimmer_30b.tt.generator_vllm`.

The **plain HF names** are the non-obvious part, and they are required for the same reason
Gemma4 needs them a few lines above. The checkpoint declares
`MuseGlimmerForConditionalGeneration` with `model_type: muse_glimmer` and nested
text/vision configs, so `hf_config != hf_text_config`. Upstream's architecture resolver
therefore falls back to `TransformersMultiModalForCausalLM` inside
`ModelConfig.__post_init__` — which runs *before* this plugin's `TT`-prefix rewrite, so
registering only the prefixed name cannot help. Registering the plain name makes upstream
resolution find the TT class directly; the prefixed alias then satisfies
`check_and_update_config`'s registry check.

The TT port implements the **text decoder only** and its class does not use
`SupportsMultiModal`, so `_model_info.supports_multimodal` is False, `multimodal_config`
stays unpopulated, and the request path is text-only. Image input is not silently accepted.

**2. `worker.py` — optional `fabric_packet_payload_bytes`.**
Lets a model open the fabric with the same router payload its collectives were tuned and
measured with. Without it the served fabric silently differs from the offline configuration
that produced the accuracy and latency evidence. New helper `get_fabric_router_config()`
returns `None` when the key is absent, so **defaults are unchanged** for every existing
model and no current behaviour moves.

## Why this cannot go upstream

Both halves are Tenstorrent-specific:

- the registration target is a **tt-metal path** (`models/autoports/...`), which upstream
  vLLM has no concept of;
- the payload change configures `ttnn.FabricRouterConfig`.

For confirmation, `grep -ri muse_glimmer` across an installed vLLM 0.24.0 returns nothing —
upstream has no knowledge of this model, and does not need any: the model runs through this
plugin's own generator rather than a vLLM model implementation.

## Dependency

The registration target lives in tt-metal on branch
`agentic-research/hous/muse-glimmer-30b`, at
`models/autoports/meta_models_muse_glimmer_30b/tt/generator_vllm.py`. Registration is
`_register_model_if_missing`, so this is inert for anyone without that checkout.

## Testing

Verified on a QB2 (4× Blackhole, P300_X2, mesh 1×4, `FABRIC_1D_RING`) with vLLM 0.24.0:

- server reaches ready in ~240 s and `/v1/models` reports `meta-models/Muse-Glimmer-30B`;
- 18-point serving benchmark sweep, ISL 128 → 65,536, **0 failed requests**;
- batch-1 decode 42.4 t/s/u at ISL 128, 19.4 t/s/u at ISL 130,560 (full 131,072 context);
- `run.py --workflow release` reaches `Acceptance: PASS (0 blocker(s))`.

Without this commit the plugin does not recognise `model_type: muse_glimmer` and the server
does not start, so a fresh clone cannot serve the model at all — which is the reason for
opening this.

## Note for reviewers

The two changes are **logically separable** — model registration and a model-agnostic fabric
knob — and I am happy to split them into two PRs if you would prefer the fabric change
reviewed on its own. They arrived in one commit because the second was found while measuring
the first.

Draft because I would like the registration approach confirmed before it is treated as
final, in particular whether registering the plain HF names is the accepted pattern here or
whether the Gemma4 precedent is considered a workaround to be replaced.
