### PR TITLE
Accept FABRIC_2D_TORUS_XY and default BH Galaxy to 2D torus

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ To run a different text model, set `MESH_DEVICE` to `N150`, `N300`, `T3K`, `TG`,
 For Llama 3.1 8B on N150, set `--max_model_len 32768`; see the tt-metal model
 demo for context-length details.
 
-To run Llama 70B on Galaxy:
+To run Llama 70B on Wormhole Galaxy:
 
 ```bash
 MESH_DEVICE=TG \
@@ -193,18 +193,30 @@ LLAMA_DIR=<path-to-weights> \
 TT_LLAMA_TEXT_VER=llama3_70b_galaxy \
 python examples/offline_inference_tt.py \
   --model "meta-llama/Llama-3.1-70B-Instruct" \
-  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
 ```
 
-To run GPT-OSS 20B on Galaxy:
+To run GPT-OSS 20B on Wormhole Galaxy:
 
 ```bash
 MESH_DEVICE="(4,8)" \
 python examples/offline_inference_tt.py \
   --model "openai/gpt-oss-20b" \
-  --max_seqs_in_batch 1 \
-  --additional-config '{"tt": {"fabric_config": "FABRIC_1D_RING"}}'
+  --max_seqs_in_batch 1
 ```
+
+To run Qwen3-32B on Blackhole Galaxy:
+
+```bash
+MESH_DEVICE=TG \
+TT_QWEN3_TEXT_VER=qwen3_32b_galaxy \
+python examples/offline_inference_tt.py \
+  --model "Qwen/Qwen3-32B" \
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1345000, "trace_region_size": 184915840}}'
+```
+
+Wormhole Galaxy defaults to `FABRIC_1D_RING` and Blackhole Galaxy defaults to
+`FABRIC_2D_TORUS_XY`, so those recipes do not need an explicit `fabric_config`.
 
 Run Llama 3.2 Vision on N300:
 
@@ -281,7 +293,7 @@ Common options:
 | `trace_region_size` | Trace region size for TT runtime tracing. |
 | `worker_l1_size` | Worker L1 size override. |
 | `l1_small_size` | Small L1 size override. |
-| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, or `CUSTOM`. |
+| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, `FABRIC_2D_TORUS_XY`, or `CUSTOM`. Any `ttnn.FabricConfig` name is accepted. Defaults: Wormhole Galaxy `FABRIC_1D_RING`, Blackhole Galaxy `FABRIC_2D_TORUS_XY`, other multi-device `FABRIC_1D`. |
 | `fabric_reliability_mode` | Fabric reliability mode, such as `STRICT_INIT` or `RELAXED_INIT`. |
 | `dispatch_core_axis` | Dispatch core axis, `row` or `col`. |
 | `always_compat_sampling` | Use vLLM's LogitProcessor and sampler path even when not required by the batch. Default: `false`. |
@@ -363,7 +375,7 @@ lanes.
 
 Serve them with the familiar `--data_parallel_size N --max_num_seqs M` flags;
 the TT backend transparently maps them to `N` in-process lanes. No config
-changes are needed:
+changes are needed. Wormhole Galaxy example (fabric defaults to `FABRIC_1D_RING`):
 
 ```bash
 MESH_DEVICE=TG \
@@ -374,7 +386,7 @@ python examples/server_example_tt.py \
   --data_parallel_size 4 \
   --max_num_seqs 8 \
   --async-scheduling \
-  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
 ```
 
 `--data_parallel_size 4 --max_num_seqs 8` runs `4` TT lanes of `8` requests

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -621,26 +621,25 @@ def get_fabric_config(tt_config, num_devices):
         # Ignore any explicit fabric request for single-device meshes.
         return None
 
-    # Set the most common value as default
-    is_6u = ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
-    fabric_config = (
-        ttnn.FabricConfig.FABRIC_1D_RING if is_6u else ttnn.FabricConfig.FABRIC_1D
-    )
+    # Wormhole Galaxy (6U) uses a 1D ring. Blackhole Galaxy needs a 2D torus:
+    # column-axis collectives have no wraparound path on 1D fabrics.
+    cluster_type = ttnn.cluster.get_cluster_type()
+    if cluster_type == ttnn.cluster.ClusterType.BLACKHOLE_GALAXY:
+        fabric_config = ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    elif cluster_type == ttnn.cluster.ClusterType.GALAXY:
+        fabric_config = ttnn.FabricConfig.FABRIC_1D_RING
+    else:
+        fabric_config = ttnn.FabricConfig.FABRIC_1D
 
-    # Override fabric_config if specified in TT plugin config.
+    # Override fabric_config if specified in TT plugin config. Resolve the name
+    # from ttnn.FabricConfig so newly added fabrics (e.g. FABRIC_2D_TORUS_XY)
+    # work without a plugin allow-list update.
     if tt_config is not None and "fabric_config" in tt_config:
         fabric_config_str = tt_config["fabric_config"]
-        fabric_config_map = {
-            "DISABLED": ttnn.FabricConfig.DISABLED,
-            "FABRIC_1D": ttnn.FabricConfig.FABRIC_1D,
-            "FABRIC_1D_RING": ttnn.FabricConfig.FABRIC_1D_RING,
-            "FABRIC_2D": ttnn.FabricConfig.FABRIC_2D,
-            "CUSTOM": ttnn.FabricConfig.CUSTOM,
-        }
-        fabric_config = fabric_config_map.get(fabric_config_str)
+        fabric_config = ttnn.FabricConfig.__members__.get(fabric_config_str)
         assert fabric_config is not None, (
             f"Invalid fabric_config: {fabric_config_str}. "
-            f"Expected one of {list(fabric_config_map.keys())}."
+            f"Expected one of {list(ttnn.FabricConfig.__members__)}."
         )
     return fabric_config
 


### PR DESCRIPTION
## Purpose

Port of [tenstorrent/vllm#470](https://github.com/tenstorrent/vllm/pull/470) to the standalone plugin.

Add Blackhole Galaxy 2D-torus fabric support. BH Galaxy column-axis collectives need a 2D torus, but the plugin's hardcoded fabric allow-list rejected it:

```
AssertionError: Invalid fabric_config: FABRIC_2D_TORUS_XY.
```

* Default `BLACKHOLE_GALAXY` to `FABRIC_2D_TORUS_XY` (Wormhole Galaxy stays on `FABRIC_1D_RING`).
* Resolve `fabric_config` names via `ttnn.FabricConfig.__members__` instead of a hardcoded dict, so any fabric enum works without plugin updates.
* Retitle Galaxy README recipes as Wormhole Galaxy, drop the now-redundant `fabric_config`, and add a BH Galaxy Qwen3-32B recipe.

## Test Plan

* BH Galaxy: default fabric resolves to `FABRIC_2D_TORUS_XY` (no override needed)
* Explicit `--additional-config '{"tt": {"fabric_config": "FABRIC_2D_TORUS_XY"}}'` accepted
* WH Galaxy default remains `FABRIC_1D_RING`

## Test Result

Same change as vllm#470, which Viktor approved. Name resolution verified against `ttnn.FabricConfig`. BH Galaxy Qwen3-32B vLLM bring-up used this fabric path.

Made with [Cursor](https://cursor.com)