### PR TITLE
tt: short-circuit the lane grammar bitmask on has_structured_output_requests (#55)

### DIFF
--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -569,6 +569,12 @@ class TTLaneCoordinator(SchedulerInterface):
         # requests (request IDs are globally unique). Row order within the
         # bitmask is irrelevant: the runner remaps rows back to batch positions
         # by request ID via reorder_grammar_bitmask_for_tt_batch.
+        #
+        # The merged flag is the union over the lanes, so a false value means no
+        # lane scheduled a constrained request and the per-step union below is
+        # pure waste.
+        if not scheduler_output.has_structured_output_requests:
+            return None
         requests: dict[str, Request] = {}
         for sched in self.lanes:
             requests.update(sched.requests)

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -253,9 +253,12 @@ def test_grammar_bitmask_skips_intermediate_prefill_chunks():
         recorded
     )
 
-    grammar_output = coordinator.get_grammar_bitmask(
-        _scheduled_output(["chunk", "decode"])
-    )
+    scheduler_output = _scheduled_output(["chunk", "decode"])
+    # The base scheduler raises the flag for "decode": a structured request that
+    # is past its prefill chunks.
+    scheduler_output.has_structured_output_requests = True
+
+    grammar_output = coordinator.get_grammar_bitmask(scheduler_output)
 
     assert recorded == [["decode"]]
     assert grammar_output.structured_output_request_ids == ["decode"]


### PR DESCRIPTION
Closes the remaining half of #55.

`TTLaneCoordinator.get_grammar_bitmask` merged `has_structured_output_requests` from every lane (`lane_scheduler.py:199`, `:220`) but never read it, unlike the base scheduler. Every step therefore paid the union of all lanes' request dicts plus the comprehension, even with nothing constrained in flight.

This is a parity/waste fix, not a behaviour fix: `if not structured_output_request_ids: return None` already returned exactly what the short-circuit returns. The other divergence named in #55, the missing `not req.is_prefill_chunk` filter, landed in #48.

The flag is safe to trust here: lanes schedule through the base `Scheduler.schedule()`, which raises the flag for each scheduled structured request that is past its prefill chunks, and `merge_lane_scheduler_outputs` ORs it across lanes.

No new tests, per the request. One existing fixture moved: `test_grammar_bitmask_skips_intermediate_prefill_chunks` now sets the flag, matching what the base scheduler would set for its non-chunk structured request. `test_grammar_bitmask_is_none_when_only_prefill_chunks_are_scheduled` keeps a false flag, which is what the base scheduler produces in that state, so it now exits at the short-circuit rather than at the empty comprehension.

Not run locally: vLLM does not install on this macOS host, so the lane-scheduler tests were not executed. `ruff check` and `ruff format --check` pass. CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)