### PR TITLE
[fix] Stop misclassifying steady-state decode as prefill.

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1062,45 +1062,6 @@ class TTModelRunner:
         sample_params = input_batch.sampling
         intermediate_prefill_mask: torch.Tensor | None = None
         if is_prompt:
-            # NOTE: In SchedulerOutput, "cached" means "request data already
-            # cached on the worker", not necessarily "decode". During a prefill
-            # step we can legitimately see cached requests if they are resumed
-            # from preemption or are chunked-prefill continuations (both still
-            # prefill work).
-            if cached_reqs.num_reqs > 0:
-                running_req_ids = {
-                    req_id
-                    for req_id in cached_reqs.req_ids
-                    if req_id not in cached_reqs.resumed_req_ids
-                    and not _is_still_prefilling(req_id)
-                }
-                if running_req_ids:
-                    # Mixed prefill+decode batch detected. This should not
-                    # happen with TTScheduler but can occur under standard DP
-                    # async scheduling edge cases. Filter decode requests out
-                    # of this prefill step; they will be re-scheduled next.
-
-                    logger.warning(
-                        "Prefill batch contained %d running decode request(s); "
-                        "filtering them from this prefill step.",
-                        len(running_req_ids),
-                    )
-
-                    req_indices = [
-                        i
-                        for i in req_indices
-                        if input_batch.req_ids[i] not in running_req_ids
-                    ]
-                    num_reqs = len(req_indices)
-                    if num_reqs == 0:
-                        return None
-
-                    # Rebuild block tables for the filtered indices.
-                    block_tables_per_group = input_batch.block_tables_for_rows(
-                        req_indices, target_width
-                    )
-                    block_tables = block_tables_per_group[0]
-
             # num_computed_tokens for each request is the input position
             # (=computed previously and cached)
             input_positions = input_batch.num_computed_tokens_cpu[req_indices]

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1033,8 +1033,13 @@ class TTModelRunner:
 
         def _is_still_prefilling(req_id: str) -> bool:
             row = input_batch.req_id_to_index[req_id]
+            # ``num_computed_tokens`` is the scheduler's pre-step snapshot, so a
+            # steady-state decode arrives with exactly one token left to
+            # compute. More than one token left means this step is a prefill
+            # chunk: either prompt tokens or a post-preemption replay.
             return (
-                input_batch.num_computed_tokens_cpu[row] < input_batch.num_tokens[row]
+                input_batch.num_computed_tokens_cpu[row] + 1
+                < input_batch.num_tokens[row]
             )
 
         # A "prefill" step can contain:

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -161,9 +161,12 @@ def test_resumed_replay_past_prompt_length_remains_prefill():
 # region Decode input construction
 
 
-def test_completed_cached_request_builds_decode_input():
-    prompt_len = num_computed_tokens = 8
-    output_len = 0
+@pytest.mark.parametrize("output_len", [0, 1, 2, 5])
+def test_completed_cached_request_builds_decode_input(output_len: int):
+    """Classify a cached request that has computed everything but its last token."""
+    prompt_len = 8
+    num_tokens = prompt_len + output_len
+    num_computed_tokens = max(prompt_len, num_tokens - 1)
     batch, request = _batch_with_one_request(
         prompt_len=prompt_len,
         output_len=output_len,
@@ -189,10 +192,11 @@ def test_completed_cached_request_builds_decode_input():
 
     assert model_input is not None
     assert model_input.prompt_lens is None
-    assert model_input.input_positions.tolist() == [prompt_len - 1] + [-1] * (
+    assert model_input.input_positions.tolist() == [num_tokens - 1] + [-1] * (
         MAX_NUM_SEQS - 1
     )
     assert model_input.input_tokens.shape == (MAX_NUM_SEQS, 1)
+    assert model_input.input_tokens[0, 0] == batch.token_ids_cpu[0, num_tokens - 1]
 
 
 # endregion Decode input construction


### PR DESCRIPTION
Resolves #66.

`_is_still_prefilling` compared `num_computed_tokens < num_tokens` in #54. vLLM snapshots `num_computed_tokens` into `SchedulerOutput` **before** `_update_after_schedule` advances it, so a steady-state decode reaches the runner at **`num_tokens - 1`** and that condition is unconditionally true. Every decode step was routed to `submit_prefill` and replayed the whole sequence. The mixed-batch guard below it derives from the same predicate, so nothing warned.

Reverting to `num_prompt_tokens` is not an option - that reintroduces the bug #54 fixed, where a post-preemption replay past the prompt length is treated as decode. Both cases sit in `num_prompt_tokens <= computed < num_tokens`; the discriminator is how many tokens remain, not where they sit. Comparing against `computed + 1` covers both: more than one token left is a prefill chunk, exactly one left is a decode.
