### PR TITLE
[fix] Align sample-time row identity across reorder/apply paths.

### DIFF
--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1104,8 +1104,7 @@ class TTLaneInputBatch(InputBatch):
         return reorder_grammar_bitmask_for_tt_batch(
             bitmask=bitmask,
             structured_output_request_ids=grammar_output.structured_output_request_ids,
-            req_id_to_index=self.req_id_to_index,
-            req_indices=list(range(batch_length)),
+            row_req_ids=self.req_ids[:batch_length],
             batch_length=batch_length,
         )
 

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -130,3 +130,9 @@ class TTModelInput:
     # sampled token, because more prompt tokens remain after this chunk.
     # ``None`` for decode.
     intermediate_prefill_mask: torch.Tensor | None = None
+
+    # Request id per forward row. A prefill build can drop rows, so forward row
+    # order is not recoverable from the persistent batch; sample-time consumers
+    # must resolve rows through this. ``None`` for lane builds, whose rows are
+    # the persistent slots.
+    row_req_ids: list[str] | None = None

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -971,7 +971,7 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
         grammar_output: GrammarOutput | None,
-    ) -> TTModelInput | None:
+    ) -> TTModelInput:
         """Build a ``TTModelInput`` for one prefill or decode step.
 
         Reads the current persistent ``self.input_batch`` and assembles the
@@ -2259,8 +2259,10 @@ class TTModelRunner:
         captured_req_ids = req_ids
         for req_idx, req_id in enumerate(captured_req_ids):
             req_state = self.requests.get(req_id)
-            if req_state is None:
-                continue
+            assert req_state is not None, (
+                "captured request missing from runner state while applying sampled "
+                f"tokens: req_id={req_id!r}"
+            )
             if request_states is not None and req_state is not request_states[req_idx]:
                 continue
 
@@ -2277,8 +2279,7 @@ class TTModelRunner:
                     sampled_token_ids_np[req_idx]
                 )
                 self.input_batch.num_tokens[current_row] = end_idx
-
-            req_state.output_token_ids.append(int(sampled_token_ids_np[req_idx]))
+                req_state.output_token_ids.append(int(sampled_token_ids_np[req_idx]))
 
     def apply_and_build_runner_output(
         self,

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -971,7 +971,7 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
         grammar_output: GrammarOutput | None,
-    ) -> TTModelInput:
+    ) -> TTModelInput | None:
         """Build a ``TTModelInput`` for one prefill or decode step.
 
         Reads the current persistent ``self.input_batch`` and assembles the
@@ -1130,6 +1130,8 @@ class TTModelRunner:
                 # defaults. The persistent ``input_batch.sampling`` tail is
                 # never read, so there is nothing to default in place.
 
+        row_req_ids = [input_batch.req_ids[i] for i in req_indices]
+
         tt_sampling_params = slice_tt_sampling_params(sample_params, req_indices)
         if not is_prompt and input_tokens.shape[0] > len(req_indices):
             # Decode inputs are padded to the rank batch size; pad the sampling
@@ -1168,8 +1170,7 @@ class TTModelRunner:
             bitmask = reorder_grammar_bitmask_for_tt_batch(
                 bitmask=bitmask,
                 structured_output_request_ids=structured_output_request_ids,
-                req_id_to_index=input_batch.req_id_to_index,
-                req_indices=req_indices,
+                row_req_ids=row_req_ids,
                 batch_length=batch_length,
             )
 
@@ -1266,7 +1267,6 @@ class TTModelRunner:
         # State follows the request, not the row (``self._req_state_slot``), which
         # subsumes the batch's condense-move remap.
         input_batch.reset_slot_remap()
-        row_req_ids = [input_batch.req_ids[i] for i in req_indices]
         prefill_empty_slots = None
         slot_remap = None
         if is_prompt:
@@ -1285,6 +1285,7 @@ class TTModelRunner:
             block_tables_per_group=block_tables_per_group,
             block_tables_per_layer=self._block_tables_per_layer(block_tables_per_group),
             unpadded_batch_size=num_reqs,
+            row_req_ids=row_req_ids,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
             perform_device_sampling=perform_device_sampling,
@@ -1573,23 +1574,20 @@ class TTModelRunner:
         *,
         lane_total: int | None,
     ) -> torch.Tensor | None:
-        """Reorder a scheduler grammar bitmask into TT batch layout, or ``None``.
-
-        Runs at sample time. ``sample_tokens`` executes before the next
-        schedule, so the live batch/lane layout still matches the forward this
-        bitmask belongs to. ``lane_total`` selects the lane reorder (full slot
-        capacity) over the non-DP front-packed reorder.
-        """
+        """Reorder a scheduler grammar bitmask into TT batch layout, or ``None``."""
         if grammar_output is None or grammar_output.grammar_bitmask is None:
             return None
+
         if lane_total is not None:
             return self.lane_batch.slot_grammar_bitmask(grammar_output, lane_total)
+
+        assert model_input.row_req_ids is not None
+
         bitmask = torch.from_numpy(grammar_output.grammar_bitmask)
         return reorder_grammar_bitmask_for_tt_batch(
             bitmask=bitmask,
             structured_output_request_ids=grammar_output.structured_output_request_ids,
-            req_id_to_index=self.input_batch.req_id_to_index,
-            req_indices=list(range(self.input_batch.num_reqs)),
+            row_req_ids=model_input.row_req_ids,
             batch_length=model_input.input_tokens.shape[0],
         )
 
@@ -1647,22 +1645,32 @@ class TTModelRunner:
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
 
-        if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
-            num_reqs = self.input_batch.num_reqs
-            prompt_lens = np.asarray(fwd.model_input.prompt_lens)
-            # A row-count mismatch means the forward ran on a filtered subset;
-            # leave it to the output builder below to report.
-            if len(prompt_lens) == num_reqs:
-                intermediate_mask = prompt_lens < self.input_batch.num_tokens[:num_reqs]
-                if intermediate_mask.any():
-                    return self._build_chunked_prefill_output(
-                        req_ids=list(self.input_batch.req_ids[:num_reqs]),
-                        sampled_token_ids=sampled_token_ids,
-                        logprobs=logprobs,
-                        intermediate_mask=intermediate_mask,
-                    )
+        row_req_ids = fwd.model_input.row_req_ids
 
-        return self.apply_and_build_runner_output(sampled_token_ids, logprobs)
+        assert row_req_ids is not None
+
+        is_prefill = not fwd.is_decode and fwd.model_input.prompt_lens is not None
+
+        if is_prefill:
+            intermediate_mask = fwd.model_input.intermediate_prefill_mask
+
+            assert intermediate_mask is not None
+
+            if intermediate_mask.any():
+                return self._build_chunked_prefill_output(
+                    req_ids=row_req_ids,
+                    sampled_token_ids=sampled_token_ids,
+                    logprobs=logprobs,
+                    intermediate_mask=intermediate_mask.numpy(),
+                )
+
+        return self.apply_and_build_runner_output(
+            sampled_token_ids,
+            logprobs,
+            # Only a prefill build can filter rows. Decode rows are the front-packed
+            # batch rows, so it keeps the vectorized state write.
+            req_ids=row_req_ids if is_prefill else None,
+        )
 
     def _build_chunked_prefill_output(
         self,

--- a/src/vllm_tt_plugin/structured_output.py
+++ b/src/vllm_tt_plugin/structured_output.py
@@ -35,11 +35,10 @@ def reorder_grammar_bitmask_for_tt_batch(
     *,
     bitmask: torch.Tensor,
     structured_output_request_ids: Sequence[str],
-    req_id_to_index: Mapping[str, int],
-    req_indices: Sequence[int],
+    row_req_ids: Sequence[str | None],
     batch_length: int,
 ) -> torch.Tensor:
-    """Reorder scheduler bitmask rows into the TT lane-local batch layout."""
+    """Reorder scheduler bitmask rows into the TT batch layout."""
     grammar_bitmask_length = bitmask.shape[1]
     reordered_bitmask = torch.full(
         (batch_length, grammar_bitmask_length),
@@ -51,13 +50,9 @@ def reorder_grammar_bitmask_for_tt_batch(
     req_id_to_bitmask_row: dict[str, int] = {
         req_id: i for i, req_id in enumerate(structured_output_request_ids)
     }
-    req_index_to_local_row = {
-        req_index: local_row for local_row, req_index in enumerate(req_indices)
-    }
-    for req_id, persistent_batch_index in req_id_to_index.items():
+    for local_row, req_id in enumerate(row_req_ids[:batch_length]):
         scheduler_bitmask_row = req_id_to_bitmask_row.get(req_id)
-        local_row = req_index_to_local_row.get(persistent_batch_index)
-        if scheduler_bitmask_row is not None and local_row is not None:
+        if scheduler_bitmask_row is not None:
             reordered_bitmask[local_row, :] = bitmask[scheduler_bitmask_row, :]
 
     return reordered_bitmask

--- a/tests/test_sample_time_grammar.py
+++ b/tests/test_sample_time_grammar.py
@@ -45,6 +45,7 @@ def _model_input(**overrides) -> TTModelInput:
         allowed_token_ids_mask_list=[None],
         generators_list=[{}],
         max_num_logprobs=[None],
+        row_req_ids=["req-0"],
     )
     base.update(overrides)
     return TTModelInput(**base)
@@ -122,28 +123,53 @@ def test_reorder_grammar_bitmask_lane_path_delegates_to_slot_reorder():
 
 
 def test_reorder_grammar_bitmask_non_dp_path_uses_front_packed_reorder():
-    """Non-DP (``lane_total=None``) reorders against the front-packed batch."""
+    """Non-DP (``lane_total=None``) reorders against the build's own rows."""
     # Two requests, only req-1 structured; batch_length comes from input_tokens.
-    runner = SimpleNamespace(
-        input_batch=SimpleNamespace(
-            req_id_to_index={"req-0": 0, "req-1": 1}, num_reqs=2
-        )
-    )
+    runner = SimpleNamespace()
     grammar = GrammarOutput(
         structured_output_request_ids=["req-1"],
         grammar_bitmask=np.array([[5, 6]], dtype=np.int32),
     )
-    model_input = _model_input(input_tokens=torch.zeros((2, 1), dtype=torch.int32))
+    model_input = _model_input(
+        input_tokens=torch.zeros((2, 1), dtype=torch.int32),
+        row_req_ids=["req-0", "req-1"],
+    )
 
     result = TTModelRunner._reorder_grammar_bitmask(
         runner, grammar, model_input, lane_total=None
     )
 
     assert result.shape == (2, VOCAB_WORDS)
-    # req-1 (batch index 1) gets its scheduler bitmask row; req-0 is left
+    # req-1 (forward row 1) gets its scheduler bitmask row; req-0 is left
     # all-ones (-1 in int32 = every token allowed).
     assert result[1].tolist() == [5, 6]
     assert torch.all(result[0] == -1)
+
+
+def test_reorder_grammar_bitmask_non_dp_path_ignores_filtered_rows():
+    """A prefill build drops mixed-in decode rows; the reorder must follow the
+    forward's rows, not the persistent batch's.
+    """
+    # Persistent batch req-0..req-3, forward kept req-0 and req-2. Under a
+    # ``range(num_reqs)`` reorder req-2 lands past the end of a 2-row tensor.
+    runner = SimpleNamespace()
+    grammar = GrammarOutput(
+        structured_output_request_ids=["req-1", "req-2"],
+        grammar_bitmask=np.array([[1, 2], [5, 6]], dtype=np.int32),
+    )
+    model_input = _model_input(
+        input_tokens=torch.zeros((2, 8), dtype=torch.int32),
+        row_req_ids=["req-0", "req-2"],
+    )
+
+    result = TTModelRunner._reorder_grammar_bitmask(
+        runner, grammar, model_input, lane_total=None
+    )
+
+    assert result.shape == (2, VOCAB_WORDS)
+    assert torch.all(result[0] == -1)
+    # req-2's own mask, not req-1's, which the forward never ran.
+    assert result[1].tolist() == [5, 6]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -6,7 +6,7 @@ import torch
 from vllm_tt_plugin.structured_output import reorder_grammar_bitmask_for_tt_batch
 
 
-def test_reorder_grammar_bitmask_uses_lane_local_rows():
+def test_reorder_grammar_bitmask_uses_forward_row_order():
     bitmask = torch.tensor(
         [
             [10, 11],
@@ -20,8 +20,7 @@ def test_reorder_grammar_bitmask_uses_lane_local_rows():
     reordered = reorder_grammar_bitmask_for_tt_batch(
         bitmask=bitmask,
         structured_output_request_ids=["req-0", "req-1", "req-2", "req-3"],
-        req_id_to_index={"req-0": 0, "req-1": 3, "req-2": 7, "req-3": 10},
-        req_indices=[3, 10],
+        row_req_ids=["req-1", "req-3"],
         batch_length=2,
     )
 
@@ -37,7 +36,8 @@ def test_reorder_grammar_bitmask_uses_lane_local_rows():
     )
 
 
-def test_reorder_grammar_bitmask_ignores_structured_requests_outside_lane():
+def test_reorder_grammar_bitmask_ignores_requests_absent_from_the_forward():
+    """A structured request the forward did not run must not claim a row."""
     bitmask = torch.tensor(
         [
             [10, 11],
@@ -49,8 +49,7 @@ def test_reorder_grammar_bitmask_ignores_structured_requests_outside_lane():
     reordered = reorder_grammar_bitmask_for_tt_batch(
         bitmask=bitmask,
         structured_output_request_ids=["req-0", "req-1"],
-        req_id_to_index={"req-0": 0, "req-1": 3},
-        req_indices=[3, 5],
+        row_req_ids=["req-1", "req-9"],
         batch_length=2,
     )
 
@@ -63,4 +62,40 @@ def test_reorder_grammar_bitmask_ignores_structured_requests_outside_lane():
             ],
             dtype=torch.int32,
         ),
+    )
+
+
+def test_reorder_grammar_bitmask_leaves_uncovered_rows_all_allowed():
+    """Decode pads to the wire batch size, so rows can outnumber requests."""
+    bitmask = torch.tensor([[10, 11]], dtype=torch.int32)
+
+    reordered = reorder_grammar_bitmask_for_tt_batch(
+        bitmask=bitmask,
+        structured_output_request_ids=["req-0"],
+        row_req_ids=["req-0"],
+        batch_length=3,
+    )
+
+    assert torch.equal(
+        reordered,
+        torch.tensor([[10, 11], [-1, -1], [-1, -1]], dtype=torch.int32),
+    )
+
+
+def test_reorder_grammar_bitmask_handles_forward_narrower_than_batch():
+    """A prefill build can drop rows, so a request's persistent batch index can
+    exceed the forward's row count."""
+    bitmask = torch.tensor([[10, 11]], dtype=torch.int32)
+
+    # Persistent batch req-0..req-3; the forward kept only req-0 and req-2.
+    reordered = reorder_grammar_bitmask_for_tt_batch(
+        bitmask=bitmask,
+        structured_output_request_ids=["req-2"],
+        row_req_ids=["req-0", "req-2"],
+        batch_length=2,
+    )
+
+    assert torch.equal(
+        reordered,
+        torch.tensor([[-1, -1], [10, 11]], dtype=torch.int32),
     )


### PR DESCRIPTION
## Purpose

Follow-up hardening for the sample-time row identity cleanup after #67.

After #67 removed the mixed-batch filter, _prepare_model_inputs no longer emits a non-prefix subset of range(num_reqs) on the non-lane path. So this PR is no longer a functional bug fix for an active mixed-batch failure mode; it hardens the row-identity plumbing and makes the reorder and apply paths agree by construction.

## Modifications

- Keep request identity per forward row on TTModelInput via row_req_ids (non-lane path), so sample-time consumers do not re-derive row ownership from mutable live-batch indexing.
- Simplify grammar-bitmask reorder to a single request-id keyed row placement loop over forward rows:
  - reorder_grammar_bitmask_for_tt_batch now maps structured_output_request_ids to bitmask rows and places rows using row_req_ids.
  - This removes the older two-map req_id_to_index plus req_indices indirection.
- Use the same reorder contract at both call sites (build-time and sample-time), so both paths consume the same row identity source.
- In _apply_sampled_tokens_to_state captured branch:
  - replace if req_state is None: continue with an assert (loud invariant failure),
  - append to req_state.output_token_ids only when current_row is not None.
- _prepare_model_inputs return type is now -> TTModelInput (no optional return from this helper).

## Notes

- Non-lane decode still uses vectorized state application (req_ids=None) and remains unchanged.
- Lane path keeps slot-ordered semantics and reuses the same reorder primitive through lane-owned row identity.

## Test Plan

Host unit tests focused on:

- grammar-bitmask reorder for non-lane and lane index regimes,
- sample-time grammar dispatch,
- model-runner state application semantics in captured versus vectorized paths.

## Test Result

- [x] `pytest` -q tests/test_model_runner.py tests/test_sample_time_grammar.py tests/test_structured_output.py (26 passed)
- [x] pytest tests -q --ignore=tests/tt from earlier PR run (170 passed, 8 skipped)
- [x] CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/32725088044) (ignore BH errors - unrelated)