### PR TITLE
[ref] Guard device-sampling path w/ bitmask-flag assertion

### DIFF
--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1355,6 +1355,10 @@ class TTLaneInputBatch(InputBatch):
                 "Intermediate prefill rows must use host sampling so their "
                 "device RNG state is not advanced."
             )
+            assert model_input.grammar_bitmask[0] is None, (
+                "grammar bitmask is set but device sampling can't apply it"
+            )
+
             tokens = tt_out.reshape(-1) if isinstance(tt_out, torch.Tensor) else tt_out
             # Decode reads each scheduled slot; prefill returns one token per
             # scheduled request, already in row order.

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -2093,6 +2093,10 @@ class TTModelRunner:
                 # Capture logprobs for this DP rank
                 logprobs_per_dp.append(sampler_output.logprobs_tensors)
             else:  # sample on device
+                assert model_input.grammar_bitmask[dp_rank] is None, (
+                    "grammar bitmask is set but device sampling can't apply it"
+                )
+
                 # Normalize TT sampled tokens to 1D [sz]. Prefill can return [sz]
                 # while decode may return [sz, 1]; downstream logprobs packing
                 # expects a flat vector here.

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -102,6 +102,7 @@ def test_extract_output_device_decode_returns_scheduled_rows_in_order():
             enable_log_probs=torch.zeros(5, dtype=torch.bool)
         ),
         max_num_logprobs=[None],
+        grammar_bitmask=[None],
     )
 
     sampled, logprobs = batch.extract_output(
@@ -128,6 +129,7 @@ def test_extract_output_device_prefill_returns_front_packed_tokens():
         ),
         max_num_logprobs=[None],
         intermediate_prefill_mask=None,
+        grammar_bitmask=[None],
     )
 
     sampled, logprobs = batch.extract_output(


### PR DESCRIPTION
## TL;DR

Assert instead of silently dropping the grammar bitmask when device sampling runs.

## Details

`extract_output` (lane) and `_get_output_tokens` (non-lane) both read `perform_device_sampling` and `grammar_bitmask` from the same `model_input`, but the device-sampling branch returned before ever checking the bitmask. Today that's harmless: `check_perform_device_sampling` already forces host sampling whenever structured outputs are in play, so the two can't actually disagree, but nothing in the code enforced that. Added an assert on both paths so a future change that decouples them fails loudly instead of silently serving unconstrained tokens.

## Related Artifacts

Resolves #60 

## Validation

```text
$ pytest --ignore=tests/tt -q tests/
...
173 passed, 8 skipped, 16 warnings in 4.24s
```

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [ ] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
