### PR TITLE
[bug] Renormalize mamba cache fields when TT disables prefix caching

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -105,6 +105,33 @@ def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
     scheduler_config.long_prefill_token_threshold = 0
 
 
+def _renormalize_mamba_cache_config(vllm_config: "VllmConfig") -> None:
+    """Re-apply core's no-prefix-caching Mamba sizing after we turn it off.
+
+    ``MambaModelConfig.verify_and_update_config`` runs as the first statement of
+    ``VllmConfig.__post_init__``, far ahead of this platform hook, and sizes
+    ``mamba_block_size`` and ``mamba_cache_mode`` against prefix caching being
+    enabled. Disabling the flag afterwards leaves a pair that
+    ``VllmConfig.validate_mamba_block_size`` rejects outright, so mirror the
+    branch core takes when prefix caching is off: that validator reads
+    ``mamba_block_size == max_model_len`` as "unset".
+
+    ``block_size`` is deliberately left alone. TT reads it when it builds the KV
+    spec, and it already holds the value core's disabled branch computes.
+    """
+    cache_config = vllm_config.cache_config
+    if getattr(cache_config, "mamba_block_size", None) is None:
+        return
+
+    cache_config.mamba_cache_mode = "none"
+    cache_config.mamba_block_size = vllm_config.model_config.max_model_len
+    logger.info(
+        "Prefix caching is disabled, so mamba_block_size is reset to "
+        "max_model_len=%d and mamba_cache_mode to 'none'.",
+        cache_config.mamba_block_size,
+    )
+
+
 def _galaxy_generator_version() -> str | None:
     """Return the active Galaxy-generator model version, or None.
 
@@ -1137,6 +1164,7 @@ class TTPlatform(Platform):
                     "disabling it",
                     model_class.__module__,
                 )
+                _renormalize_mamba_cache_config(vllm_config)
             else:
                 # Check if the model architecture uses sliding window
                 uses_sliding_window = (
@@ -1148,6 +1176,7 @@ class TTPlatform(Platform):
                         "Prefix caching is not supported in TT backend for "
                         "models with sliding window, disabling it"
                     )
+                    _renormalize_mamba_cache_config(vllm_config)
 
         logger.info(
             "Automatic prefix caching is %s",


### PR DESCRIPTION
## TL;DR

The TT platform disables prefix caching after vLLM core has already sized the
Mamba cache fields against it, leaving a pair that
`VllmConfig.validate_mamba_block_size` rejects. Any GDN model (the Qwen3.5 / 3.6 / 3.8
family) run with prefix caching explicitly enabled fails to build its engine
config. The plugin's own `examples/offline_inference_tt.py` enables it on every
run, so that path is broken for the whole family.

## Details

Three pieces of config logic touch `enable_prefix_caching` and
`mamba_block_size`, at three different times:

1. `MambaModelConfig.verify_and_update_config` runs from
   `try_verify_and_update_config()`, the **first statement** of
   `VllmConfig.__post_init__`. It branches on `enable_prefix_caching`. With
   caching on, it sets `mamba_block_size = cache_config.block_size` and
   `mamba_cache_mode = "align"`.
2. `TTPlatform.check_and_update_config` runs ~300 lines later in the same
   `__post_init__`. It reads the TT model's
   `model_capabilities["supports_prefix_caching"]`, which `Qwen36ForCausalLM`
   declares as `False`, and turns the flag off.
3. `validate_mamba_block_size` is a Pydantic `@model_validator(mode="after")`,
   so it runs last and compares the two:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Value error, --mamba-block-size can only be set with --enable-prefix-caching
```

The no-prefix-caching configuration is perfectly satisfiable: core's disabled
branch sets `mamba_block_size = max_model_len`, which the validator
deliberately reads as "unset". Only the ordering is wrong.

This does not go away by fixing the arch registration, either. `is_hybrid`
comes from `_model_info`, resolved from `ModelConfig.architecture`, which is
computed before this hook prepends `"TT"` (see the comment in
`worker.py::_tt_kv_cache_spec_hook`). So core inspects upstream's
`Qwen3_5ForConditionalGeneration`, which is `IsHybrid`, and the whole Mamba
path runs regardless.

Applying the capability earlier is the theoretically nicer fix but has no hook:
`try_verify_and_update_config()` is the first statement of `__post_init__`, and
the only platform hook ahead of it, `pre_register_and_update()`, receives an
argument parser and does not know which model is loading. So this PR takes the
other route and re-applies core's disabled branch at the point we disable the
flag.

Two notes on the shape:

- `mamba_cache_mode` is reset alongside the block size. `"align"` mode carries
  its own downstream constraints that only hold while prefix caching is on
  (on upstream `v0.25.1`, `VllmConfig.validate_block_size` asserts
  `block_size <= max_num_batched_tokens` under align mode), so clearing the
  block size alone would just move the landmine.
- `cache_config.block_size` is deliberately **not** touched. It is the one
  field in this neighbourhood that TT actually reads, and core already gave it
  the value its disabled branch computes, because the enlargement came from the
  `mamba_cache_mode != "all"` branch of `HybridAttentionMambaModelConfig`.

Risk is bounded: `mamba_block_size` and `mamba_cache_mode` are never read on
the TT path. Every consumer in vLLM core is CUDA-side (the mamba/gdn/linear
attention backends, `layers/mamba/*`, and the `MambaSpec` branches of
`single_type_kv_cache_manager.py`), and `Qwen36ForCausalLM` has no
`get_kv_cache_spec` hook, so the plugin emits a single `FullAttentionSpec`. The
helper's early return means every non-hybrid model sees a byte-identical
config.

### When this triggers, and why CI missed it

Core already disables prefix caching for hybrid models on its own:
`EngineArgs.enable_prefix_caching` defaults to `None` and resolves to
`ModelConfig.is_prefix_caching_supported`, which returns `False` for
`attn_type == "hybrid"`. So a run that leaves the flag alone never reaches this
bug.

Reaching it needs prefix caching set **explicitly**, because an explicit value
skips that resolution. That is exactly what `examples/offline_inference_tt.py`
does on every run: it exposes only `--disable_prefix_caching` with the argparse
default `True`, and passes it into `LLM(...)`. Hence the reporter's repro.
`examples/server_example_tt.py` never sets the flag.

The trigger is the explicit flag, not the entry point: `vllm serve
--enable-prefix-caching` against a GDN model fails identically.

That divergence is why this was never caught. tt-metal's nightly
`vllm-model-tests.yaml` does run two tier-1 `Qwen/Qwen3.6-27B` legs on
`bh_quietbox_2`, but they launch `server_example_tt.py`, so prefix caching
resolves to `False` and the mamba branch is never entered. No leg in that matrix
enables the flag explicitly; the two legs named for prefix caching
(`Llama-3.1-8B-Instruct`, `Llama-3.3-70B-Instruct`) are named for the benchmark
sending `--random-prefix-len 128` and rely on the feature resolving on by
default, which happens only because Llama is a decoder model. The nightly log
confirms it: the platform's own "Prefix caching is not supported ... disabling
it" warning is absent (the block was skipped because the flag was already
false), there is no "Mamba cache mode ..." line at all, and the engine reports
`enable_prefix_caching=False` and constructs fine. No CI job runs
`offline_inference_tt.py`.

Follow-up worth filing separately: default that example's argument to `None` so
the offline and served paths resolve identically. It is a no-op for decoder
models, where `is_prefix_caching_supported` is already `True`.

## Related Artifacts

Resolves tenstorrent/vllm#473. The same fix is applied to the fork's vendored
copy in tenstorrent/vllm (PR linked from that issue), since the offending block
is byte-identical in both trees.

## Validation

`pre-commit run --files` on the changed file:

```text
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
```

No tests in this PR, deliberately. A host-only config test is the natural
regression guard here and is cheap, but the host-only suite is not executed by
any CI job (#19), so it would sit unrun. Worth adding once that is resolved.

Not run: any functional validation. `vllm` is not installable on the darwin dev
box this was written on, so nothing beyond lint was executed locally. The change
is a ~6-line config helper whose two written fields are never read on the TT
path, but it has not been exercised.

The repro to confirm, on 2 x Blackhole p150a as a `(1,2)` mesh
(`MESH_DEVICE=P300`):

```bash
python3 examples/offline_inference_tt.py \
  --model Qwen/Qwen3.8-27B --max_model_len 4096 --max_seqs_in_batch 8
```

This must now start without `--disable_prefix_caching`. @L-Beale-NZ offered a
reproducing setup on tenstorrent/vllm#473 and is the fastest path to confirming
it.

## Checklist

- [x] This PR is focused on a single logical change.
- [ ] I added or updated tests where applicable. Deliberately not: see Validation.
- [ ] I ran the relevant checks such as unit tests and Actions and recorded them above. Lint only; no pytest, no device run.
- [x] I updated documentation where applicable. N/A, no user-facing surface changes.
