### PR TITLE
Accept the tools argument in Gemma4ToolParser.__init__

### DIFF
--- a/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -43,8 +43,8 @@ class Gemma4ToolParser(ToolParser):
     and normalizes arguments into a JSON string for the OpenAI tool-call schema.
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
 
         # Streaming state.
         self.current_tool_name_sent: bool = False


### PR DESCRIPTION
vLLM constructs tool parsers as `tool_parser(tokenizer, request.tools)` since vllm-project/vllm#38029, so `Gemma4ToolParser`'s rigid `(self, tokenizer)` signature turns every `tool_choice:"auto"` request into an HTTP 400 (`__init__() takes 2 positional arguments but 3 were given`). This killed release run [32132213868](https://github.com/tenstorrent/tt-agentic-bringup-qb2/actions/runs/32132213868) and, via the workaround of dropping the tool-calling flags from the model spec, zeroed `swe_bench_verified` on run [32355285037](https://github.com/tenstorrent/tt-agentic-bringup-qb2/actions/runs/32355285037/job/96397565355). Root cause: tenstorrent/tt-agentic-bringup-qb2#2.

Fix: accept and forward extra constructor args, the same pattern `Gemma4ReasoningParser` already uses — the parser never consults the tool definitions.

Companion spec PR (land this one first): tenstorrent/tt-inference-server#5014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)