### PR TITLE
[feat] Log request IDs that are missing remapped bitmask row.

### DIFF
--- a/src/vllm_tt_plugin/structured_output.py
+++ b/src/vllm_tt_plugin/structured_output.py
@@ -8,9 +8,17 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from vllm_tt_plugin.logger import init_tt_logger
+
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.worker.gpu_input_batch import CachedRequestState
+
+
+logger = init_tt_logger(__name__)
+
+# Track missing request IDs we've already warned about, so each ID logs once.
+_warned_missing_request_ids: set[str] = set()
 
 
 def has_structured_outputs(
@@ -38,7 +46,11 @@ def reorder_grammar_bitmask_for_tt_batch(
     row_req_ids: Sequence[str | None],
     batch_length: int,
 ) -> torch.Tensor:
-    """Reorder scheduler bitmask rows into the TT batch layout."""
+    """Reorder scheduler bitmask rows into the TT batch layout.
+
+    Warn once per process for each request ID that is missing a remapped row.
+    """
+    # region Reorder rows
     grammar_bitmask_length = bitmask.shape[1]
     reordered_bitmask = torch.full(
         (batch_length, grammar_bitmask_length),
@@ -50,9 +62,39 @@ def reorder_grammar_bitmask_for_tt_batch(
     req_id_to_bitmask_row: dict[str, int] = {
         req_id: i for i, req_id in enumerate(structured_output_request_ids)
     }
+
+    # Collect placeable and placed IDs to log missing IDs if left.
+    placeable_ids = {
+        req_id
+        for req_id in row_req_ids[:batch_length]
+        if req_id is not None and req_id in req_id_to_bitmask_row
+    }
+    placed_ids: set[str] = set()
+
     for local_row, req_id in enumerate(row_req_ids[:batch_length]):
         scheduler_bitmask_row = req_id_to_bitmask_row.get(req_id)
         if scheduler_bitmask_row is not None:
             reordered_bitmask[local_row, :] = bitmask[scheduler_bitmask_row, :]
+            placed_ids.add(req_id)
+    # endregion
+
+    # region Log missing request IDs
+    missing_ids = placeable_ids - placed_ids
+    new_missing_ids = sorted(
+        req_id for req_id in missing_ids if req_id not in _warned_missing_request_ids
+    )
+    if new_missing_ids:
+        _warned_missing_request_ids.update(new_missing_ids)
+        msg = (
+            "Structured-output bitmask remap shortfall: %d new missing "
+            "request ID%s did not receive a bitmask row:\n%s"
+        )
+        args = [
+            len(new_missing_ids),
+            "" if len(new_missing_ids) == 1 else "s",
+            new_missing_ids,
+        ]
+        logger.warning(msg, *args)
+    # endregion
 
     return reordered_bitmask


### PR DESCRIPTION
## TL;DR

Add observability for grammar-bitmask remapping shortfalls by warning when a placeable structured-output request does not get a remapped bitmask row. To keep noise manageable, each missing request ID is warned only once per process.

## Details

When remapping grammar bitmask rows into TT batch order, a structured request can end up without a mapped row and silently fall back to unconstrained behavior. This change adds targeted logging in that path:

- Initializes plugin logger usage in structured_output.
- Tracks placeable IDs and actually placed IDs during remap.
- Computes missing IDs as placeable minus placed.
- Logs only newly seen missing request IDs (process-local dedupe), so repeated misses for the same request ID do not spam logs. E.g.:
  ```python
  WARNING 08-25 16:41:09 [tt/structured_output.py:96] Structured-output bitmask remap shortfall: 3 new missing request IDs did not receive a bitmask row:
  WARNING 08-25 16:41:09 [tt/structured_output.py:96] ['req-17', 'req-42', 'req-91']
  ```
- Keeps remap behavior unchanged; this is observability-only.

## Related Artifacts

Resolves #59

## Validation

Manual checks, because adding only log messages.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.