### PR TITLE
[bug] Skip a captured row whose request the engine already dropped

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -2259,11 +2259,12 @@ class TTModelRunner:
         captured_req_ids = req_ids
         for req_idx, req_id in enumerate(captured_req_ids):
             req_state = self.requests.get(req_id)
-            assert req_state is not None, (
-                "captured request missing from runner state while applying sampled "
-                f"tokens: req_id={req_id!r}"
-            )
-            if request_states is not None and req_state is not request_states[req_idx]:
+            # A deferred decode step can be applied after the engine finished
+            # and dropped its request, so a missing state is ordinary. Same for
+            # readmission under a reused id: the token has no live owner.
+            if req_state is None or (
+                request_states is not None and req_state is not request_states[req_idx]
+            ):
                 continue
 
             current_row = self.input_batch.req_id_to_index.get(req_id)


### PR DESCRIPTION
## TL;DR

An `assert` added in #68 fires during normal serving and kills the engine on the
first request turnover of any run with `sample_on_device_mode` set. It guards a
condition that is ordinary rather than an invariant break, so this replaces it
with a skip.

## Details

`_apply_sampled_tokens_to_state` reaches its captured-row branch from the async
decode completion path:

```
execute_model -> apply_ready_completed_decode_steps -> apply_completed_decode_step
```

That applies a decode step whose readback finished during a *later* engine step.
By then the engine may have finished and dropped the request the row belongs to,
so `self.requests.get(req_id)` legitimately returns `None`. #68 turned that into
a fatal assert.

Skipping is the correct handling, for four reasons:

- `apply_completed_decode_step` writes only runner-side state. The engine-facing
  output comes from `build_runner_output_from_completed_step`, so skipping
  withholds nothing from vLLM.
- Once a request is dropped, its row may already belong to a different request.
  Writing there is the corruption described in #61 and #57.
- The guard immediately below already skips when the request exists but is not in
  the batch (`current_row is not None`). A missing request state is a strictly
  stronger form of the same staleness, so this folds into the existing
  `request_states` check rather than adding a special case.
- It is what the code did before #68, and that behaviour is verified correct on
  device below.

Device sampling is the only requirement for the crash. Tracing and
`--async-scheduling` are irrelevant: the two-request probe crashes identically
with either one removed, and passes with `sample_on_device_mode` removed.

Deliberately not addressed here, to keep this to one logical change: the stale
comment at the top of this function that #61 reports, and the pre-#68
unconditional `output_token_ids.append` that #68 fixed and this PR leaves fixed.

## Related Artifacts

Regression from #68. Adjacent to #61 and #57, which examine the row-identity
reasoning in this same function, but neither reports this crash.

Found while investigating the `Llama-3.1-8B-Instruct with sampling-tests
[wh_llmbox]` structured-output failure in tt-metal nightly run 32792350903. That
separate flaky correctness failure is **not** fixed here, and it did not
reproduce on this hardware (9/9 clean rounds on the plugin commit the nightly
ran).

## Validation

Hardware: T3K, 4x n300 (8 Wormhole chips), `MESH_DEVICE=T3K`. Model
`meta-llama/Llama-3.1-8B-Instruct`, tt-metal `35c9b3ee1ca`, vLLM `0.25.1`.
Server config is the failing CI matrix entry's, verbatim:

```text
--async-scheduling --additional-config '{"tt":{"fabric_config":"FABRIC_1D","sample_on_device_mode":"all","trace_region_size":85000000}}'
```

Host checks:

```text
pytest tests -q --ignore=tests/tt
173 passed, 8 skipped

pre-commit run --files src/vllm_tt_plugin/model_runner.py
trailing-whitespace, end-of-file-fixer, check-merge-conflict, ruff-check, ruff-format: Passed
```

Device, two sequential single requests (the minimal repro), before the fix:

```text
req 1 -> OK: 'The quick brown fox jumps over the lazy dog.'
req 2 -> ERROR: EngineCore encountered an issue.
AssertionError: captured request missing from runner state while applying
  sampled tokens: req_id='chatcmpl-a17cb626437fce17-bffdf034'   <- request 1, finished
```

Reproduced 4/4: twice on the config above, once with `trace_region_size` removed,
once with `--async-scheduling` removed. With `sample_on_device_mode` removed it
does not occur (6/6 clean).

After the fix, 6/6 requests succeed and the completions match the
`sample_on_device_mode`-disabled control exactly:

```text
req 1 -> OK: 'The quick brown fox jumps over the lazy dog.'
req 2 -> OK: ' Paris\nQ: What is the capital of Australia? A: Canberra\nQ: What is the'
req 3..6 -> OK (same alternating pair)
asserts in server log: none
```

Device, structured-output benchmark (the CI gate), 32 prompts, 4 rounds against
one server after the plain benchmark, with the fix:

```text
round 1: correct_rate=100.0 tokens=3440
round 2: correct_rate=100.0 tokens=3509
round 3: correct_rate=100.0 tokens=3470
round 4: correct_rate=100.0 tokens=3469
```

Output-token counts near 3450 are the healthy signature; the failing CI run
emitted 30281 because nothing terminated.

## Checklist

- [x] This PR is focused on a single logical change.
- [ ] I added or updated tests where applicable. This change carries no host-test
      coverage; it is verified on device (below).
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.

AI assistance was used to investigate, implement and test this change.