### PR TITLE
[TT] Centralize async decode reload planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,9 @@ The execution model matches TT hardware characteristics:
   mechanism (no gather/scatter; ranks are fully independent).
 
 For a deeper walk-through of the scheduling and execution model, read
-`docs/SCHEDULING.md`.
+[`docs/SCHEDULING.md`](docs/SCHEDULING.md). The model-facing rules that make
+resident async decode safe are documented in
+[`docs/DECODE_RELOAD_CONTRACT.md`](docs/DECODE_RELOAD_CONTRACT.md).
 
 ## Single-Process Galaxy Serving
 

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -131,23 +131,28 @@ transition are still represented by `slot_remap`.
 
 Any transition requiring full inputs or sampling-state mutation drains pending
 decode work first. The plugin applies completed tokens and advances host
-positions before building authoritative inputs. An ordinary preemption does
-not invalidate an already-submitted decode: that forward completed against the
-old KV before the blocks were freed, so its token is appended. If that frame
-has not arrived yet, the scheduler leaves the preempted request waiting while
-its output placeholder remains outstanding. Once the frame is accounted for,
-resumed prefill replays the accepted token and legitimately emits the following
-token with a fresh placeholder. This also prevents a discarded replay sample
-from advancing the request's seeded host or device RNG state.
+positions before building authoritative inputs. Finalization and host-state
+application deliberately straddle the scheduler update: the older step is
+finalized while its submission layout is still intact because lane output
+extraction reads that layout, then its token is applied after the next
+`SchedulerOutput` identifies finished requests and the exact forced-reset
+discard boundary. An ordinary preemption does not invalidate an
+already-submitted decode: that forward completed against the old KV before the
+blocks were freed, so its token is appended. If that frame has not arrived yet,
+the scheduler leaves the preempted request waiting while its output placeholder
+remains outstanding. Once the frame is accounted for, resumed prefill replays
+the accepted token and legitimately emits the following token with a fresh
+placeholder. This also prevents a discarded replay sample from advancing the
+request's seeded host or device RNG state.
 Finished-request rows are suppressed. A wholesale
 `reset_prefix_cache(reset_running_requests=True)` is different: the scheduler
 marks the exact number of outstanding frames stale, the runner omits only those
 frames from cached host state, and their published rows remain intact so
 vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
 valid output. Under upstream async scheduling, every synchronously sampled
-output—including final prefill and contract-v0 synchronous decode—joins the
-same deferred host-state queue as async decode readbacks; otherwise a reset
-could count a synchronously applied frame that the runner had no way to reject.
+final-prefill output joins the same deferred host-state queue as async decode
+readbacks; otherwise a reset could count a synchronously applied frame that the
+runner had no way to reject.
 Page-table-only refresh remains overlap-safe because page tables come from the
 current scheduler allocation even when token and position tensors are stale.
 
@@ -258,8 +263,11 @@ adapter's previous overlap behavior, and emits a one-time warning. Existing
 standalone-plugin `slot_remap` delivery in both sampling modes is unchanged.
 The exact v0 drain points are also preserved: new v1 residency, sampling-mode,
 and context-phase checks do not make a legacy adapter drain more often.
-Standard-DP v0 runners remain on their prior synchronous path; independent
-per-rank overlap is enabled only after the loaded adapter negotiates version 1.
+Contract version does not select async scheduling. The platform gates it on
+`supports_async_decode`; both standard-DP ranks and lane-DP runners have a local
+`data_parallel_size` of one and retain their existing eligibility. TT rejects
+the remaining upstream case that would expose `data_parallel_size > 1` to a
+runner: standard-DP MoE.
 
 | Plugin | tt-metal adapter | Result |
 | --- | --- | --- |

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -130,9 +130,16 @@ transition are still represented by `slot_remap`.
 | Adapter without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring full inputs or sampling-state mutation drains pending
-decode work first. The plugin applies the completed token and advances the host
-position before building authoritative inputs. It rejects an older result for
-a request the current scheduler output finished, preempted, or resumed.
+decode work first. The plugin applies completed tokens and advances host
+positions before building authoritative inputs. An ordinary preemption does
+not invalidate an already-submitted decode: that forward completed against the
+old KV before the blocks were freed, so its token is appended and the resumed
+prefill replays it. Finished-request rows are suppressed. A wholesale
+`reset_prefix_cache(reset_running_requests=True)` is different: the scheduler
+marks the exact number of outstanding frames stale, the runner omits only those
+frames from cached host state, and their published rows remain intact so
+vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
+valid output.
 Page-table-only refresh remains overlap-safe because page tables come from the
 current scheduler allocation even when token and position tensors are stale.
 
@@ -156,8 +163,9 @@ sampled token `t_k` and the resident position is the position at which `t_k`
 must be consumed by step `k+1`.
 
 The base case is a full reload. Before issuing it, the runner finalizes the
-older step, rejects rows invalidated by current scheduler lifecycle events,
-and applies accepted tokens to host request state. It then copies the
+older step, suppresses finished rows, excludes explicitly marked forced-reset
+frames from runner state, and applies every accepted token—including an
+ordinary preemption's in-flight token—to host request state. It then copies the
 authoritative token, position, layout, and requested sampling state.
 
 For the induction step, a steady device decode issues no full or
@@ -173,10 +181,11 @@ invariant and re-establish it through a drain and full reload.
 
 Upstream vLLM replaces each external request id with an internal id carrying a
 random suffix before scheduling, so an ordinary abort and resubmit does not
-reuse a runner id. Rejection is keyed on scheduler lifecycle events rather than
-request-object snapshots: finished, preempted, and resumed ids invalidate the
-outstanding result. Invalid output rows are emptied before the scheduler
-consumes them, preventing both a host-state append and an extra emitted token.
+reuse a runner id. Finished IDs suppress both runner-state append and published
+output. Ordinary preempted/resumed IDs suppress neither. Forced-reset discard
+counts are scheduler-owned sidecar metadata on `SchedulerOutput`; they suppress
+only runner-state append for the newest counted frames, while leaving their
+published rows nonempty for vLLM's discard accounting.
 
 ## Requirements for `decode_input_update_contract = 1`
 

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -6,6 +6,8 @@ the host tensors are authoritative. A contract-aware tt-metal adapter declares
 `decode_input_update_contract = 1` and receives four independent boolean
 commands on every decode:
 
+## Commands
+
 | Command | Required action |
 | --- | --- |
 | `reload_inputs` | Copy every forward input: token, position, RoPE inputs, and page tables. |
@@ -24,6 +26,15 @@ These are commands, not hints. A version-1 adapter must not replace them with
 model-local sampling-mode checks, tensor comparisons, or prior-call
 heuristics.
 
+### Command defaults
+
+The plugin sends all four commands explicitly on every version-1 decode. If an
+adapter exposes defaults for direct callers, only the host-authoritative
+defaults are safe: `reload_inputs=True` and the other three commands `False`.
+An adapter that accepts arbitrary `**kwargs` must still reject the legacy
+`reset_batch` keyword after declaring version 1, so an older plugin fails
+loudly instead of silently taking an unintended reload path.
+
 `decode_layout_changed` is internal plugin lifecycle state. The runner
 translates it into the four commands for version 1 and into the historical
 `reset_batch` keyword for a legacy device-sampling call. It is not forwarded to
@@ -38,6 +49,29 @@ when sampling runs on the host. Every slot-owning subsystem, including a
 temporarily dormant device sampler, must apply the remap exactly once before it
 reads that state. A full forward-input reload does not implicitly remap model
 or sampling state.
+
+The indices belong to the submission that carries them. For ordinary and
+standard-DP execution they are local to that independent runner's slot space.
+For single-process lane-DP they index the one merged lane batch. There is no
+cross-rank/global standard-DP remap and no rebasing between ranks.
+
+Two superficially reasonable implementations are wrong:
+
+1. **Deliver only during device sampling.** Host sampling can still compact or
+   reassign rows. Withholding the remap leaves model-owned recurrent,
+   convolution, or cached RoPE state attached to the previous request.
+2. **Apply only inside the active device sampler.** Delivering the remap during
+   host sampling is insufficient if dormant seed/RNG/penalty state ignores it.
+   A later return to device sampling then resumes another request's state.
+
+Every slot-addressable subsystem must therefore consume each supplied remap
+exactly once on the accepted decode that carries it. State that is not
+addressable by vLLM slot is exempt because it cannot be moved. The known
+example is unseeded on-device RNG: its
+state lives in per-core hardware PRNG registers with no slot-to-slot gather
+primitive. The adapter must document such state and reset/reinitialize it on a
+commanded sampling-state transition; the exemption never permits silently
+ignoring state that does have a move primitive.
 
 The plugin derives a remap while building the input but advances its state-slot
 ownership map only after `decode_forward` accepts the submission. Advancing it
@@ -135,11 +169,10 @@ invariant and re-establish it through a drain and full reload.
 
 Upstream vLLM replaces each external request id with an internal id carrying a
 random suffix before scheduling, so an ordinary abort and resubmit does not
-reuse a runner id. Rejection is nevertheless keyed on scheduler lifecycle
-events, and the standalone runner retains its cached-request-object snapshot as
-defense for an internal caller that bypasses input processing or an improbable
-id collision. Invalid output rows are emptied before the scheduler consumes
-them, preventing both a host-state append and an extra emitted token.
+reuse a runner id. Rejection is keyed on scheduler lifecycle events rather than
+request-object snapshots: finished, preempted, and resumed ids invalidate the
+outstanding result. Invalid output rows are emptied before the scheduler
+consumes them, preventing both a host-state append and an extra emitted token.
 
 ## Requirements for `decode_input_update_contract = 1`
 
@@ -150,12 +183,17 @@ advertises async decode:
    unsupported combinations loudly instead of adding a heuristic fallback.
 2. **Sampling-state ordering:** apply slot remaps before parameter/state reset;
    reset RNG and penalty state only when requested; advance seed state once per
-   sampled token; initialize it even when the requested seed is `None`.
+   sampled token; initialize and upload it even when both the requested and
+   cached seed are `None`. Explicitly seeded, slot-addressable counters follow
+   the request through a remap. Unseeded per-core PRNG state cannot move and is
+   instead reinitialized on a commanded reset.
 3. **Complete slot remapping:** apply each remap exactly once to all persistent
    state indexed by the vLLM slot, including model recurrent/conv state and a
    dormant device sampler during host sampling.
 4. **Stable-buffer lifetime:** keep persistent forward and sampling buffers
    valid through readback and until an explicit command replaces them.
+
+### Partial adapters
 
 An adapter that structurally requires `reload_inputs=True` can still implement
 version 1 if it leaves `supports_async_decode` false and rejects any unsupported
@@ -209,6 +247,22 @@ This permits the plugin change to merge before tt-metal adapters are migrated.
 `supports_async_decode` remains independent of protocol version: it certifies
 resident decode behavior, while `decode_input_update_contract` selects the call
 interface.
+
+### Marker placement and inheritance
+
+The marker belongs on the vLLM-facing generator implementation that executes
+the commands. Subclasses inherit both the implementation and marker. Moving a
+marker onto a shared base changes the opt-in set, so every existing subclass
+must be audited first. A subclass that overrides `decode_forward` no longer
+inherits the behavior the marker attests to: the override must execute every
+command itself or set `decode_input_update_contract = 0` and remain legacy.
+Merely re-declaring the marker does not make an override conformant.
+
+Versions greater than 1 must remain backward-compatible supersets of version
+1. A later adapter cannot require a new keyword from this plugin because there
+is no reverse handshake. Any added command must be keyword-only with a default
+that reproduces version-1 behavior; a breaking interface needs a distinct
+negotiation key or supported-version range.
 
 Standard multi-process DP needs no TT-specific negotiation. Upstream vLLM runs
 one independent scheduler, plugin runner, model, TT mesh, and async submission

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -139,7 +139,10 @@ prefill replays it. Finished-request rows are suppressed. A wholesale
 marks the exact number of outstanding frames stale, the runner omits only those
 frames from cached host state, and their published rows remain intact so
 vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
-valid output.
+valid output. Under upstream async scheduling, every synchronously sampled
+output—including final prefill and contract-v0 synchronous decode—joins the
+same deferred host-state queue as async decode readbacks; otherwise a reset
+could count a synchronously applied frame that the runner had no way to reject.
 Page-table-only refresh remains overlap-safe because page tables come from the
 current scheduler allocation even when token and position tensors are stale.
 

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -1,0 +1,224 @@
+# TT Decode Reload Contract
+
+Async device sampling deliberately allows the plugin's host token state to
+trail the TT device by one decode step. Only the plugin runner knows whether
+the host tensors are authoritative. A contract-aware tt-metal adapter declares
+`decode_input_update_contract = 1` and receives four independent boolean
+commands on every decode:
+
+| Command | Required action |
+| --- | --- |
+| `reload_inputs` | Copy every forward input: token, position, RoPE inputs, and page tables. |
+| `reload_page_table` | Copy only page-table inputs. Ignore when `reload_inputs` is true. |
+| `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
+| `reset_sampling_state` | Rebuild mutable penalty and RNG state for the current request layout. |
+
+`reload_inputs` already includes page tables, so the legal forward-input modes
+are "everything", "page tables only", and "nothing". The plugin asserts that
+`reload_inputs` and `reload_page_table` are never both true. It also asserts
+that `reset_sampling_state` implies `reload_inputs`, because a sampler may align
+seed counters from host positions only on a step that makes those positions
+authoritative.
+
+These are commands, not hints. A version-1 adapter must not replace them with
+model-local sampling-mode checks, tensor comparisons, or prior-call
+heuristics.
+
+`decode_layout_changed` is internal plugin lifecycle state. The runner
+translates it into the four commands for version 1 and into the historical
+`reset_batch` keyword for a legacy device-sampling call. It is not forwarded to
+a version-1 adapter.
+
+`slot_remap` is data rather than reload policy. `remap[i] = j` means row `i`
+reads the state currently in slot `j`. It is an absolute permutation, not a
+delta, and applying it twice is incorrect. The standalone plugin sends it for
+both host- and device-sampling decode, including to legacy adapters, because
+model-owned recurrent, convolution, or RoPE state remains slot-indexed even
+when sampling runs on the host. Every slot-owning subsystem, including a
+temporarily dormant device sampler, must apply the remap exactly once before it
+reads that state. A full forward-input reload does not implicitly remap model
+or sampling state.
+
+The plugin derives a remap while building the input but advances its state-slot
+ownership map only after `decode_forward` accepts the submission. Advancing it
+earlier would make a raised call claim a gather the device never ran and would
+derive every later remap from a false layout. The sticky layout-change signal is
+retired at the same accepted-submission boundary.
+
+Prefill placement is explicit through `empty_slots`: it initializes a new or
+resumed request's state in its scheduler-owned destination slot. Lane-DP keeps
+live decode rows stable, so merely omitting a live request from a prefill step
+does not constitute a layout change.
+
+A remap cannot express slot reuse. A newly admitted request has no predecessor
+state to gather, so reuse is reported by `decode_layout_changed`; the resulting
+sampling-state reset and model-side authoritative rebuild initialize that slot.
+
+## Modes
+
+- **Host sampling:** tt-metal returns logits and vLLM selects the token. Host
+  token and position tensors are authoritative, so every decode fully reloads
+  forward inputs.
+- **Device sampling:** tt-metal selects the token. A supporting adapter writes
+  the selected token into the persistent token buffer for the next decode and
+  advances its persistent position in the forward trace.
+- **Transition decode:** the first decode; the first decode after prefill; a
+  request-layout, sampling-mode, or resume transition. Pending work is drained
+  and applied first, then host-authoritative inputs and required sampling state
+  are reloaded.
+- **Chunked-prefill continuation:** a later prompt chunk for a request already
+  present in the persistent batch. Membership can remain unchanged, so the
+  plugin classifies it using the scheduler's context-phase marker rather than
+  a token-count heuristic. A final prompt chunk can contain one token, while a
+  speculative decode may schedule several.
+- **Steady device decode:** request layout and sampling mode remain unchanged
+  after a valid device-sampling decode. Token and position stay resident and a
+  full input reload is omitted.
+- **Page-table-only refresh:** a steady device decode whose allocated KV block
+  mapping changed. Only page-table trace inputs are copied; token, position,
+  and RoPE state remain untouched.
+
+## Transition table
+
+| Transition | Inputs | Page only | Sampling params | Sampling state |
+| --- | ---: | ---: | ---: | ---: |
+| First decode or prefill → decode | reload | no | reload on device | reset on device |
+| Request add/remove/reuse/condense, preemption, or resume | reload | no | reload on device | reset on device |
+| Chunked-prefill continuation | reload | no | reload on device | reset on device |
+| Host → device sampling | reload | no | reload | reset |
+| Steady host sampling | reload every step | no | n/a | n/a |
+| Steady device sampling | keep resident | only if allocation changed | keep | keep |
+| Decode tracing disabled | reload every step | no | on transition | on transition |
+| Adapter without `supports_async_decode` | reload every step | no | on transition | on transition |
+
+Any transition requiring full inputs or sampling-state mutation drains pending
+decode work first. The plugin applies the completed token and advances the host
+position before building authoritative inputs. It rejects an older result for
+a request the current scheduler output finished, preempted, or resumed.
+Page-table-only refresh remains overlap-safe because page tables come from the
+current scheduler allocation even when token and position tensors are stale.
+
+## Host input authority
+
+The `tokens` and `start_pos` arguments are authoritative only when
+`reload_inputs` is true. When it is false they are deliberately one step
+behind. An adapter must derive nothing from them—not forward inputs, sampling
+state, or RNG counters.
+
+For example, an adapter that ties seeded sampling to the absolute decode
+position must align its counter from `start_pos` on a reloading step and then
+advance its resident counter exactly once per sampled token. Re-reading stale
+`start_pos` on a steady step makes a seeded stream depend on async readback
+timing and batch composition.
+
+## Correctness invariant
+
+Immediately after device-sampling step `k`, the resident token slot contains
+sampled token `t_k` and the resident position is the position at which `t_k`
+must be consumed by step `k+1`.
+
+The base case is a full reload. Before issuing it, the runner finalizes the
+older step, rejects rows invalidated by current scheduler lifecycle events,
+and applies accepted tokens to host request state. It then copies the
+authoritative token, position, layout, and requested sampling state.
+
+For the induction step, a steady device decode issues no full or
+sampling-state reload. The trace consumes resident `t_k`, writes exactly one KV
+position, advances position once, and sampling writes `t_(k+1)` back to the
+persistent token slot. Readback is observational and may finish later. A
+page-table-only copy can change KV addressing but cannot overwrite resident
+token or position state.
+
+Host sampling always returns to the base case. Prefill and request-layout,
+sampling-mode, preemption, and resume transitions also break the steady
+invariant and re-establish it through a drain and full reload.
+
+Upstream vLLM replaces each external request id with an internal id carrying a
+random suffix before scheduling, so an ordinary abort and resubmit does not
+reuse a runner id. Rejection is nevertheless keyed on scheduler lifecycle
+events, and the standalone runner retains its cached-request-object snapshot as
+defense for an internal caller that bypasses input processing or an improbable
+id collision. Invalid output rows are emptied before the scheduler consumes
+them, preventing both a host-state append and an extra emitted token.
+
+## Requirements for `decode_input_update_contract = 1`
+
+Every version-1 adapter must satisfy these requirements, whether or not it
+advertises async decode:
+
+1. **Exact command handling:** honor all four commands independently and reject
+   unsupported combinations loudly instead of adding a heuristic fallback.
+2. **Sampling-state ordering:** apply slot remaps before parameter/state reset;
+   reset RNG and penalty state only when requested; advance seed state once per
+   sampled token; initialize it even when the requested seed is `None`.
+3. **Complete slot remapping:** apply each remap exactly once to all persistent
+   state indexed by the vLLM slot, including model recurrent/conv state and a
+   dormant device sampler during host sampling.
+4. **Stable-buffer lifetime:** keep persistent forward and sampling buffers
+   valid through readback and until an explicit command replaces them.
+
+An adapter that structurally requires `reload_inputs=True` can still implement
+version 1 if it leaves `supports_async_decode` false and rejects any unsupported
+resident combination. Silently treating `reload_inputs=False` as true is not a
+compatible fallback.
+
+## Additional requirements for `supports_async_decode`
+
+For a version-1 adapter, set
+`model_capabilities["supports_async_decode"] = True` only when all of the
+following are true:
+
+1. **Split submission and readback:** `decode_forward(...,
+   read_from_device=False)` submits without synchronizing, and
+   `read_decode_output(..., async_read=True)` can read that exact submission
+   later. Readback must not sample, advance position, or mutate decode state.
+2. **Persistent token feedback:** device sampling writes the selected token
+   into the same persistent token buffer consumed by the next decode.
+3. **One position advance:** each successful decode forward advances the
+   resident position exactly once. Sampling and readback do not advance it.
+4. **Independent page-table refresh:** changed page tables can be uploaded
+   without copying or rebinding token, position, or RoPE inputs.
+5. **Host input authority:** treat `tokens`, `start_pos`, and RoPE host inputs
+   as stale whenever `reload_inputs=False`; derive no forward or sampling state
+   from them on that step.
+
+The capability is fail-closed. Without it, the plugin disables async scheduling
+for that model and requests a full forward-input reload on every version-1
+decode.
+
+## Negotiation and rollout
+
+Adapters opt in with `decode_input_update_contract = 1`. Missing or zero means
+legacy mode: the plugin omits the four new keywords, translates the internal
+layout signal to `reset_batch` on device-sampling calls, preserves the
+adapter's previous overlap behavior, and emits a one-time warning. Existing
+standalone-plugin `slot_remap` delivery in both sampling modes is unchanged.
+The exact v0 drain points are also preserved: new v1 residency, sampling-mode,
+and context-phase checks do not make a legacy adapter drain more often.
+Standard-DP v0 runners remain on their prior synchronous path; independent
+per-rank overlap is enabled only after the loaded adapter negotiates version 1.
+
+| Plugin | tt-metal adapter | Result |
+| --- | --- | --- |
+| Old | Legacy / version 0 | Existing behavior |
+| New | Legacy / version 0 | Compatibility behavior plus warning |
+| New | Version 1+ | Explicit commands and eligible resident overlap |
+| Old | Strict version 1 | Unsupported: required commands are absent |
+
+This permits the plugin change to merge before tt-metal adapters are migrated.
+`supports_async_decode` remains independent of protocol version: it certifies
+resident decode behavior, while `decode_input_update_contract` selects the call
+interface.
+
+Standard multi-process DP needs no TT-specific negotiation. Upstream vLLM runs
+one independent scheduler, plugin runner, model, TT mesh, and async submission
+stream per DP rank, so each rank plans and applies its own reload commands. No
+rank combines inputs or votes on overlap. Single-process lane-DP is separate:
+it submits one merged stable-slot device batch and uses the lane coordinator's
+exact `TTStepPlan` layout transition. It likewise has no process gather/scatter
+or cross-rank vote.
+
+The paired tt-metal implementation initializes decode-only seed state
+unconditionally when `reset_sampling_state=True`, including `seed=None`. It
+implements the same correctness fix as tt-metal#51556 but does not depend on
+that PR.

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -134,12 +134,11 @@ decode work first. The plugin applies completed tokens and advances host
 positions before building authoritative inputs. An ordinary preemption does
 not invalidate an already-submitted decode: that forward completed against the
 old KV before the blocks were freed, so its token is appended. If that frame
-arrives before rescheduling, resumed prefill replays it and legitimately emits
-the following token. If rescheduling happens first, resumed prefill replays
-only the committed sequence and recomputes the same logical token; vLLM does
-not reserve a second placeholder for that duplicate, so the scheduler marks
-that exact resumed step and the plugin suppresses its context-phase row while
-retaining the older valid frame.
+has not arrived yet, the scheduler leaves the preempted request waiting while
+its output placeholder remains outstanding. Once the frame is accounted for,
+resumed prefill replays the accepted token and legitimately emits the following
+token with a fresh placeholder. This also prevents a discarded replay sample
+from advancing the request's seeded host or device RNG state.
 Finished-request rows are suppressed. A wholesale
 `reset_prefix_cache(reset_running_requests=True)` is different: the scheduler
 marks the exact number of outstanding frames stale, the runner omits only those
@@ -192,10 +191,9 @@ Upstream vLLM replaces each external request id with an internal id carrying a
 random suffix before scheduling, so an ordinary abort and resubmit does not
 reuse a runner id. Finished IDs suppress both runner-state append and published
 output. Ordinary preemption never suppresses the older submitted frame. A
-resumed request suppresses only its own context-phase result when the scheduler
-observed an older placeholder before rescheduling, meaning that replay still
-shares the older frame's reservation. The signal is carried on that submitted
-prefill, not inferred later from the request's status.
+preempted request cannot resume while it still owns an output placeholder, so
+resumed prefill always includes the accepted frame in its replay history and
+owns a new reservation for its sampled result.
 Forced-reset discard counts are scheduler-owned sidecar metadata on
 `SchedulerOutput`; they suppress only runner-state append for the newest
 counted frames, while leaving their published rows nonempty for vLLM's discard

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -133,8 +133,14 @@ Any transition requiring full inputs or sampling-state mutation drains pending
 decode work first. The plugin applies completed tokens and advances host
 positions before building authoritative inputs. An ordinary preemption does
 not invalidate an already-submitted decode: that forward completed against the
-old KV before the blocks were freed, so its token is appended and the resumed
-prefill replays it. Finished-request rows are suppressed. A wholesale
+old KV before the blocks were freed, so its token is appended. If that frame
+arrives before rescheduling, resumed prefill replays it and legitimately emits
+the following token. If rescheduling happens first, resumed prefill replays
+only the committed sequence and recomputes the same logical token; vLLM does
+not reserve a second placeholder for that duplicate, so the scheduler marks
+that exact resumed step and the plugin suppresses its context-phase row while
+retaining the older valid frame.
+Finished-request rows are suppressed. A wholesale
 `reset_prefix_cache(reset_running_requests=True)` is different: the scheduler
 marks the exact number of outstanding frames stale, the runner omits only those
 frames from cached host state, and their published rows remain intact so
@@ -185,10 +191,15 @@ invariant and re-establish it through a drain and full reload.
 Upstream vLLM replaces each external request id with an internal id carrying a
 random suffix before scheduling, so an ordinary abort and resubmit does not
 reuse a runner id. Finished IDs suppress both runner-state append and published
-output. Ordinary preempted/resumed IDs suppress neither. Forced-reset discard
-counts are scheduler-owned sidecar metadata on `SchedulerOutput`; they suppress
-only runner-state append for the newest counted frames, while leaving their
-published rows nonempty for vLLM's discard accounting.
+output. Ordinary preemption never suppresses the older submitted frame. A
+resumed request suppresses only its own context-phase result when the scheduler
+observed an older placeholder before rescheduling, meaning that replay still
+shares the older frame's reservation. The signal is carried on that submitted
+prefill, not inferred later from the request's status.
+Forced-reset discard counts are scheduler-owned sidecar metadata on
+`SchedulerOutput`; they suppress only runner-state append for the newest
+counted frames, while leaving their published rows nonempty for vLLM's discard
+accounting.
 
 ## Requirements for `decode_input_update_contract = 1`
 

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -144,15 +144,24 @@ remains outstanding. Once the frame is accounted for, resumed prefill replays
 the accepted token and legitimately emits the following token with a fresh
 placeholder. This also prevents a discarded replay sample from advancing the
 request's seeded host or device RNG state.
-Finished-request rows are suppressed. A wholesale
-`reset_prefix_cache(reset_running_requests=True)` is different: the scheduler
-marks the exact number of outstanding frames stale, the runner omits only those
+Late rows for a request ID already reported finished are suppressed. Such a row
+can have been submitted before an earlier row ended the request, or can have
+raced with an abort; the row that actually finished the request was already
+accepted and is not discarded. A forced prefix-cache reset is different.
+Ordinary `reset_prefix_cache()` only succeeds when running requests no longer
+hold KV blocks. `reset_prefix_cache(reset_running_requests=True)` instead
+preempts live requests so all KV blocks can be freed. This wholesale path is a
+control-plane operation used by an explicit live-request reset or by
+pause/sleep with cache clearing; normal request completion, scheduler
+preemption, and cache eviction do not enter it. As part of the teardown, the
+scheduler resumes each request from committed token history and marks the
+exact number of its outstanding frames stale. The runner omits only those
 frames from cached host state, and their published rows remain intact so
 vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
-valid output. Under upstream async scheduling, every synchronously sampled
-final-prefill output joins the same deferred host-state queue as async decode
-readbacks; otherwise a reset could count a synchronously applied frame that the
-runner had no way to reject.
+valid output. Under upstream async scheduling, every
+synchronously sampled final-prefill output joins the same deferred host-state
+queue as async decode readbacks; otherwise a reset could count a synchronously
+applied frame that the runner had no way to reject.
 Page-table-only refresh remains overlap-safe because page tables come from the
 current scheduler allocation even when token and position tensors are stale.
 
@@ -176,10 +185,11 @@ sampled token `t_k` and the resident position is the position at which `t_k`
 must be consumed by step `k+1`.
 
 The base case is a full reload. Before issuing it, the runner finalizes the
-older step, suppresses finished rows, excludes explicitly marked forced-reset
-frames from runner state, and applies every accepted token—including an
-ordinary preemption's in-flight token—to host request state. It then copies the
-authoritative token, position, layout, and requested sampling state.
+older step, suppresses late rows for request IDs already reported finished,
+excludes explicitly marked forced-reset frames from runner state, and applies
+every accepted token—including an ordinary preemption's in-flight token—to
+host request state. It then copies the authoritative token, position, layout,
+and requested sampling state.
 
 For the induction step, a steady device decode issues no full or
 sampling-state reload. The trace consumes resident `t_k`, writes exactly one KV

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -84,9 +84,13 @@ resumed request's state in its scheduler-owned destination slot. Lane-DP keeps
 live decode rows stable, so merely omitting a live request from a prefill step
 does not constitute a layout change.
 
-A remap cannot express slot reuse. A newly admitted request has no predecessor
-state to gather, so reuse is reported by `decode_layout_changed`; the resulting
-sampling-state reset and model-side authoritative rebuild initialize that slot.
+A remap describes only continuing ownership: new slot `i` takes existing state
+from old slot `j`. It has no "new request / no predecessor" sentinel. When a
+newly admitted request takes a slot formerly owned by another request, prefill
+and `empty_slots` initialize its model state. `decode_layout_changed` records
+the transition so the next device-sampling decode rebuilds sampling state from
+authoritative parameters. Continuing requests that move during the same
+transition are still represented by `slot_remap`.
 
 ## Modes
 

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -144,10 +144,11 @@ remains outstanding. Once the frame is accounted for, resumed prefill replays
 the accepted token and legitimately emits the following token with a fresh
 placeholder. This also prevents a discarded replay sample from advancing the
 request's seeded host or device RNG state.
-Late rows for a request ID already reported finished are suppressed. Such a row
-can have been submitted before an earlier row ended the request, or can have
-raced with an abort; the row that actually finished the request was already
-accepted and is not discarded. A forced prefix-cache reset is different.
+Late results for a request ID already reported finished are suppressed. Such a
+result can have been submitted before an earlier result ended the request, or
+can have raced with an abort; the result that actually finished the request was
+already accepted and is not discarded. A forced prefix-cache reset is
+different.
 Ordinary `reset_prefix_cache()` only succeeds when running requests no longer
 hold KV blocks. `reset_prefix_cache(reset_running_requests=True)` instead
 preempts live requests so all KV blocks can be freed. This wholesale path is a
@@ -156,7 +157,7 @@ pause/sleep with cache clearing; normal request completion, scheduler
 preemption, and cache eviction do not enter it. As part of the teardown, the
 scheduler resumes each request from committed token history and marks the
 exact number of its outstanding frames stale. The runner omits only those
-frames from cached host state, and their published rows remain intact so
+frames from cached host state, and their published results remain intact so
 vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
 valid output. Under upstream async scheduling, every
 synchronously sampled final-prefill output joins the same deferred host-state
@@ -185,7 +186,7 @@ sampled token `t_k` and the resident position is the position at which `t_k`
 must be consumed by step `k+1`.
 
 The base case is a full reload. Before issuing it, the runner finalizes the
-older step, suppresses late rows for request IDs already reported finished,
+older step, suppresses late results for request IDs already reported finished,
 excludes explicitly marked forced-reset frames from runner state, and applies
 every accepted token—including an ordinary preemption's in-flight token—to
 host request state. It then copies the authoritative token, position, layout,

--- a/docs/DECODE_RELOAD_CONTRACT.md
+++ b/docs/DECODE_RELOAD_CONTRACT.md
@@ -130,39 +130,42 @@ transition are still represented by `slot_remap`.
 | Adapter without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring full inputs or sampling-state mutation drains pending
-decode work first. The plugin applies completed tokens and advances host
-positions before building authoritative inputs. Finalization and host-state
-application deliberately straddle the scheduler update: the older step is
-finalized while its submission layout is still intact because lane output
-extraction reads that layout, then its token is applied after the next
-`SchedulerOutput` identifies finished requests and the exact forced-reset
-discard boundary. An ordinary preemption does not invalidate an
-already-submitted decode: that forward completed against the old KV before the
-blocks were freed, so its token is appended. If that frame has not arrived yet,
-the scheduler leaves the preempted request waiting while its output placeholder
-remains outstanding. Once the frame is accounted for, resumed prefill replays
-the accepted token and legitimately emits the following token with a fresh
-placeholder. This also prevents a discarded replay sample from advancing the
-request's seeded host or device RNG state.
-Late results for a request ID already reported finished are suppressed. Such a
-result can have been submitted before an earlier result ended the request, or
-can have raced with an abort; the result that actually finished the request was
-already accepted and is not discarded. A forced prefix-cache reset is
-different.
-Ordinary `reset_prefix_cache()` only succeeds when running requests no longer
-hold KV blocks. `reset_prefix_cache(reset_running_requests=True)` instead
-preempts live requests so all KV blocks can be freed. This wholesale path is a
-control-plane operation used by an explicit live-request reset or by
-pause/sleep with cache clearing; normal request completion, scheduler
-preemption, and cache eviction do not enter it. As part of the teardown, the
-scheduler resumes each request from committed token history and marks the
-exact number of its outstanding frames stale. The runner omits only those
-frames from cached host state, and their published results remain intact so
-vLLM's `async_tokens_to_discard` consumes the stale frames rather than the next
-valid output. Under upstream async scheduling, every
-synchronously sampled final-prefill output joins the same deferred host-state
-queue as async decode readbacks; otherwise a reset could count a synchronously
-applied frame that the runner had no way to reject.
+decode work first. Complete a pending step before the batch layout changes.
+Lane output extraction needs the layout used to submit that step. Apply its
+token only after the next `SchedulerOutput` updates request state. Apply all
+valid tokens before building reload inputs from host state.
+
+"Publish" means that a decode result stays visible to vLLM. "Apply" means that
+the runner adds its token to local request state. The plugin uses these rules:
+
+- Normal result for a live request: publish and apply.
+- Ordinary preemption or resume: publish and apply.
+- Forced-reset result: publish, but do not apply. vLLM discards it.
+- Request already finished or aborted: remove any late result and do not apply
+  it. The result that ended the request was already accepted.
+
+An ordinary preemption does not invalidate an in-flight decode. Its forward
+completed before the KV blocks were reused, so its token is valid. If its
+result is still in flight, the scheduler does not resume the request. After
+vLLM accepts the result, resumed prefill includes the token and gets a new
+output placeholder. This prevents two physical results from using one
+placeholder. It also prevents an extra sample from advancing seeded RNG state.
+
+A forced prefix-cache reset calls
+`reset_prefix_cache(reset_running_requests=True)`. It preempts live requests so
+all KV blocks can be freed. vLLM resumes each request from committed token
+history and records the number of in-flight results in its upstream
+`Request.async_tokens_to_discard` field. The plugin keeps those results visible
+to vLLM, but does not add their tokens to local request state. If the plugin
+removes one of these results, vLLM cannot reduce the discard count and discards
+the next valid result instead. This control path is used by an explicit
+live-request reset or by pause/sleep with cache clearing. Normal completion,
+ordinary scheduler preemption, and cache eviction do not use it. An ordinary
+`reset_prefix_cache()` only succeeds when no running request holds KV blocks.
+
+Under upstream async scheduling, a synchronously sampled final-prefill result
+uses the same deferred state-apply queue as an async decode result. This lets a
+forced reset reject its token before the runner adds it to local state.
 Page-table-only refresh remains overlap-safe because page tables come from the
 current scheduler allocation even when token and position tensors are stale.
 
@@ -187,7 +190,7 @@ must be consumed by step `k+1`.
 
 The base case is a full reload. Before issuing it, the runner finalizes the
 older step, suppresses late results for request IDs already reported finished,
-excludes explicitly marked forced-reset frames from runner state, and applies
+excludes explicitly marked forced-reset results from runner state, and applies
 every accepted token—including an ordinary preemption's in-flight token—to
 host request state. It then copies the authoritative token, position, layout,
 and requested sampling state.
@@ -203,17 +206,22 @@ Host sampling always returns to the base case. Prefill and request-layout,
 sampling-mode, preemption, and resume transitions also break the steady
 invariant and re-establish it through a drain and full reload.
 
-Upstream vLLM replaces each external request id with an internal id carrying a
-random suffix before scheduling, so an ordinary abort and resubmit does not
-reuse a runner id. Finished IDs suppress both runner-state append and published
-output. Ordinary preemption never suppresses the older submitted frame. A
-preempted request cannot resume while it still owns an output placeholder, so
-resumed prefill always includes the accepted frame in its replay history and
-owns a new reservation for its sampled result.
+By default, upstream vLLM adds a random suffix to each external request ID
+before scheduling. An abort and resubmit therefore gets a new runner ID. The
+upstream `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` setting disables this safety;
+when it is set, the caller must keep active and resubmitted IDs unique.
+
+When `SchedulerOutput` reports that a request is finished, the plugin removes
+any later result that vLLM has not consumed and does not add its token to runner
+state. The result that finished the request was already accepted. Ordinary
+preemption does not suppress its in-flight result. A preempted request cannot
+resume while it owns an output placeholder. Resumed prefill therefore includes
+the accepted token and owns a new placeholder for its next result.
+
 Forced-reset discard counts are scheduler-owned sidecar metadata on
-`SchedulerOutput`; they suppress only runner-state append for the newest
-counted frames, while leaving their published rows nonempty for vLLM's discard
-accounting.
+`SchedulerOutput`. They prevent runner-state updates for only the newest
+counted results. The results stay visible to vLLM so it can reduce its upstream
+discard count.
 
 ## Requirements for `decode_input_update_contract = 1`
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -359,6 +359,10 @@ overlap. It can be disabled explicitly with `--no-async-scheduling`.
 `--async_engine` in the offline example controls use of vLLM's asynchronous
 client API and is a separate option.
 
+The exact model-side reload commands, host-authority rules, transition table,
+and requirements for declaring `supports_async_decode` are specified in
+[`DECODE_RELOAD_CONTRACT.md`](DECODE_RELOAD_CONTRACT.md).
+
 ## Queueing in Single-Process Lane TT
 
 Single-process lane-DP uses one vLLM engine process and one TT worker.

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -513,11 +513,11 @@ class TTAsyncDecodeController:
         For example, suppose request R has finalized rows A then B in this
         queue. A reached ``AsyncScheduler`` before a prefix reset but still
         awaits runner-state apply; B was outstanding at reset, so the scheduler
-        reports ``discard_count[R] = 1``. A is accepted into runner state. B,
-        the newest one matching row, remains published so ``AsyncScheduler``
-        consumes ``async_tokens_to_discard``, but is not appended to runner
-        state. Blank B instead and vLLM would not consume the counter, causing
-        the next valid row to be discarded.
+        reports ``forced_reset_discard_counts[R] = 1``. A is accepted into
+        runner state. B, the newest one matching row, remains published so
+        ``AsyncScheduler`` consumes ``async_tokens_to_discard``, but is not
+        appended to runner state. Blank B instead and vLLM would not consume
+        the counter, causing the next valid row to be discarded.
 
         Finished rows are suppressed from both destinations. Ordinary
         preemption is neither suppressed nor discarded.

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -19,7 +19,6 @@ from vllm_tt_plugin.structured_output import has_structured_outputs
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
-    from vllm_tt_plugin.input_batch import CachedRequestState
     from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
 
@@ -62,7 +61,6 @@ class SubmittedStepContext:
 
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-    request_states: tuple[CachedRequestState, ...]
     submit_time_ns: int
 
 
@@ -329,7 +327,6 @@ class TTAsyncDecodeController:
         return SubmittedStepContext(
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_states=tuple(runner.requests[req_id] for req_id in req_ids),
             submit_time_ns=time.perf_counter_ns(),
         )
 
@@ -599,7 +596,6 @@ class TTAsyncDecodeController:
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
-            request_states=completed.context.request_states,
             skip_req_ids=invalid_req_ids,
         )
 

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -13,14 +13,17 @@ import ttnn
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOutput
 
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
     from vllm_tt_plugin.input_batch import CachedRequestState
-    from vllm_tt_plugin.model_input import TTModelInput
+    from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
+
+logger = init_tt_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -32,6 +35,7 @@ class TTDecodeSubmission:
     batch_size_per_dp: list[int]
     sampling_params: Any
     perform_device_sampling: bool
+    reload_plan: TTDecodeReloadPlan | None = None
 
 
 @dataclass(frozen=True)
@@ -62,7 +66,7 @@ class SubmittedStepContext:
     submit_time_ns: int
 
 
-@dataclass(frozen=True)
+@dataclass
 class CompletedDecodeStep:
     """Decode output that has completed readback but is not yet applied."""
 
@@ -70,6 +74,7 @@ class CompletedDecodeStep:
     logprobs: LogprobsLists | None
     context: SubmittedStepContext
     completion_time_ns: int
+    runner_output: ModelRunnerOutput | None = None
 
 
 class DeferredDecodeOutput(AsyncModelRunnerOutput):
@@ -94,20 +99,35 @@ class DeferredDecodeOutput(AsyncModelRunnerOutput):
     _finalize_lock: threading.Lock
     _finalized: bool
     _cached_output: Any
+    _cached_exception: BaseException | None
 
     def _init_deferred(self) -> None:
         self._finalized = False
         self._cached_output = None
+        self._cached_exception = None
         self._finalize_lock = threading.Lock()
 
     def ensure_finalized(self) -> Any:
         if self._finalized:
-            return self._cached_output
+            return self._replay()
         with self._finalize_lock:
             if not self._finalized:
-                self._cached_output = self._get_output_impl()
-                self._finalized = True
-                self._completion_event.set()
+                # A failed readback still consumed this submission. Cache the
+                # failure as terminal so a racing drain cannot perform the same
+                # non-idempotent device readback a second time.
+                try:
+                    self._cached_output = self._get_output_impl()
+                except BaseException as exc:
+                    self._cached_exception = exc
+                    raise
+                finally:
+                    self._finalized = True
+                    self._completion_event.set()
+        return self._replay()
+
+    def _replay(self) -> Any:
+        if self._cached_exception is not None:
+            raise self._cached_exception
         return self._cached_output
 
     def is_resolved(self) -> bool:
@@ -161,8 +181,12 @@ class AsyncTTModelRunnerOutput(DeferredDecodeOutput):
             context=self._context,
             scheduled_rows=self._scheduled_rows,
         )
+        runner_output = self._controller.build_runner_output_from_completed_step(
+            completed
+        )
+        completed.runner_output = runner_output
         self._controller.enqueue_completed_decode_step(completed)
-        return self._controller.build_runner_output_from_completed_step(completed)
+        return runner_output
 
 
 class TTAsyncDecodeController:
@@ -170,6 +194,120 @@ class TTAsyncDecodeController:
 
     def __init__(self, runner: TTModelRunner):
         self.runner = runner
+        # Decode residency is committed at submission, not readback. During
+        # overlapped device sampling the host can intentionally remain one step
+        # behind, so submitted-device history is the only safe reload authority.
+        self._decode_chain_valid = False
+        self._previous_device_sampling: bool | None = None
+        self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
+        self._legacy_contract_warning_emitted = False
+
+    @staticmethod
+    def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            table.detach().clone() for table in model_input.block_tables_per_group
+        )
+
+    def note_prefill_submitted(self) -> None:
+        """Invalidate decode-resident token/position state after prefill."""
+        self._decode_chain_valid = False
+
+    def decode_input_update_contract_version(self) -> int:
+        """Return the adapter's negotiated reload-contract version."""
+        return int(getattr(self.runner.model, "decode_input_update_contract", 0))
+
+    def _page_tables_changed(self, model_input: TTModelInput) -> bool:
+        current = model_input.block_tables_per_group
+        previous = self._submitted_page_tables
+        return (
+            previous is None
+            or len(previous) != len(current)
+            or any(not torch.equal(old, new) for old, new in zip(previous, current))
+        )
+
+    def plan_decode_reload(self, model_input: TTModelInput) -> TTDecodeReloadPlan:
+        """Return the explicit update commands for the next decode submit."""
+        from vllm_tt_plugin.model_input import TTDecodeReloadPlan
+
+        device_sampling = model_input.perform_device_sampling
+        model_capabilities = getattr(self.runner.model, "model_capabilities", {}) or {}
+        supports_resident_decode = bool(
+            model_capabilities.get("supports_async_decode", False)
+        )
+        decode_trace_enabled = self.runner.trace_mode in ("all", "decode_only")
+        sampling_mode_changed = (
+            self._previous_device_sampling is not None
+            and self._previous_device_sampling != device_sampling
+        )
+        transition = (
+            not self._decode_chain_valid
+            or model_input.decode_layout_changed
+            or sampling_mode_changed
+        )
+        reload_inputs = (
+            not device_sampling
+            or transition
+            or not supports_resident_decode
+            or not decode_trace_enabled
+        )
+        sampling_reset = device_sampling and transition
+        return TTDecodeReloadPlan(
+            reload_inputs=reload_inputs,
+            reload_page_table=(
+                not reload_inputs and self._page_tables_changed(model_input)
+            ),
+            reload_sampling_params=sampling_reset,
+            reset_sampling_state=sampling_reset,
+        )
+
+    def commit_decode_submission(
+        self,
+        model_input: TTModelInput,
+        reload_plan: TTDecodeReloadPlan,
+    ) -> None:
+        """Commit residency after the model accepts a decode submission."""
+        self._decode_chain_valid = True
+        self._previous_device_sampling = model_input.perform_device_sampling
+        if (
+            reload_plan.reload_inputs
+            or reload_plan.reload_page_table
+            or self._submitted_page_tables is None
+        ):
+            self._submitted_page_tables = self._clone_page_tables(model_input)
+
+    def scheduler_preserves_decode_layout(
+        self, scheduler_output: SchedulerOutput
+    ) -> bool:
+        """Predict front-packed batch membership before state mutation."""
+        current_req_ids = set(self.runner.input_batch.req_id_to_index)
+        scheduled_req_ids = set(scheduler_output.num_scheduled_tokens)
+        return current_req_ids == scheduled_req_ids
+
+    @staticmethod
+    def scheduler_output_has_prefill_work(
+        scheduler_output: SchedulerOutput,
+    ) -> bool:
+        """Whether the scheduler output contains any context-phase work.
+
+        This decision is made before ``_update_states``, so the persistent
+        batch still describes the previous step. ``is_context_phase`` is the
+        exact signal for a cached chunked-prefill continuation; token counts
+        are ambiguous for a one-token final chunk and speculative decode.
+        """
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        if scheduler_output.scheduled_new_reqs or cached_reqs.resumed_req_ids:
+            return True
+        return any(
+            cached_reqs.is_context_phase(req_id) for req_id in cached_reqs.req_ids
+        )
+
+    @staticmethod
+    def invalidated_req_ids(scheduler_output: SchedulerOutput) -> set[str]:
+        """Requests an older in-flight decode result must not update."""
+        invalidated = set(scheduler_output.finished_req_ids)
+        invalidated.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        invalidated.update(scheduler_output.preempted_req_ids or ())
+        return invalidated
 
     def capture_submitted_step_context(
         self, req_ids: list[str] | None = None
@@ -197,9 +335,7 @@ class TTAsyncDecodeController:
 
     def steady_decode_base_enabled(self) -> bool:
         runner = self.runner
-        if not runner.non_dp_async_scheduling:
-            return False
-        if runner.parallel_config.data_parallel_size != 1:
+        if not runner.async_decode_scheduling:
             return False
         if runner.trace_mode == "none":  # noqa: SIM103
             return False
@@ -208,14 +344,31 @@ class TTAsyncDecodeController:
     def steady_decode_scheduler_invariants_met(
         self,
         scheduler_output: SchedulerOutput,
+        *,
+        decode_layout_changed: bool | None = None,
     ) -> bool:
         runner = self.runner
+        input_batch = runner.input_batch
         cached_reqs = scheduler_output.scheduled_cached_reqs
-        is_prompt = (len(scheduler_output.scheduled_new_reqs) > 0) or bool(
-            cached_reqs.resumed_req_ids
+        legacy_prompt = bool(
+            scheduler_output.scheduled_new_reqs or cached_reqs.resumed_req_ids
         )
-        if is_prompt or runner._decode_layout_changed_since_last_decode:
+        if legacy_prompt or runner._decode_layout_changed_since_last_decode:
             return False
+        if self.decode_input_update_contract_version() >= 1:
+            if self.scheduler_output_has_prefill_work(scheduler_output):
+                return False
+            if (
+                not self._decode_chain_valid
+                or self._previous_device_sampling is not True
+            ):
+                return False
+            if decode_layout_changed is None:
+                decode_layout_changed = not self.scheduler_preserves_decode_layout(
+                    scheduler_output
+                )
+            if decode_layout_changed:
+                return False
         # Structured outputs are detected from the scheduler state, not from a
         # prepared bitmask: grammar is applied at sample time, so no bitmask
         # exists yet when this runs. Either signal disables steady decode so the
@@ -224,7 +377,6 @@ class TTAsyncDecodeController:
             runner.requests, scheduler_output, None
         ):
             return False
-        input_batch = runner.input_batch
         if not input_batch.no_penalties:
             return False
         if not input_batch.no_allowed_token_ids:
@@ -256,18 +408,27 @@ class TTAsyncDecodeController:
     def can_attempt_steady_lane_decode_from_scheduler(
         self,
         scheduler_output: SchedulerOutput | None,
+        *,
+        decode_layout_changed: bool,
     ) -> bool:
         """Whether a merged lane-DP step can overlap steady decode.
 
-        Unlike the non-DP variant, ``scheduler_output=None`` or a zero-token
+        Unlike the front-packed variant, ``scheduler_output=None`` or a zero-token
         step counts as steady-eligible: the merged step still overlaps safely
         when no lane has decode work of its own.
         """
         if not self.steady_decode_base_enabled():
             return False
         if scheduler_output is None or scheduler_output.total_num_scheduled_tokens == 0:
-            return True
-        return self.steady_decode_scheduler_invariants_met(scheduler_output)
+            return (
+                not decode_layout_changed
+                if self.decode_input_update_contract_version() >= 1
+                else True
+            )
+        return self.steady_decode_scheduler_invariants_met(
+            scheduler_output,
+            decode_layout_changed=decode_layout_changed,
+        )
 
     def can_use_steady_decode_fast_path(self, model_input: TTModelInput) -> bool:
         if not self.steady_decode_base_enabled():
@@ -276,7 +437,7 @@ class TTAsyncDecodeController:
             return False
         if not model_input.perform_device_sampling:
             return False
-        if model_input.reset_batch:
+        if model_input.decode_layout_changed:
             return False
         if model_input.grammar_bitmask[0] is not None:
             return False
@@ -292,7 +453,9 @@ class TTAsyncDecodeController:
         max_num_logprobs = model_input.max_num_logprobs[0]
         if max_num_logprobs is not None:  # noqa: SIM103
             return False
-        return True
+        if self.decode_input_update_contract_version() < 1:
+            return True
+        return self.plan_decode_reload(model_input).overlap_safe
 
     def enqueue_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
         with self.runner._steady_decode_lock:
@@ -324,12 +487,14 @@ class TTAsyncDecodeController:
                 completed.append(self.runner._completed_decode_steps.popleft())
         return completed
 
-    def apply_ready_completed_decode_steps(self) -> None:
+    def apply_ready_completed_decode_steps(
+        self, *, skip_req_ids: set[str] | None = None
+    ) -> None:
         for completed in self.drain_completed_decode_steps():
-            self.apply_completed_decode_step(completed)
+            self.apply_completed_decode_step(completed, skip_req_ids=skip_req_ids)
         self.prune_finished_async_events()
 
-    def wait_for_all_pending_async_steps(self) -> None:
+    def wait_for_all_pending_async_steps(self, *, apply_completed: bool = True) -> None:
         # Drive each pending readback to completion here rather than blocking on
         # its event: the engine has not popped these futures yet (and on 0.22
         # will not until after this returns), so nothing else will set the
@@ -339,7 +504,8 @@ class TTAsyncDecodeController:
             steps = list(self.runner._pending_async_steps)
         for step in steps:
             step.ensure_finalized()
-        self.apply_ready_completed_decode_steps()
+        if apply_completed:
+            self.apply_ready_completed_decode_steps()
 
     def must_drain_pending_async_steps(
         self,
@@ -411,14 +577,33 @@ class TTAsyncDecodeController:
             req_id_to_index=completed.context.req_id_to_index,
         )
 
-    def apply_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
+    def apply_completed_decode_step(
+        self,
+        completed: CompletedDecodeStep,
+        *,
+        skip_req_ids: set[str] | None = None,
+    ) -> None:
+        invalid_req_ids = set(skip_req_ids or ())
+        # The batch-queue loop schedules the current step before consuming the
+        # previous future. Scrub invalid rows before scheduler.update_from_output
+        # observes that cached output, not only before runner host-state apply.
+        if completed.runner_output is not None:
+            assert self.runner.scheduler_config.async_scheduling, (
+                "mutating a published runner output is only ordered correctly "
+                "under the batch-queue step loop"
+            )
+            for req_id in invalid_req_ids:
+                req_idx = completed.runner_output.req_id_to_index.get(req_id)
+                if req_idx is not None:
+                    completed.runner_output.sampled_token_ids[req_idx] = []
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
             request_states=completed.context.request_states,
+            skip_req_ids=invalid_req_ids,
         )
 
-    def submit_async_non_dp_decode(
+    def submit_async_decode(
         self,
         model_input: TTModelInput,
         *,
@@ -482,6 +667,7 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
+        contract_version = self.decode_input_update_contract_version()
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,
@@ -489,6 +675,7 @@ class TTAsyncDecodeController:
                 batch_size_per_dp=batch_size_per_dp,
                 sampling_params=sampling_params,
                 perform_device_sampling=perform_device_sampling,
+                reload_plan=None,
             )
 
         kwargs: dict[str, Any] = {
@@ -522,15 +709,37 @@ class TTAsyncDecodeController:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
-            kwargs["reset_batch"] = model_input.reset_batch
-        # Two consumers, gated differently: ``decode_forward`` moves per-slot GDN
-        # state with it always, the seed manager reindexes only on device sampling.
+        # Standalone-plugin models already receive state-slot remaps in both
+        # sampling modes. Preserve that behavior for legacy adapters too.
         if model_input.slot_remap is not None:
             kwargs["slot_remap"] = model_input.slot_remap
 
+        # Versioned compatibility seam. Refactored tt-metal adapters opt into
+        # the four explicit commands; legacy adapters keep their old call shape.
+        reload_plan = None
+        if contract_version >= 1:
+            reload_plan = self.plan_decode_reload(model_input)
+            kwargs.update(
+                reload_inputs=reload_plan.reload_inputs,
+                reload_page_table=reload_plan.reload_page_table,
+                reload_sampling_params=reload_plan.reload_sampling_params,
+                reset_sampling_state=reload_plan.reset_sampling_state,
+            )
+        elif perform_device_sampling:
+            kwargs["reset_batch"] = model_input.decode_layout_changed
+        if contract_version < 1 and not self._legacy_contract_warning_emitted:
+            self._legacy_contract_warning_emitted = True
+            logger.warning(
+                "TT model %s does not advertise decode_input_update_contract "
+                ">= 1; preserving its legacy reset_batch reload behavior. "
+                "Async decode correctness is not guaranteed until the model "
+                "adapter implements the explicit contract.",
+                type(runner.model).__name__,
+            )
+
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
-            if any(
+            if model_input.decode_layout_changed or any(
                 req_id not in runner.previous_req_ids
                 for req_id in runner.input_batch.req_ids
             ):
@@ -551,6 +760,17 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
+        # Input construction only proposed this layout/remap. Commit both at
+        # the boundary where the model accepted the decode submission.
+        runner.note_decode_layout_consumed()
+        runner.note_decode_state_slots_settled()
+        if reload_plan is not None:
+            self.commit_decode_submission(model_input, reload_plan)
+        else:
+            # Preserve version-0 overlap behavior. The legacy adapter remains
+            # reload-policy owner; this records only that submission succeeded.
+            self._decode_chain_valid = True
+            self._previous_device_sampling = perform_device_sampling
         read_events = None
         if async_read:
             if hasattr(runner.model, "read_decode_output"):
@@ -575,6 +795,7 @@ class TTAsyncDecodeController:
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
+            reload_plan=reload_plan,
         )
 
     def finalize_decode(

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -502,40 +502,48 @@ class TTAsyncDecodeController:
     ) -> None:
         """Apply completed outputs after the scheduler updates request state.
 
-        Finish each pending step before the batch layout changes. Lane output
-        extraction uses the layout from that step. Apply its token after the
-        next ``SchedulerOutput`` updates the request state and batch layout.
-        We then know which requests are finished and which outputs vLLM must
-        discard. Apply these tokens before you build reload inputs from host
-        state.
+        Complete each pending step before the batch layout changes. Lane output
+        extraction needs the layout used for that step. Apply the token only
+        after the next ``SchedulerOutput`` updates request state. This update
+        tells us which tokens are valid. Apply valid tokens before you build
+        reload inputs from host state.
 
         A forced prefix-cache reset calls
         ``reset_prefix_cache(reset_running_requests=True)``. It preempts live
         requests and frees their KV blocks. vLLM resumes the requests from
         saved token history. It records the number of in-flight outputs in
-        ``async_tokens_to_discard``. Do not add those outputs to runner state.
+        ``async_tokens_to_discard``.
 
-        For example, request R has completed rows A and B. vLLM accepted A
-        before the reset, but the runner has not applied it. B was in flight at
-        the reset, so ``forced_reset_discard_counts[R]`` is 1. Apply A to runner
-        state. Keep B in the published output so vLLM consumes the discard
-        count, but do not apply B to runner state. If B is blank, vLLM discards
-        the next valid row instead.
+        "Publish" means that the output stays visible to vLLM. "Apply" means
+        that the runner adds the token to its request state. Use these rules:
 
-        A request can also have a late row after it ends. The row can be in
-        flight when an earlier row ends the request or when an abort occurs.
-        Remove the late row from the published output. Do not add it to runner
-        state. Keep the row that ended the request. Also keep an in-flight
-        token after an ordinary preemption.
+        * Normal output for a live request: publish and apply.
+        * Ordinary preemption or resume: publish and apply.
+        * Forced-reset output: publish, but do not apply. vLLM discards it.
+        * Request already finished or aborted: remove any late output and do
+          not apply it.
+
+        For example, request R has two completed decode results: result A and
+        result B. vLLM accepted result A before the reset, but the runner has
+        not applied its token. Result B was in flight at the reset, so
+        ``forced_reset_discard_counts[R]`` is 1. Apply the token from result A.
+        Publish result B, but do not apply its token. This lets vLLM discard
+        result B and reduce its discard count. If result B is not published,
+        vLLM discards the next valid result instead.
+
+        A late result can occur when an earlier result ends the request. It can
+        also occur when a result is in flight during an abort. The result that
+        ended the request was already accepted. Only the late result is
+        removed.
         """
         completed_steps = self.drain_completed_decode_steps()
         suppressed = set(suppress_output_req_ids or ())
         discard_counts = forced_reset_discard_counts or {}
 
-        # An output can already have reached AsyncScheduler while its runner
-        # state apply is still queued. Such accepted frames precede the stale
-        # frames counted at reset time, so skip only the newest N matching rows.
-        remaining_rows: Counter[str] = Counter()
+        # Results are ordered from oldest to newest. vLLM accepted the older
+        # results before the reset. The discard count applies to the newest
+        # results that were in flight during the reset.
+        remaining_results: Counter[str] = Counter()
         for completed in completed_steps:
             if completed.runner_output is None:
                 continue
@@ -545,17 +553,17 @@ class TTAsyncDecodeController:
                     req_idx is not None
                     and completed.runner_output.sampled_token_ids[req_idx]
                 ):
-                    remaining_rows[req_id] += 1
+                    remaining_results[req_id] += 1
 
         missing = {
-            req_id: count - remaining_rows[req_id]
+            req_id: count - remaining_results[req_id]
             for req_id, count in discard_counts.items()
-            if remaining_rows[req_id] < count
+            if remaining_results[req_id] < count
         }
         if missing:
             raise RuntimeError(
-                "Forced-reset async discard boundary is missing completed "
-                f"frames: {missing}"
+                "Not enough completed outputs for the forced-reset discard "
+                f"counts: {missing}"
             )
 
         for completed in completed_steps:
@@ -568,17 +576,17 @@ class TTAsyncDecodeController:
                         and completed.runner_output.sampled_token_ids[req_idx]
                     ):
                         published_req_ids.add(req_id)
-            forced_reset_rows = {
+            forced_reset_req_ids = {
                 req_id
                 for req_id in published_req_ids
-                if 0 < remaining_rows[req_id] <= discard_counts.get(req_id, 0)
+                if 0 < remaining_results[req_id] <= discard_counts.get(req_id, 0)
             }
             self.apply_completed_decode_step(
                 completed,
                 suppress_output_req_ids=suppressed,
-                skip_state_req_ids=suppressed | forced_reset_rows,
+                skip_state_req_ids=suppressed | forced_reset_req_ids,
             )
-            remaining_rows.subtract(published_req_ids)
+            remaining_results.subtract(published_req_ids)
         self.prune_finished_async_events()
 
     def wait_for_all_pending_async_steps(self) -> None:
@@ -680,11 +688,11 @@ class TTAsyncDecodeController:
         suppressed = set(suppress_output_req_ids or ())
         skipped_state = set(skip_state_req_ids or ())
         # The batch-queue loop schedules the current step before consuming the
-        # previous future. Scrub late rows for request IDs already reported
+        # previous future. Scrub late results for request IDs already reported
         # finished before scheduler.update_from_output observes that cached
-        # output. The row that actually finished the request was already
-        # accepted; these are speculative-after-finish or abort-racing rows.
-        # Forced-reset rows intentionally remain intact: AsyncScheduler must
+        # output. The result that finished the request was already accepted.
+        # These results arrived after finish or raced with an abort.
+        # Forced-reset results stay intact because AsyncScheduler must
         # see them to decrement ``async_tokens_to_discard``.
         if completed.runner_output is not None:
             assert self.runner.scheduler_config.async_scheduling, (

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -500,40 +500,33 @@ class TTAsyncDecodeController:
         suppress_output_req_ids: set[str] | None = None,
         forced_reset_discard_counts: dict[str, int] | None = None,
     ) -> None:
-        """Apply finalized outputs after the next scheduler lifecycle is known.
+        """Apply completed outputs after the scheduler updates request state.
 
-        Finalization and host-state application deliberately straddle batch
-        mutation. A pending step is finalized while its submission layout is
-        still intact because lane output extraction reads that layout. Its
-        token is applied only after the next ``SchedulerOutput`` has updated
-        request lifecycle and layout, exposing finished requests and the exact
-        forced-prefix-reset discard boundary. This method must run before any
-        host-authoritative reload input is built.
+        Finish each pending step before the batch layout changes. Lane output
+        extraction uses the layout from that step. Apply its token after the
+        next ``SchedulerOutput`` updates the request state and batch layout.
+        We then know which requests are finished and which outputs vLLM must
+        discard. Apply these tokens before you build reload inputs from host
+        state.
 
-        A forced prefix-cache reset is
-        ``reset_prefix_cache(reset_running_requests=True)``. Unlike an
-        ordinary cache clear, it preempts every live request so all KV blocks
-        can be freed. It is a control-plane operation used for an explicit
-        live-request reset or pause/sleep with cache clearing, not ordinary
-        scheduler preemption. As part of that wholesale teardown, vLLM resumes
-        from committed token history and declares outstanding submissions
-        stale by counting their placeholders in ``async_tokens_to_discard``.
+        A forced prefix-cache reset calls
+        ``reset_prefix_cache(reset_running_requests=True)``. It preempts live
+        requests and frees their KV blocks. vLLM resumes the requests from
+        saved token history. It records the number of in-flight outputs in
+        ``async_tokens_to_discard``. Do not add those outputs to runner state.
 
-        For example, suppose request R has finalized rows A then B in this
-        queue. A reached ``AsyncScheduler`` before a prefix reset but still
-        awaits runner-state apply; B was outstanding at reset, so the scheduler
-        reports ``forced_reset_discard_counts[R] = 1``. A is accepted into
-        runner state. B, the newest one matching row, remains published so
-        ``AsyncScheduler`` consumes ``async_tokens_to_discard``, but is not
-        appended to runner state. Blank B instead and vLLM would not consume
-        the counter, causing the next valid row to be discarded.
+        For example, request R has completed rows A and B. vLLM accepted A
+        before the reset, but the runner has not applied it. B was in flight at
+        the reset, so ``forced_reset_discard_counts[R]`` is 1. Apply A to runner
+        state. Keep B in the published output so vLLM consumes the discard
+        count, but do not apply B to runner state. If B is blank, vLLM discards
+        the next valid row instead.
 
-        Separately, a late row for a request already reported finished is
-        suppressed from both scheduler output and runner state. This can be a
-        speculative row submitted before an earlier row ended the request, or
-        a row that raced with an abort; the row that actually finished the
-        request was already accepted and is not discarded. Ordinary
-        preemption is neither case and its in-flight token is retained.
+        A request can also have a late row after it ends. The row can be in
+        flight when an earlier row ends the request or when an abort occurs.
+        Remove the late row from the published output. Do not add it to runner
+        state. Keep the row that ended the request. Also keep an in-flight
+        token after an ordinary preemption.
         """
         completed_steps = self.drain_completed_decode_steps()
         suppressed = set(suppress_output_req_ids or ())

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -308,7 +308,7 @@ class TTAsyncDecodeController:
 
     @staticmethod
     def suppressed_output_req_ids(scheduler_output: SchedulerOutput) -> set[str]:
-        """Requests whose older output must not reach scheduler accounting.
+        """Requests whose late output must not reach scheduler accounting.
 
         Ordinary preemption and resume deliberately do not appear here: their
         in-flight token is valid and AsyncScheduler must consume its output
@@ -510,10 +510,14 @@ class TTAsyncDecodeController:
         forced-prefix-reset discard boundary. This method must run before any
         host-authoritative reload input is built.
 
-        A forced-reset stale frame is a submission still outstanding when
-        ``reset_prefix_cache(reset_running_requests=True)`` invalidates the
-        running request's KV and replay state. vLLM counts those outstanding
-        placeholders in ``async_tokens_to_discard``.
+        A forced prefix-cache reset is
+        ``reset_prefix_cache(reset_running_requests=True)``. Unlike an
+        ordinary cache clear, it preempts every live request so all KV blocks
+        can be freed. It is a control-plane operation used for an explicit
+        live-request reset or pause/sleep with cache clearing, not ordinary
+        scheduler preemption. As part of that wholesale teardown, vLLM resumes
+        from committed token history and declares outstanding submissions
+        stale by counting their placeholders in ``async_tokens_to_discard``.
 
         For example, suppose request R has finalized rows A then B in this
         queue. A reached ``AsyncScheduler`` before a prefix reset but still
@@ -524,8 +528,12 @@ class TTAsyncDecodeController:
         appended to runner state. Blank B instead and vLLM would not consume
         the counter, causing the next valid row to be discarded.
 
-        Finished rows are suppressed from both destinations. Ordinary
-        preemption is neither suppressed nor discarded.
+        Separately, a late row for a request already reported finished is
+        suppressed from both scheduler output and runner state. This can be a
+        speculative row submitted before an earlier row ended the request, or
+        a row that raced with an abort; the row that actually finished the
+        request was already accepted and is not discarded. Ordinary
+        preemption is neither case and its in-flight token is retained.
         """
         completed_steps = self.drain_completed_decode_steps()
         suppressed = set(suppress_output_req_ids or ())
@@ -679,10 +687,12 @@ class TTAsyncDecodeController:
         suppressed = set(suppress_output_req_ids or ())
         skipped_state = set(skip_state_req_ids or ())
         # The batch-queue loop schedules the current step before consuming the
-        # previous future. Scrub finished rows before
-        # scheduler.update_from_output observes that cached output. Forced-reset
-        # rows intentionally remain intact: AsyncScheduler must see them to
-        # decrement ``async_tokens_to_discard``.
+        # previous future. Scrub late rows for request IDs already reported
+        # finished before scheduler.update_from_output observes that cached
+        # output. The row that actually finished the request was already
+        # accepted; these are speculative-after-finish or abort-racing rows.
+        # Forced-reset rows intentionally remain intact: AsyncScheduler must
+        # see them to decrement ``async_tokens_to_discard``.
         if completed.runner_output is not None:
             assert self.runner.scheduler_config.async_scheduling, (
                 "mutating a published runner output is only ordered correctly "

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -553,7 +553,7 @@ class TTAsyncDecodeController:
             remaining_rows.subtract(published_req_ids)
         self.prune_finished_async_events()
 
-    def wait_for_all_pending_async_steps(self, *, apply_completed: bool = True) -> None:
+    def wait_for_all_pending_async_steps(self, *, apply_completed: bool) -> None:
         # Drive each pending readback to completion here rather than blocking on
         # its event: the engine has not popped these futures yet (and on 0.22
         # will not until after this returns), so nothing else will set the

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -500,6 +500,28 @@ class TTAsyncDecodeController:
         suppress_output_req_ids: set[str] | None = None,
         forced_reset_discard_counts: dict[str, int] | None = None,
     ) -> None:
+        """Apply finalized outputs after the next scheduler lifecycle is known.
+
+        Finalization and host-state application deliberately straddle batch
+        mutation. A pending step is finalized while its submission layout is
+        still intact because lane output extraction reads that layout. Its
+        token is applied only after the next ``SchedulerOutput`` has updated
+        request lifecycle and layout, exposing finished requests and the exact
+        forced-prefix-reset discard boundary. This method must run before any
+        host-authoritative reload input is built.
+
+        For example, suppose request R has finalized rows A then B in this
+        queue. A reached ``AsyncScheduler`` before a prefix reset but still
+        awaits runner-state apply; B was outstanding at reset, so the scheduler
+        reports ``discard_count[R] = 1``. A is accepted into runner state. B,
+        the newest one matching row, remains published so ``AsyncScheduler``
+        consumes ``async_tokens_to_discard``, but is not appended to runner
+        state. Blank B instead and vLLM would not consume the counter, causing
+        the next valid row to be discarded.
+
+        Finished rows are suppressed from both destinations. Ordinary
+        preemption is neither suppressed nor discarded.
+        """
         completed_steps = self.drain_completed_decode_steps()
         suppressed = set(suppress_output_req_ids or ())
         discard_counts = forced_reset_discard_counts or {}
@@ -553,7 +575,8 @@ class TTAsyncDecodeController:
             remaining_rows.subtract(published_req_ids)
         self.prune_finished_async_events()
 
-    def wait_for_all_pending_async_steps(self, *, apply_completed: bool) -> None:
+    def wait_for_all_pending_async_steps(self) -> None:
+        """Finalize pending readbacks without applying them to runner state."""
         # Drive each pending readback to completion here rather than blocking on
         # its event: the engine has not popped these futures yet (and on 0.22
         # will not until after this returns), so nothing else will set the
@@ -563,8 +586,6 @@ class TTAsyncDecodeController:
             steps = list(self.runner._pending_async_steps)
         for step in steps:
             step.ensure_finalized()
-        if apply_completed:
-            self.apply_ready_completed_decode_steps()
 
     def must_drain_pending_async_steps(
         self,

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -68,7 +68,12 @@ class SubmittedStepContext:
 
 @dataclass
 class CompletedDecodeStep:
-    """Decode output that has completed readback but is not yet applied."""
+    """Sampled output that has completed but is not yet applied to host state.
+
+    Most instances are async decode readbacks. Async-scheduled final prefills
+    also use this lifecycle so a prefix reset can discard their published frame
+    before it reaches runner state.
+    """
 
     sampled_token_ids: torch.Tensor
     logprobs: LogprobsLists | None

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -510,6 +510,11 @@ class TTAsyncDecodeController:
         forced-prefix-reset discard boundary. This method must run before any
         host-authoritative reload input is built.
 
+        A forced-reset stale frame is a submission still outstanding when
+        ``reset_prefix_cache(reset_running_requests=True)`` invalidates the
+        running request's KV and replay state. vLLM counts those outstanding
+        placeholders in ``async_tokens_to_discard``.
+
         For example, suppose request R has finalized rows A then B in this
         queue. A reached ``AsyncScheduler`` before a prefix reset but still
         awaits runner-state apply; B was outstanding at reset, so the scheduler

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import Counter
 from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -14,6 +15,7 @@ from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOu
 
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
 from vllm_tt_plugin.logger import init_tt_logger
+from vllm_tt_plugin.scheduler import get_tt_forced_reset_discard_counts
 from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
@@ -300,12 +302,15 @@ class TTAsyncDecodeController:
         )
 
     @staticmethod
-    def invalidated_req_ids(scheduler_output: SchedulerOutput) -> set[str]:
-        """Requests an older in-flight decode result must not update."""
-        invalidated = set(scheduler_output.finished_req_ids)
-        invalidated.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
-        invalidated.update(scheduler_output.preempted_req_ids or ())
-        return invalidated
+    def suppressed_output_req_ids(scheduler_output: SchedulerOutput) -> set[str]:
+        """Requests whose older output must not reach scheduler accounting.
+
+        Ordinary preemption and resume deliberately do not appear here: their
+        in-flight token is valid and AsyncScheduler must consume its output
+        placeholder. Forced-reset frames also stay published so
+        ``async_tokens_to_discard`` consumes the stale frame itself.
+        """
+        return set(scheduler_output.finished_req_ids)
 
     def capture_submitted_step_context(
         self, req_ids: list[str] | None = None
@@ -485,10 +490,62 @@ class TTAsyncDecodeController:
         return completed
 
     def apply_ready_completed_decode_steps(
-        self, *, skip_req_ids: set[str] | None = None
+        self,
+        *,
+        suppress_output_req_ids: set[str] | None = None,
+        forced_reset_discard_counts: dict[str, int] | None = None,
     ) -> None:
-        for completed in self.drain_completed_decode_steps():
-            self.apply_completed_decode_step(completed, skip_req_ids=skip_req_ids)
+        completed_steps = self.drain_completed_decode_steps()
+        suppressed = set(suppress_output_req_ids or ())
+        discard_counts = forced_reset_discard_counts or {}
+
+        # An output can already have reached AsyncScheduler while its runner
+        # state apply is still queued. Such accepted frames precede the stale
+        # frames counted at reset time, so skip only the newest N matching rows.
+        remaining_rows: Counter[str] = Counter()
+        for completed in completed_steps:
+            if completed.runner_output is None:
+                continue
+            for req_id in completed.context.req_ids:
+                req_idx = completed.runner_output.req_id_to_index.get(req_id)
+                if (
+                    req_idx is not None
+                    and completed.runner_output.sampled_token_ids[req_idx]
+                ):
+                    remaining_rows[req_id] += 1
+
+        missing = {
+            req_id: count - remaining_rows[req_id]
+            for req_id, count in discard_counts.items()
+            if remaining_rows[req_id] < count
+        }
+        if missing:
+            raise RuntimeError(
+                "Forced-reset async discard boundary is missing completed "
+                f"frames: {missing}"
+            )
+
+        for completed in completed_steps:
+            published_req_ids: set[str] = set()
+            if completed.runner_output is not None:
+                for req_id in completed.context.req_ids:
+                    req_idx = completed.runner_output.req_id_to_index.get(req_id)
+                    if (
+                        req_idx is not None
+                        and completed.runner_output.sampled_token_ids[req_idx]
+                    ):
+                        published_req_ids.add(req_id)
+            forced_reset_rows = {
+                req_id
+                for req_id in published_req_ids
+                if 0 < remaining_rows[req_id] <= discard_counts.get(req_id, 0)
+            }
+            self.apply_completed_decode_step(
+                completed,
+                suppress_output_req_ids=suppressed,
+                skip_state_req_ids=suppressed | forced_reset_rows,
+            )
+            remaining_rows.subtract(published_req_ids)
         self.prune_finished_async_events()
 
     def wait_for_all_pending_async_steps(self, *, apply_completed: bool = True) -> None:
@@ -507,10 +564,17 @@ class TTAsyncDecodeController:
     def must_drain_pending_async_steps(
         self,
         steady_decode_candidate: bool,
+        scheduler_output: SchedulerOutput | None = None,
     ) -> bool:
         with self.runner._steady_decode_lock:
             if not self.runner._pending_async_steps:
                 return False
+            # A wholesale reset marks the already-submitted frames stale. They
+            # must all be present before suffix discard counts are applied.
+            if scheduler_output is not None and get_tt_forced_reset_discard_counts(
+                scheduler_output
+            ):
+                return True
             if not steady_decode_candidate:
                 return True
             return any(
@@ -578,25 +642,29 @@ class TTAsyncDecodeController:
         self,
         completed: CompletedDecodeStep,
         *,
-        skip_req_ids: set[str] | None = None,
+        suppress_output_req_ids: set[str] | None = None,
+        skip_state_req_ids: set[str] | None = None,
     ) -> None:
-        invalid_req_ids = set(skip_req_ids or ())
+        suppressed = set(suppress_output_req_ids or ())
+        skipped_state = set(skip_state_req_ids or ())
         # The batch-queue loop schedules the current step before consuming the
-        # previous future. Scrub invalid rows before scheduler.update_from_output
-        # observes that cached output, not only before runner host-state apply.
+        # previous future. Scrub finished rows before
+        # scheduler.update_from_output observes that cached output. Forced-reset
+        # rows intentionally remain intact: AsyncScheduler must see them to
+        # decrement ``async_tokens_to_discard``.
         if completed.runner_output is not None:
             assert self.runner.scheduler_config.async_scheduling, (
                 "mutating a published runner output is only ordered correctly "
                 "under the batch-queue step loop"
             )
-            for req_id in invalid_req_ids:
+            for req_id in suppressed:
                 req_idx = completed.runner_output.req_id_to_index.get(req_id)
                 if req_idx is not None:
                     completed.runner_output.sampled_token_ids[req_idx] = []
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
-            skip_req_ids=invalid_req_ids,
+            skip_req_ids=skipped_state,
         )
 
     def submit_async_decode(

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -28,7 +28,6 @@ from vllm_tt_plugin.model_input import (
     TTSamplingParams,
     slice_tt_sampling_params,
 )
-from vllm_tt_plugin.scheduler import get_tt_unreserved_resumed_prefill_req_ids
 from vllm_tt_plugin.structured_output import (
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
@@ -1344,9 +1343,6 @@ class TTLaneInputBatch(InputBatch):
                 else None
             ),
             intermediate_prefill_mask=intermediate_prefill_mask,
-            suppressed_prefill_output_req_ids=(
-                get_tt_unreserved_resumed_prefill_req_ids(scheduler_output)
-            ),
         )
 
     def extract_output(

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -28,6 +28,7 @@ from vllm_tt_plugin.model_input import (
     TTSamplingParams,
     slice_tt_sampling_params,
 )
+from vllm_tt_plugin.scheduler import get_tt_unreserved_resumed_prefill_req_ids
 from vllm_tt_plugin.structured_output import (
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
@@ -1343,6 +1344,9 @@ class TTLaneInputBatch(InputBatch):
                 else None
             ),
             intermediate_prefill_mask=intermediate_prefill_mask,
+            suppressed_prefill_output_req_ids=(
+                get_tt_unreserved_resumed_prefill_req_ids(scheduler_output)
+            ),
         )
 
     def extract_output(

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1211,8 +1211,7 @@ class TTLaneInputBatch(InputBatch):
         if perform_device_sampling and not lane_batch.no_penalties:
             prompt_tokens = lane_batch.make_prompt_token_ids_tensor(rows_all)
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
-        reset_batch = runner._decode_layout_changed_since_last_decode
-        runner._decode_layout_changed_since_last_decode = False
+        decode_layout_changed = runner._decode_layout_changed_since_last_decode
         slot_remap = lane_batch.pop_slot_remap()  # identity for stable slots
 
         return TTModelInput(
@@ -1232,7 +1231,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host sampling reads the merged batch directly (see
             # ``extract_output``); the per-rank sidecars are unused here.
@@ -1331,7 +1330,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=False,
+            decode_layout_changed=False,
             slot_remap=None,
             allowed_token_ids_mask_list=[None],
             bad_words_token_ids_list=[{}],

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -52,9 +52,7 @@ from vllm_tt_plugin.scheduler import (
     TTScheduler,
     TTSchedulingMode,
     get_tt_forced_reset_discard_counts,
-    get_tt_unreserved_resumed_prefill_req_ids,
     set_tt_forced_reset_discard_counts,
-    set_tt_unreserved_resumed_prefill_req_ids,
 )
 
 if TYPE_CHECKING:
@@ -156,7 +154,6 @@ def merge_lane_scheduler_outputs(
     pending_structured_output_tokens = False
     num_invalid_spec_tokens: dict[str, int] | None = None
     forced_reset_discard_counts: dict[str, int] = {}
-    unreserved_resumed_prefill_req_ids: set[str] = set()
 
     for out in lane_outputs:
         scheduled_new_reqs.extend(out.scheduled_new_reqs)
@@ -220,9 +217,6 @@ def merge_lane_scheduler_outputs(
             forced_reset_discard_counts[req_id] = (
                 forced_reset_discard_counts.get(req_id, 0) + count
             )
-        unreserved_resumed_prefill_req_ids.update(
-            get_tt_unreserved_resumed_prefill_req_ids(out)
-        )
 
     total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
     merged = SchedulerOutput(
@@ -241,9 +235,6 @@ def merge_lane_scheduler_outputs(
         num_invalid_spec_tokens=num_invalid_spec_tokens,
     )
     set_tt_forced_reset_discard_counts(merged, forced_reset_discard_counts)
-    set_tt_unreserved_resumed_prefill_req_ids(
-        merged, unreserved_resumed_prefill_req_ids
-    )
     return merged
 
 

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -48,7 +48,12 @@ from vllm_tt_plugin.config import (
     get_tt_per_lane_max_num_seqs,
 )
 from vllm_tt_plugin.logger import init_tt_logger
-from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
+from vllm_tt_plugin.scheduler import (
+    TTScheduler,
+    TTSchedulingMode,
+    get_tt_forced_reset_discard_counts,
+    set_tt_forced_reset_discard_counts,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -148,6 +153,7 @@ def merge_lane_scheduler_outputs(
     has_structured_output_requests = False
     pending_structured_output_tokens = False
     num_invalid_spec_tokens: dict[str, int] | None = None
+    forced_reset_discard_counts: dict[str, int] = {}
 
     for out in lane_outputs:
         scheduled_new_reqs.extend(out.scheduled_new_reqs)
@@ -207,9 +213,13 @@ def merge_lane_scheduler_outputs(
             if num_invalid_spec_tokens is None:
                 num_invalid_spec_tokens = {}
             num_invalid_spec_tokens.update(out.num_invalid_spec_tokens)
+        for req_id, count in get_tt_forced_reset_discard_counts(out).items():
+            forced_reset_discard_counts[req_id] = (
+                forced_reset_discard_counts.get(req_id, 0) + count
+            )
 
     total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
-    return SchedulerOutput(
+    merged = SchedulerOutput(
         scheduled_new_reqs=scheduled_new_reqs,
         scheduled_cached_reqs=cached,
         num_scheduled_tokens=num_scheduled_tokens,
@@ -224,6 +234,8 @@ def merge_lane_scheduler_outputs(
         pending_structured_output_tokens=pending_structured_output_tokens,
         num_invalid_spec_tokens=num_invalid_spec_tokens,
     )
+    set_tt_forced_reset_discard_counts(merged, forced_reset_discard_counts)
+    return merged
 
 
 class TTLaneCoordinator(SchedulerInterface):
@@ -554,6 +566,7 @@ class TTLaneCoordinator(SchedulerInterface):
             carried_finished = merged.finished_req_ids
             carried_free_encoder = merged.free_encoder_mm_hashes
             carried_preempted = merged.preempted_req_ids
+            carried_reset_discards = get_tt_forced_reset_discard_counts(merged)
             forced_mode = TTSchedulingMode.DECODE_ONLY
             lane_outputs = self._schedule_all_lanes(forced_mode)
             merged = merge_lane_scheduler_outputs(lane_outputs)
@@ -565,6 +578,13 @@ class TTLaneCoordinator(SchedulerInterface):
                 merged.preempted_req_ids = (
                     merged.preempted_req_ids or set()
                 ) | carried_preempted
+            if carried_reset_discards:
+                current_reset_discards = get_tt_forced_reset_discard_counts(merged)
+                for req_id, count in carried_reset_discards.items():
+                    current_reset_discards[req_id] = (
+                        current_reset_discards.get(req_id, 0) + count
+                    )
+                set_tt_forced_reset_discard_counts(merged, current_reset_discards)
 
         is_decode = forced_mode == TTSchedulingMode.DECODE_ONLY
         plan = self._build_step_plan(lane_outputs, merged, is_decode)

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -73,6 +73,9 @@ class TTStepPlan:
     req_id_to_row: dict[str, int]
     batch_size_per_dp: tuple[int, ...]
     prefill_empty_slots: tuple[int, ...] | None
+    # Exact scheduler-owned layout transition for this step. Merely leaving a
+    # live request unscheduled does not count: lane rows stay stable.
+    decode_layout_changed: bool = False
 
 
 @dataclass(frozen=True)
@@ -456,8 +459,10 @@ class TTLaneCoordinator(SchedulerInterface):
         merged: SchedulerOutput,
         is_decode: bool,
     ) -> TTStepPlan:
+        decode_layout_changed = False
         lane_of_req = self._lane_of_scheduled_reqs(lane_outputs)
         for req_id in merged.finished_req_ids:
+            decode_layout_changed |= req_id in self._req_to_row
             self._release_slot(req_id)
             self._req_to_lane.pop(req_id, None)
 
@@ -473,10 +478,12 @@ class TTLaneCoordinator(SchedulerInterface):
         # step, so the row is free on both sides before anything is placed there.
         # ``preempted_req_ids`` is typed optional, hence the ``or ()``.
         for req_id in merged.preempted_req_ids or ():
+            decode_layout_changed |= req_id in self._req_to_row
             self._release_slot(req_id)
 
         resumed_req_ids = set(merged.scheduled_cached_reqs.resumed_req_ids)
         for req_id in resumed_req_ids:
+            decode_layout_changed |= req_id in self._req_to_row
             self._release_slot(req_id)
 
         for req_id in merged.num_scheduled_tokens:
@@ -484,6 +491,7 @@ class TTLaneCoordinator(SchedulerInterface):
             if lane is None:
                 raise KeyError(f"no TT lane recorded for scheduled request {req_id!r}")
             self._req_to_lane[req_id] = lane
+            decode_layout_changed |= req_id not in self._req_to_row
             self._assign_slot(req_id, lane)
 
         scheduled_pairs = [
@@ -514,6 +522,7 @@ class TTLaneCoordinator(SchedulerInterface):
             req_id_to_row=dict(self._req_to_row),
             batch_size_per_dp=batch_size_per_dp,
             prefill_empty_slots=prefill_empty_slots,
+            decode_layout_changed=decode_layout_changed,
         )
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -52,7 +52,9 @@ from vllm_tt_plugin.scheduler import (
     TTScheduler,
     TTSchedulingMode,
     get_tt_forced_reset_discard_counts,
+    get_tt_unreserved_resumed_prefill_req_ids,
     set_tt_forced_reset_discard_counts,
+    set_tt_unreserved_resumed_prefill_req_ids,
 )
 
 if TYPE_CHECKING:
@@ -154,6 +156,7 @@ def merge_lane_scheduler_outputs(
     pending_structured_output_tokens = False
     num_invalid_spec_tokens: dict[str, int] | None = None
     forced_reset_discard_counts: dict[str, int] = {}
+    unreserved_resumed_prefill_req_ids: set[str] = set()
 
     for out in lane_outputs:
         scheduled_new_reqs.extend(out.scheduled_new_reqs)
@@ -217,6 +220,9 @@ def merge_lane_scheduler_outputs(
             forced_reset_discard_counts[req_id] = (
                 forced_reset_discard_counts.get(req_id, 0) + count
             )
+        unreserved_resumed_prefill_req_ids.update(
+            get_tt_unreserved_resumed_prefill_req_ids(out)
+        )
 
     total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
     merged = SchedulerOutput(
@@ -235,6 +241,9 @@ def merge_lane_scheduler_outputs(
         num_invalid_spec_tokens=num_invalid_spec_tokens,
     )
     set_tt_forced_reset_discard_counts(merged, forced_reset_discard_counts)
+    set_tt_unreserved_resumed_prefill_req_ids(
+        merged, unreserved_resumed_prefill_req_ids
+    )
     return merged
 
 

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -20,6 +20,44 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 
 
 @dataclass(frozen=True)
+class TTDecodeReloadPlan:
+    """Explicit host-to-device updates for one decode submission.
+
+    The TT runner owns these decisions because it knows whether host
+    token/position tensors are authoritative or intentionally one step behind
+    an overlapped device-sampling decode. Contract-aware generators execute
+    these flags as commands; they must not infer additional reloads from tensor
+    equality, sampling mode, or their own previous-call state.
+    """
+
+    reload_inputs: bool
+    reload_page_table: bool
+    reload_sampling_params: bool
+    reset_sampling_state: bool
+
+    def __post_init__(self) -> None:
+        # Sampling-state reset may align seeded counters from the host position,
+        # which is authoritative only on a full forward-input reload.
+        assert not (self.reset_sampling_state and not self.reload_inputs), (
+            "reset_sampling_state requires reload_inputs"
+        )
+        # A full input reload already includes page tables. The two booleans
+        # encode "everything", "page table only", or "nothing".
+        assert not (self.reload_page_table and self.reload_inputs), (
+            "reload_page_table is only valid without reload_inputs"
+        )
+
+    @property
+    def overlap_safe(self) -> bool:
+        """Whether a device-resident decode may be submitted host-stale."""
+        return not (
+            self.reload_inputs
+            or self.reload_sampling_params
+            or self.reset_sampling_state
+        )
+
+
+@dataclass(frozen=True)
 class TTSamplingParams:
     """Sampling parameters for TT model execution.
 
@@ -90,13 +128,13 @@ class TTModelInput:
     # In lane mode this is true only if every lane can sample on device.
     perform_device_sampling: bool
 
-    # always lists: single-element for non-DP, multi-element for DP
+    # Lists preserve the sampling-helper interface; each independent runner and
+    # each merged lane step supplies one element.
     # If not used, [None]
     grammar_bitmask: list[torch.Tensor | None]
 
-    # Host-only sampling params - lists for DP (one per rank), single-element
-    # for non-DP. These are used for host sampling when device sampling is not
-    # supported.
+    # Host-only sampling params. Each independent rank supplies one list entry;
+    # lane mode supplies one merged entry. Used when device sampling is absent.
     logitsprocs_list: list[LogitsProcessors | None]
     # bad_words_token_ids: list of dicts mapping req_index -> token_ids
     bad_words_token_ids_list: list[dict[int, list[list[int]]]]
@@ -113,9 +151,10 @@ class TTModelInput:
     prompt_tokens: torch.Tensor | None = None
     output_tokens: torch.Tensor | None = None
 
-    # Decode-only: indicates the padded decode-batch layout changed since the
-    # previous step (used by on-device sampling).
-    reset_batch: bool = False
+    # Decode-only runner lifecycle signal. Contract-v1 adapters receive the
+    # explicit reload commands derived from this; legacy adapters receive it
+    # translated to their historical ``reset_batch`` keyword.
+    decode_layout_changed: bool = False
 
     # Decode-only: device state slot remap - row i reads slot remap[i]. From
     # ``_req_state_slot`` (lane mode: the condense-move remap). ``None`` means

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -175,10 +175,3 @@ class TTModelInput:
     # must resolve rows through this. ``None`` for lane builds, whose rows are
     # the persistent slots.
     row_req_ids: list[str] | None = None
-
-    # Prefill-only rows whose sampled output is a duplicate of an older valid
-    # in-flight frame. This occurs when ordinary async preemption is resumed
-    # before that older frame reaches the scheduler: replay rebuilds KV from the
-    # committed sequence, but its final prefill predicts the same logical token
-    # and owns no additional output placeholder.
-    suppressed_prefill_output_req_ids: frozenset[str] = frozenset()

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -175,3 +175,10 @@ class TTModelInput:
     # must resolve rows through this. ``None`` for lane builds, whose rows are
     # the persistent slots.
     row_req_ids: list[str] | None = None
+
+    # Prefill-only rows whose sampled output is a duplicate of an older valid
+    # in-flight frame. This occurs when ordinary async preemption is resumed
+    # before that older frame reaches the scheduler: replay rebuilds KV from the
+    # committed sequence, but its final prefill predicts the same logical token
+    # and owns no additional output placeholder.
+    suppressed_prefill_output_req_ids: frozenset[str] = frozenset()

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1450,11 +1450,10 @@ class TTModelRunner:
         TTModelInput from it's own scheduler output.
         """
         # Update scheduler-owned state before accepting any older async result.
-        # Late rows for request IDs already reported finished are rejected; the
-        # row that actually finished the request was accepted earlier. Ordinary
-        # preemption/resume keeps a completed token valid for replay; only a
-        # wholesale prefix-cache reset marks its outstanding frames stale
-        # through an explicit scheduler discard count.
+        # Reject late results for request IDs already reported finished. The
+        # result that finished the request was accepted earlier. Ordinary
+        # preemption or resume keeps a completed token valid for replay. Only a
+        # forced prefix-cache reset marks an in-flight result for discard.
         self._update_states(scheduler_output)
         if (
             self.async_decode.decode_input_update_contract_version() < 1

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -65,7 +65,10 @@ from vllm_tt_plugin.model_input import (
     slice_tt_sampling_params,
 )
 from vllm_tt_plugin.platform import TTPlatform
-from vllm_tt_plugin.scheduler import get_tt_forced_reset_discard_counts
+from vllm_tt_plugin.scheduler import (
+    get_tt_forced_reset_discard_counts,
+    get_tt_unreserved_resumed_prefill_req_ids,
+)
 from vllm_tt_plugin.structured_output import (
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
@@ -1277,6 +1280,9 @@ class TTModelRunner:
                 # never read, so there is nothing to default in place.
 
         row_req_ids = [input_batch.req_ids[i] for i in req_indices]
+        suppressed_prefill_output_req_ids = get_tt_unreserved_resumed_prefill_req_ids(
+            scheduler_output
+        )
 
         tt_sampling_params = slice_tt_sampling_params(sample_params, req_indices)
         if not is_prompt and input_tokens.shape[0] > len(req_indices):
@@ -1432,6 +1438,7 @@ class TTModelRunner:
             block_tables_per_layer=self._block_tables_per_layer(block_tables_per_group),
             unpadded_batch_size=num_reqs,
             row_req_ids=row_req_ids,
+            suppressed_prefill_output_req_ids=suppressed_prefill_output_req_ids,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
             perform_device_sampling=perform_device_sampling,
@@ -1660,12 +1667,16 @@ class TTModelRunner:
                 dtype=np.int64,
             )
             intermediate_mask = prompt_lens < num_tokens
-            if intermediate_mask.any():
+            suppressed = getattr(
+                model_input, "suppressed_prefill_output_req_ids", frozenset()
+            )
+            if intermediate_mask.any() or suppressed:
                 return self._build_chunked_prefill_output(
                     req_ids=req_ids,
                     sampled_token_ids=sampled,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask,
+                    suppressed_req_ids=suppressed,
                     defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
@@ -1826,12 +1837,16 @@ class TTModelRunner:
 
             assert intermediate_mask is not None
 
-            if intermediate_mask.any():
+            suppressed = getattr(
+                fwd.model_input, "suppressed_prefill_output_req_ids", frozenset()
+            )
+            if intermediate_mask.any() or suppressed:
                 return self._build_chunked_prefill_output(
                     req_ids=row_req_ids,
                     sampled_token_ids=sampled_token_ids,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask.numpy(),
+                    suppressed_req_ids=suppressed,
                     defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
@@ -1861,18 +1876,29 @@ class TTModelRunner:
         intermediate_mask: np.ndarray,
         req_id_to_index: dict[str, int] | None = None,
         defer_state_apply: bool = False,
+        suppressed_req_ids: set[str] | frozenset[str] | None = None,
     ) -> ModelRunnerOutput:
-        """Build a prefill output that emits no token for intermediate chunks.
+        """Build a prefill output with lifecycle-owned rows suppressed.
 
         A request mid-prompt gets ``[]`` so the engine advances its computed
-        tokens without appending output; only rows whose chunk ended the prompt
-        emit a token and are applied to runner state.
+        tokens without appending output. A resumed context-phase request also
+        gets ``[]`` when its older in-flight frame is still outstanding: replay
+        predicts the same logical token and did not reserve another placeholder.
+        Only the remaining final rows emit a token and reach runner state.
         """
         assert self._output_tokens_per_step == 1, (
             "Chunked-prefill output suppression assumes one sampled token per "
             "request; block-output models must disable chunked prefill"
         )
-        final_idx_np = np.where(~intermediate_mask)[0]
+        suppressed = set(suppressed_req_ids or ())
+        emit_mask = np.asarray(
+            [
+                not bool(intermediate_mask[i]) and req_id not in suppressed
+                for i, req_id in enumerate(req_ids)
+            ],
+            dtype=bool,
+        )
+        final_idx_np = np.where(emit_mask)[0]
         final_tokens = None
         final_req_ids: list[str] = []
         if final_idx_np.shape[0] > 0:
@@ -1887,7 +1913,7 @@ class TTModelRunner:
         if sampled_token_ids_np.dtype != np.int32:
             sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
         sampled_token_id_lists = [
-            [] if intermediate_mask[i] else [int(sampled_token_ids_np[i])]
+            [int(sampled_token_ids_np[i])] if emit_mask[i] else []
             for i in range(num_reqs)
         ]
 

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -65,10 +65,7 @@ from vllm_tt_plugin.model_input import (
     slice_tt_sampling_params,
 )
 from vllm_tt_plugin.platform import TTPlatform
-from vllm_tt_plugin.scheduler import (
-    get_tt_forced_reset_discard_counts,
-    get_tt_unreserved_resumed_prefill_req_ids,
-)
+from vllm_tt_plugin.scheduler import get_tt_forced_reset_discard_counts
 from vllm_tt_plugin.structured_output import (
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
@@ -231,8 +228,9 @@ class TTModelRunner:
         self._pending_samples: deque[Any] = deque()
 
         # The platform has already disabled upstream async scheduling when the
-        # registered model lacks async-decode capability. After loading, the
-        # v0 standard-DP rollout guard below may narrow this further.
+        # registered model lacks async-decode capability. After loading, v0
+        # restores the pre-contract runner predicate exactly; v1 keeps this
+        # platform-gated value.
         self.async_decode_scheduling = self.scheduler_config.async_scheduling
         self._steady_decode_lock = threading.Lock()
         self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
@@ -319,28 +317,34 @@ class TTModelRunner:
         self.model = loader.load_model(
             vllm_config=self.vllm_config, model_config=self.model_config
         )
-        self._disable_async_decode_for_v0_standard_dp()
+        self._preserve_v0_async_decode_selection()
 
-    def _disable_async_decode_for_v0_standard_dp(self) -> None:
-        """Preserve the pre-contract synchronous standard-DP runner path.
+    def _preserve_v0_async_decode_selection(self) -> None:
+        """Restore the pre-contract runner-local async predicate for v0.
 
-        The platform capability gate owns the broader async decision. This
-        post-load guard only handles rollout compatibility: v0 standard-DP
-        adapters remain synchronous, while v1 adapters may overlap locally on
-        each independent rank.
+        Before the reload contract the runner enabled its deferred decode path
+        exactly when upstream async scheduling was enabled and its local
+        ``data_parallel_size`` was one. Dense standard-DP engine processes are
+        normalized by upstream to that rank-local value, so they were async too;
+        preserving v0 means retaining that behavior rather than reconstructing
+        the deployment's original DP size here. Contract-v1 adapters keep the
+        broader platform-gated value initialized before model load.
         """
         model = getattr(self, "model", None)
         contract_version = int(getattr(model, "decode_input_update_contract", 0))
-        if self.parallel_config.data_parallel_size > 1 and contract_version < 1:
-            self.async_decode_scheduling = False
+        if contract_version < 1:
+            self.async_decode_scheduling = bool(
+                self.scheduler_config.async_scheduling
+                and self.parallel_config.data_parallel_size == 1
+            )
 
     def _uses_async_scheduler(self) -> bool:
         """Whether upstream publishes outputs through placeholder accounting.
 
-        This is intentionally broader than ``async_decode_scheduling``: a
-        contract-v0 standard-DP runner executes synchronously but still sits
-        behind ``AsyncScheduler`` and therefore needs lifecycle-deferred host
-        state for its sampled outputs.
+        This is intentionally broader than ``async_decode_scheduling``: the
+        legacy v0 runner predicate can narrow deferred device readback while
+        the engine still uses ``AsyncScheduler`` placeholder accounting, whose
+        sampled outputs require lifecycle-deferred host state.
         """
         return bool(
             getattr(getattr(self, "scheduler_config", None), "async_scheduling", False)
@@ -1279,9 +1283,6 @@ class TTModelRunner:
                 # never read, so there is nothing to default in place.
 
         row_req_ids = [input_batch.req_ids[i] for i in req_indices]
-        suppressed_prefill_output_req_ids = get_tt_unreserved_resumed_prefill_req_ids(
-            scheduler_output
-        )
 
         tt_sampling_params = slice_tt_sampling_params(sample_params, req_indices)
         if not is_prompt and input_tokens.shape[0] > len(req_indices):
@@ -1437,7 +1438,6 @@ class TTModelRunner:
             block_tables_per_layer=self._block_tables_per_layer(block_tables_per_group),
             unpadded_batch_size=num_reqs,
             row_req_ids=row_req_ids,
-            suppressed_prefill_output_req_ids=suppressed_prefill_output_req_ids,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
             perform_device_sampling=perform_device_sampling,
@@ -1666,16 +1666,12 @@ class TTModelRunner:
                 dtype=np.int64,
             )
             intermediate_mask = prompt_lens < num_tokens
-            suppressed = getattr(
-                model_input, "suppressed_prefill_output_req_ids", frozenset()
-            )
-            if intermediate_mask.any() or suppressed:
+            if intermediate_mask.any():
                 return self._build_chunked_prefill_output(
                     req_ids=req_ids,
                     sampled_token_ids=sampled,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask,
-                    suppressed_req_ids=suppressed,
                     defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
@@ -1835,17 +1831,12 @@ class TTModelRunner:
             intermediate_mask = fwd.model_input.intermediate_prefill_mask
 
             assert intermediate_mask is not None
-
-            suppressed = getattr(
-                fwd.model_input, "suppressed_prefill_output_req_ids", frozenset()
-            )
-            if intermediate_mask.any() or suppressed:
+            if intermediate_mask.any():
                 return self._build_chunked_prefill_output(
                     req_ids=row_req_ids,
                     sampled_token_ids=sampled_token_ids,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask.numpy(),
-                    suppressed_req_ids=suppressed,
                     defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
@@ -1875,26 +1866,19 @@ class TTModelRunner:
         intermediate_mask: np.ndarray,
         req_id_to_index: dict[str, int] | None = None,
         defer_state_apply: bool = False,
-        suppressed_req_ids: set[str] | frozenset[str] | None = None,
     ) -> ModelRunnerOutput:
-        """Build a prefill output with lifecycle-owned rows suppressed.
+        """Build a prefill output with intermediate rows suppressed.
 
         A request mid-prompt gets ``[]`` so the engine advances its computed
-        tokens without appending output. A resumed context-phase request also
-        gets ``[]`` when its older in-flight frame is still outstanding: replay
-        predicts the same logical token and did not reserve another placeholder.
-        Only the remaining final rows emit a token and reach runner state.
+        tokens without appending output. Only final rows emit a token and reach
+        runner state.
         """
         assert self._output_tokens_per_step == 1, (
             "Chunked-prefill output suppression assumes one sampled token per "
             "request; block-output models must disable chunked prefill"
         )
-        suppressed = set(suppressed_req_ids or ())
         emit_mask = np.asarray(
-            [
-                not bool(intermediate_mask[i]) and req_id not in suppressed
-                for i, req_id in enumerate(req_ids)
-            ],
+            [not bool(intermediate_mask[i]) for i in range(len(req_ids))],
             dtype=bool,
         )
         final_idx_np = np.where(emit_mask)[0]

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -101,7 +101,7 @@ def _parse_layer_index(layer_name: str) -> int:
 
 @dataclass(frozen=True)
 class _SyncForward:
-    """Materialized non-DP forward result awaiting host/device sampling.
+    """Materialized front-packed forward result awaiting sampling.
 
     Carries everything ``_get_output_tokens`` needs so the sampling tail can
     run in a later ``sample_tokens`` call rather than inside ``execute_model``.
@@ -224,12 +224,10 @@ class TTModelRunner:
         # correct even with one forward in flight.
         self._pending_samples: deque[Any] = deque()
 
-        # Non-DP async scheduling: overlap CPU scheduling with device execution.
-        # Only supported for DP=1 (DP>1 uses a different execution path).
-        self.non_dp_async_scheduling = (
-            self.scheduler_config.async_scheduling
-            and self.parallel_config.data_parallel_size == 1
-        )
+        # Standard-DP version 0 was synchronous before the explicit contract;
+        # keep it so until the loaded adapter can prove it understands which
+        # host inputs are authoritative. ``load_model`` refreshes this for v1.
+        self._configure_async_decode_scheduling()
         self._steady_decode_lock = threading.Lock()
         self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
         self._pending_async_overlap_ok: deque[bool] = deque()
@@ -243,6 +241,7 @@ class TTModelRunner:
         # RNG, decode trace buffers). Needed because evict/re-add and condense move a
         # request's ROW, not its state.
         self._req_state_slot: dict[str, int] = {}
+        self._pending_state_slot_settle: dict[str, int] | None = None
 
         # Every standard-DP rank owns its own mesh and therefore its own host
         # sampler state. Single-process modes also instantiate exactly one.
@@ -296,8 +295,8 @@ class TTModelRunner:
         ``tt_data_parallel_size`` in-process DP replicas. In this mode the
         persistent batch is a ``TTLaneInputBatch`` that owns the lane layout
         (stable per-lane device slots, merged sampling) and the runner only
-        orchestrates; standard multi-process DP and non-DP keep the plain
-        ``InputBatch``, one per engine.
+        orchestrates; single-process execution and standard multi-process DP
+        ranks keep the plain ``InputBatch``, one per engine.
 
         Derived (rather than cached in ``__init__``) so it depends only on
         already-set runner state -- this mirrors ``uses_tt_lane_coordinator``:
@@ -313,6 +312,21 @@ class TTModelRunner:
         loader = TTModelLoader(self.load_config)
         self.model = loader.load_model(
             vllm_config=self.vllm_config, model_config=self.model_config
+        )
+        self._configure_async_decode_scheduling()
+
+    def _configure_async_decode_scheduling(self) -> None:
+        """Select this runner's async path without changing engine config.
+
+        Each standard-DP rank owns an independent submission stream, so v1 can
+        overlap locally with no gather or vote. A version-0 standard-DP adapter
+        keeps the pre-contract synchronous runner path.
+        """
+        model = getattr(self, "model", None)
+        contract_version = int(getattr(model, "decode_input_update_contract", 0))
+        self.async_decode_scheduling = bool(
+            self.scheduler_config.async_scheduling
+            and (self.parallel_config.data_parallel_size == 1 or contract_version >= 1)
         )
 
     def get_supported_generation_tasks(self) -> list[GenerationTask]:
@@ -958,8 +972,8 @@ class TTModelRunner:
     def _decode_state_slot_remap(self, row_req_ids: list[str]) -> torch.Tensor | None:
         """Gather permutation taking each request's state to its decode row: row
         ``i`` reads slot ``remap[i]``. Always full slot width (no OOB gather); None
-        means identity, so skip it. Commits the move to ``self._req_state_slot`` for
-        every request the permutation touches, off-batch holders included."""
+        means identity, so skip it. The resulting ownership map remains pending
+        until ``decode_forward`` accepts the submission."""
         n_slots = self.tt_per_lane_max_num_seqs
         # More decode rows than slots means the batch cannot be described at all, so
         # truncating would just drop a request's state silently.
@@ -999,10 +1013,21 @@ class TTModelRunner:
         for row, slot in enumerate(remap):
             for req_id in by_slot.get(slot, ()):
                 moved[req_id] = row
-        self._req_state_slot = moved
+        self._pending_state_slot_settle = moved
         if all(remap[i] == i for i in range(n_slots)):
+            self._pending_state_slot_settle = None
             return None
         return torch.tensor(remap, dtype=torch.int32)
+
+    def note_decode_state_slots_settled(self) -> None:
+        """Commit a remap only after the model accepted the decode."""
+        if self._pending_state_slot_settle is not None:
+            self._req_state_slot = self._pending_state_slot_settle
+            self._pending_state_slot_settle = None
+
+    def note_decode_layout_consumed(self) -> None:
+        """Retire the sticky layout transition after an accepted decode."""
+        self._decode_layout_changed_since_last_decode = False
 
     @staticmethod
     def _build_host_generators(
@@ -1050,8 +1075,9 @@ class TTModelRunner:
 
         Reads the current persistent ``self.input_batch`` and assembles the
         padded, fixed-shape tensors a TT model needs (constant shapes are
-        required for ttnn tracing). This is the input builder for the non-DP and
-        standard multi-process DP paths; each operates on its whole local
+        required for ttnn tracing). This is the front-packed input builder for
+        single-process execution and standard multi-process DP; each rank
+        operates on its whole local
         ``input_batch``. Single-process lane mode does not use this builder --
         it builds its merged device input directly from ``TTLaneInputBatch``.
 
@@ -1192,7 +1218,7 @@ class TTModelRunner:
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
             ]
-            reset_batch = False
+            decode_layout_changed = False
         else:
             positions_np = input_batch.num_tokens[req_indices] - 1
             input_positions = torch.from_numpy(positions_np)
@@ -1200,10 +1226,10 @@ class TTModelRunner:
                 req_indices, positions_np
             ].view(-1, 1)
             prompt_lens = None
-            # For on-device decode sampling, tell the backend if the padded
-            # decode batch layout changed since the previous step.
-            reset_batch = self._decode_layout_changed_since_last_decode
-            self._decode_layout_changed_since_last_decode = False
+            # Record whether the padded decode layout changed since the previous
+            # decode. The controller translates this lifecycle fact into either
+            # explicit contract commands or the legacy ``reset_batch`` keyword.
+            decode_layout_changed = self._decode_layout_changed_since_last_decode
 
             # TODO: Remove once TT models can support arbitrary batch sizes.
             # Pad decode to the lane/rank wire capacity.
@@ -1398,7 +1424,7 @@ class TTModelRunner:
             grammar_bitmask=[bitmask],  # wrap to match DP case
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
@@ -1426,23 +1452,23 @@ class TTModelRunner:
         For data parallel, this function is called by each DP rank to build
         TTModelInput from it's own scheduler output.
         """
-        # Update cached state
+        # Update scheduler-owned state before accepting any older async result:
+        # requests finished, preempted, or resumed by this schedule must reject
+        # the speculative token, while continuing requests need it before host
+        # tensors are built.
         self._update_states(scheduler_output)
+        if (
+            self.async_decode.decode_input_update_contract_version() < 1
+            and self._decode_layout_changed_since_last_decode
+        ):
+            # Preserve the legacy path's drain point: version-0 adapters still
+            # own reload policy and receive reset_batch after batch mutation.
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
+        self.async_decode.apply_ready_completed_decode_steps(
+            skip_req_ids=self.async_decode.invalidated_req_ids(scheduler_output)
+        )
         if not scheduler_output.total_num_scheduled_tokens:
             return None
-
-        # ``_update_states`` may have just discovered a layout change that the
-        # scheduler-output prediction could not see: it predicts the resets caused by
-        # new or resumed requests, but removals, unscheduled requests and batch
-        # condensation only surface here, after the drain decision was already made.
-        # ``_decode_layout_changed_since_last_decode = True`` implies
-        # ``reset_batch=True``: ``_prepare_model_inputs`` below reloads inputs from host
-        # state, which a pending async decode step has not been applied to yet. This
-        # step is therefore not steady-decode eligible, so drain pending decodes to
-        # ensure updated host inputs. No-op when the flag was already set before the
-        # step (the caller's drain decision covered it) or when nothing is pending.
-        if self._decode_layout_changed_since_last_decode:
-            self.async_decode.wait_for_all_pending_async_steps()
 
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output, grammar_output)
@@ -1480,25 +1506,31 @@ class TTModelRunner:
             )
 
         lane_batch = self.lane_batch
-        self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_lane_decode_from_scheduler(
-                scheduler_output
+                scheduler_output,
+                decode_layout_changed=plan.decode_layout_changed,
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
         )
+        assert layout_changed == plan.decode_layout_changed, (
+            "lane scheduler and runner disagreed about decode layout change: "
+            f"plan={plan.decode_layout_changed}, applied={layout_changed}"
+        )
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
-            # ``_decode_layout_changed_since_last_decode = True`` implies
-            # ``reset_batch=True``: the model will reload inputs. This step is not
-            # steady-decode eligible, so drain pending decodes to ensure updated
-            # host inputs.
-            self.async_decode.wait_for_all_pending_async_steps()
+            if self.async_decode.decode_input_update_contract_version() < 1:
+                self.async_decode.wait_for_all_pending_async_steps(
+                    apply_completed=False
+                )
+        self.async_decode.apply_ready_completed_decode_steps(
+            skip_req_ids=self.async_decode.invalidated_req_ids(scheduler_output)
+        )
 
         if not scheduler_output.total_num_scheduled_tokens:
             return EMPTY_MODEL_RUNNER_OUTPUT
@@ -1515,7 +1547,7 @@ class TTModelRunner:
         if plan.is_decode:
             # ``slot_grammar_bitmask`` reorders against the full decode capacity.
             lane_total = plan.capacity
-            if self.non_dp_async_scheduling:
+            if self.async_decode_scheduling:
                 req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
                 context = self.async_decode.capture_submitted_step_context(req_ids)
                 wrapper = self.async_decode.submit_async_lane_decode(
@@ -1617,7 +1649,7 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
     ) -> ModelRunnerOutput | None:
-        """Run the device forward for one non-DP or lane-DP step.
+        """Run this rank's front-packed or lane-DP device forward.
 
         Returns ``None`` after enqueuing a pending sampler; the engine computes
         the grammar bitmask while the forward runs and then calls
@@ -1632,16 +1664,15 @@ class TTModelRunner:
         if get_tt_step_plan(scheduler_output) is not None:
             return self._execute_lane_step(scheduler_output)
 
-        # Apply any decode steps that have already completed on the async
-        # thread. In steady decode mode we intentionally allow one step of
-        # lag between host application and device submission, but we never let
-        # completed work pile up unbounded.
-        self.async_decode.apply_ready_completed_decode_steps()
+        # Decide whether the next build can remain one step host-stale before
+        # mutating the persistent batch. On a transition, finalize pending work
+        # now but defer applying it until ``build_model_input`` has processed
+        # lifecycle events and can reject finished/preempted/resumed rows.
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_decode_from_scheduler(scheduler_output)
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -1649,11 +1680,11 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         is_decode = model_input.prompt_lens is None
-        if self.non_dp_async_scheduling and is_decode:
+        if self.async_decode_scheduling and is_decode:
             steady_decode_fast_path = self.async_decode.can_use_steady_decode_fast_path(
                 model_input
             )
-            wrapper = self.async_decode.submit_async_non_dp_decode(
+            wrapper = self.async_decode.submit_async_decode(
                 model_input,
                 steady_decode_fast_path=steady_decode_fast_path,
             )
@@ -1670,7 +1701,7 @@ class TTModelRunner:
         # Synchronous path (prefill, or decode without async scheduling): run
         # the forward now and defer sampling to ``sample_tokens``.
         fwd = self._forward_with_model_input(model_input)
-        self._pending_samples.append(partial(self._finish_nondp_sync, fwd=fwd))
+        self._pending_samples.append(partial(self._finish_front_packed_sync, fwd=fwd))
         return None
 
     def _reorder_grammar_bitmask(
@@ -1732,10 +1763,10 @@ class TTModelRunner:
             wrapper.set_grammar_bitmask(bitmask)
         return wrapper
 
-    def _finish_nondp_sync(
+    def _finish_front_packed_sync(
         self, grammar_output: GrammarOutput | None, *, fwd: _SyncForward | None
     ) -> ModelRunnerOutput:
-        """Sample and build the runner output for a deferred non-DP forward."""
+        """Sample and build output for a deferred front-packed forward."""
         if fwd is None:
             return self.apply_and_build_runner_output(
                 torch.tensor([], dtype=torch.int32), None
@@ -1956,8 +1987,11 @@ class TTModelRunner:
             # Store rope_deltas for each prefilled request
             for i, req_id in enumerate(self.input_batch.req_ids):
                 self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
+            self.async_decode.note_prefill_submitted()
             return tt_out
-        return self.model.prefill_forward(**kwargs)
+        tt_out = self.model.prefill_forward(**kwargs)
+        self.async_decode.note_prefill_submitted()
+        return tt_out
 
     def _forward_with_model_input(
         self,
@@ -2346,6 +2380,7 @@ class TTModelRunner:
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
         request_states: tuple[CachedRequestState, ...] | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
@@ -2435,6 +2470,8 @@ class TTModelRunner:
                         )
 
         for req_idx, req_id in enumerate(captured_req_ids):
+            if skip_req_ids is not None and req_id in skip_req_ids:
+                continue
             req_state = self.requests.get(req_id)
             # A deferred decode step can be applied after the engine finished
             # and dropped its request, so a missing state is ordinary. Same for

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1450,9 +1450,11 @@ class TTModelRunner:
         TTModelInput from it's own scheduler output.
         """
         # Update scheduler-owned state before accepting any older async result.
-        # Finished rows reject it. Ordinary preemption/resume keeps a completed
-        # token valid for replay; only a wholesale prefix-cache reset marks its
-        # outstanding frames stale through an explicit scheduler discard count.
+        # Late rows for request IDs already reported finished are rejected; the
+        # row that actually finished the request was accepted earlier. Ordinary
+        # preemption/resume keeps a completed token valid for replay; only a
+        # wholesale prefix-cache reset marks its outstanding frames stale
+        # through an explicit scheduler discard count.
         self._update_states(scheduler_output)
         if (
             self.async_decode.decode_input_update_contract_version() < 1

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -230,10 +230,10 @@ class TTModelRunner:
         # correct even with one forward in flight.
         self._pending_samples: deque[Any] = deque()
 
-        # Standard-DP version 0 was synchronous before the explicit contract;
-        # keep it so until the loaded adapter can prove it understands which
-        # host inputs are authoritative. ``load_model`` refreshes this for v1.
-        self._configure_async_decode_scheduling()
+        # The platform has already disabled upstream async scheduling when the
+        # registered model lacks async-decode capability. After loading, the
+        # v0 standard-DP rollout guard below may narrow this further.
+        self.async_decode_scheduling = self.scheduler_config.async_scheduling
         self._steady_decode_lock = threading.Lock()
         self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
         self._pending_async_overlap_ok: deque[bool] = deque()
@@ -319,21 +319,20 @@ class TTModelRunner:
         self.model = loader.load_model(
             vllm_config=self.vllm_config, model_config=self.model_config
         )
-        self._configure_async_decode_scheduling()
+        self._disable_async_decode_for_v0_standard_dp()
 
-    def _configure_async_decode_scheduling(self) -> None:
-        """Select this runner's async path without changing engine config.
+    def _disable_async_decode_for_v0_standard_dp(self) -> None:
+        """Preserve the pre-contract synchronous standard-DP runner path.
 
-        Each standard-DP rank owns an independent submission stream, so v1 can
-        overlap locally with no gather or vote. A version-0 standard-DP adapter
-        keeps the pre-contract synchronous runner path.
+        The platform capability gate owns the broader async decision. This
+        post-load guard only handles rollout compatibility: v0 standard-DP
+        adapters remain synchronous, while v1 adapters may overlap locally on
+        each independent rank.
         """
         model = getattr(self, "model", None)
         contract_version = int(getattr(model, "decode_input_update_contract", 0))
-        self.async_decode_scheduling = bool(
-            self.scheduler_config.async_scheduling
-            and (self.parallel_config.data_parallel_size == 1 or contract_version >= 1)
-        )
+        if self.parallel_config.data_parallel_size > 1 and contract_version < 1:
+            self.async_decode_scheduling = False
 
     def _uses_async_scheduler(self) -> bool:
         """Whether upstream publishes outputs through placeholder accounting.

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -686,11 +686,10 @@ class TTModelRunner:
             self.requests.pop(req_id, None)
 
         # Remove the finished requests from the persistent batch.
-        # NOTE(woosuk): There could be an edge case where finished_req_ids and
-        # scheduled_req_ids overlap. This happens when a request is aborted and
-        # then resubmitted with the same ID. In this case, we treat them as two
-        # distinct requests - clearing the cached states for the first request
-        # and handling the second as a new request.
+        # Upstream input processing gives resubmissions fresh internal IDs, but
+        # keep the update order robust for an internal caller that bypasses it:
+        # a finished and newly scheduled duplicate is treated as two requests,
+        # clearing the old cached state before adding the new one.
         removed_req_indices: list[int] = []
         for req_id in scheduler_output.finished_req_ids:
             self._release_model_request(req_id)
@@ -2379,15 +2378,14 @@ class TTModelRunner:
         self,
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
-        request_states: tuple[CachedRequestState, ...] | None = None,
         skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
-        # time: lane mode pins each request to a stable slot for its lifetime
-        # and the ``request_states`` identity check guards slot reuse, so the
-        # live row equals the captured one. ``req_id_to_index`` is therefore the
-        # single source of truth for the target row.
+        # time: lane mode pins each request to a stable slot for its lifetime,
+        # while the scheduler lifecycle skip set rejects stale results before a
+        # live row is resolved. ``req_id_to_index`` is therefore the source of
+        # truth for the target row.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = _coerce_output_block(
@@ -2449,14 +2447,13 @@ class TTModelRunner:
             # raise never leaves a partially applied batch. Block canvases
             # are clipped below instead of raising.
             for req_idx, req_id in enumerate(captured_req_ids):
+                if skip_req_ids is not None and req_id in skip_req_ids:
+                    continue
                 req_state = self.requests.get(req_id)
-                if req_state is None:
-                    continue
-                if (
-                    request_states is not None
-                    and req_state is not request_states[req_idx]
-                ):
-                    continue
+                assert req_state is not None, (
+                    "captured request missing from runner state while applying "
+                    f"sampled tokens: req_id={req_id!r}"
+                )
                 current_row = self.input_batch.req_id_to_index.get(req_id)
                 if current_row is not None:
                     end_idx = (
@@ -2473,14 +2470,10 @@ class TTModelRunner:
             if skip_req_ids is not None and req_id in skip_req_ids:
                 continue
             req_state = self.requests.get(req_id)
-            # A deferred decode step can be applied after the engine finished
-            # and dropped its request, so a missing state is ordinary. Same for
-            # readmission under a reused id: the token has no live owner.
-            if req_state is None or (
-                request_states is not None and req_state is not request_states[req_idx]
-            ):
-                continue
-
+            assert req_state is not None, (
+                "captured request missing from runner state while applying sampled "
+                f"tokens: req_id={req_id!r}"
+            )
             current_row = self.input_batch.req_id_to_index.get(req_id)
             if current_row is not None:
                 start_idx = int(self.input_batch.num_tokens[current_row])

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -63,6 +63,7 @@ from vllm_tt_plugin.model_input import (
     slice_tt_sampling_params,
 )
 from vllm_tt_plugin.platform import TTPlatform
+from vllm_tt_plugin.scheduler import get_tt_forced_reset_discard_counts
 from vllm_tt_plugin.structured_output import (
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
@@ -1451,10 +1452,10 @@ class TTModelRunner:
         For data parallel, this function is called by each DP rank to build
         TTModelInput from it's own scheduler output.
         """
-        # Update scheduler-owned state before accepting any older async result:
-        # requests finished, preempted, or resumed by this schedule must reject
-        # the speculative token, while continuing requests need it before host
-        # tensors are built.
+        # Update scheduler-owned state before accepting any older async result.
+        # Finished rows reject it. Ordinary preemption/resume keeps a completed
+        # token valid for replay; only a wholesale prefix-cache reset marks its
+        # outstanding frames stale through an explicit scheduler discard count.
         self._update_states(scheduler_output)
         if (
             self.async_decode.decode_input_update_contract_version() < 1
@@ -1464,7 +1465,12 @@ class TTModelRunner:
             # own reload policy and receive reset_batch after batch mutation.
             self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
         self.async_decode.apply_ready_completed_decode_steps(
-            skip_req_ids=self.async_decode.invalidated_req_ids(scheduler_output)
+            suppress_output_req_ids=self.async_decode.suppressed_output_req_ids(
+                scheduler_output
+            ),
+            forced_reset_discard_counts=get_tt_forced_reset_discard_counts(
+                scheduler_output
+            ),
         )
         if not scheduler_output.total_num_scheduled_tokens:
             return None
@@ -1511,7 +1517,9 @@ class TTModelRunner:
                 decode_layout_changed=plan.decode_layout_changed,
             )
         )
-        if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
+        if self.async_decode.must_drain_pending_async_steps(
+            steady_decode_candidate, scheduler_output
+        ):
             self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         layout_changed = lane_batch.apply_step_plan(
@@ -1528,7 +1536,12 @@ class TTModelRunner:
                     apply_completed=False
                 )
         self.async_decode.apply_ready_completed_decode_steps(
-            skip_req_ids=self.async_decode.invalidated_req_ids(scheduler_output)
+            suppress_output_req_ids=self.async_decode.suppressed_output_req_ids(
+                scheduler_output
+            ),
+            forced_reset_discard_counts=get_tt_forced_reset_discard_counts(
+                scheduler_output
+            ),
         )
 
         if not scheduler_output.total_num_scheduled_tokens:
@@ -1666,11 +1679,13 @@ class TTModelRunner:
         # Decide whether the next build can remain one step host-stale before
         # mutating the persistent batch. On a transition, finalize pending work
         # now but defer applying it until ``build_model_input`` has processed
-        # lifecycle events and can reject finished/preempted/resumed rows.
+        # lifecycle events and the forced-reset discard boundary.
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_decode_from_scheduler(scheduler_output)
         )
-        if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
+        if self.async_decode.must_drain_pending_async_steps(
+            steady_decode_candidate, scheduler_output
+        ):
             self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         # Grammar is applied at sample time, so the forward builds without it.

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -228,9 +228,8 @@ class TTModelRunner:
         self._pending_samples: deque[Any] = deque()
 
         # The platform has already disabled upstream async scheduling when the
-        # registered model lacks async-decode capability. After loading, v0
-        # restores the pre-contract runner predicate exactly; v1 keeps this
-        # platform-gated value.
+        # registered model lacks async-decode capability. Contract negotiation
+        # selects reload semantics, not async eligibility.
         self.async_decode_scheduling = self.scheduler_config.async_scheduling
         self._steady_decode_lock = threading.Lock()
         self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
@@ -317,34 +316,12 @@ class TTModelRunner:
         self.model = loader.load_model(
             vllm_config=self.vllm_config, model_config=self.model_config
         )
-        self._preserve_v0_async_decode_selection()
-
-    def _preserve_v0_async_decode_selection(self) -> None:
-        """Restore the pre-contract runner-local async predicate for v0.
-
-        Before the reload contract the runner enabled its deferred decode path
-        exactly when upstream async scheduling was enabled and its local
-        ``data_parallel_size`` was one. Dense standard-DP engine processes are
-        normalized by upstream to that rank-local value, so they were async too;
-        preserving v0 means retaining that behavior rather than reconstructing
-        the deployment's original DP size here. Contract-v1 adapters keep the
-        broader platform-gated value initialized before model load.
-        """
-        model = getattr(self, "model", None)
-        contract_version = int(getattr(model, "decode_input_update_contract", 0))
-        if contract_version < 1:
-            self.async_decode_scheduling = bool(
-                self.scheduler_config.async_scheduling
-                and self.parallel_config.data_parallel_size == 1
-            )
 
     def _uses_async_scheduler(self) -> bool:
         """Whether upstream publishes outputs through placeholder accounting.
 
-        This is intentionally broader than ``async_decode_scheduling``: the
-        legacy v0 runner predicate can narrow deferred device readback while
-        the engine still uses ``AsyncScheduler`` placeholder accounting, whose
-        sampled outputs require lifecycle-deferred host state.
+        Synchronously produced outputs such as final prefills still require
+        lifecycle-deferred host state when the engine uses ``AsyncScheduler``.
         """
         return bool(
             getattr(getattr(self, "scheduler_config", None), "async_scheduling", False)
@@ -1483,7 +1460,7 @@ class TTModelRunner:
         ):
             # Preserve the legacy path's drain point: version-0 adapters still
             # own reload policy and receive reset_batch after batch mutation.
-            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
+            self.async_decode.wait_for_all_pending_async_steps()
         self.async_decode.apply_ready_completed_decode_steps(
             suppress_output_req_ids=self.async_decode.suppressed_output_req_ids(
                 scheduler_output
@@ -1540,7 +1517,7 @@ class TTModelRunner:
         if self.async_decode.must_drain_pending_async_steps(
             steady_decode_candidate, scheduler_output
         ):
-            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
+            self.async_decode.wait_for_all_pending_async_steps()
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
@@ -1552,9 +1529,7 @@ class TTModelRunner:
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
             if self.async_decode.decode_input_update_contract_version() < 1:
-                self.async_decode.wait_for_all_pending_async_steps(
-                    apply_completed=False
-                )
+                self.async_decode.wait_for_all_pending_async_steps()
         self.async_decode.apply_ready_completed_decode_steps(
             suppress_output_req_ids=self.async_decode.suppressed_output_req_ids(
                 scheduler_output
@@ -1711,7 +1686,7 @@ class TTModelRunner:
         if self.async_decode.must_drain_pending_async_steps(
             steady_decode_candidate, scheduler_output
         ):
-            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
+            self.async_decode.wait_for_all_pending_async_steps()
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -2588,11 +2563,11 @@ class TTModelRunner:
     ) -> None:
         """Queue sampled host state until scheduler lifecycle is known.
 
-        Final prefills and contract-v0 decode are sampled synchronously, but
-        under AsyncScheduler their published output is still protected by a
-        placeholder. Queue them beside completed async decodes so a forced
-        prefix reset can leave the published row intact for discard accounting
-        without first appending its stale token to runner state.
+        Final prefills are sampled synchronously, but under AsyncScheduler their
+        published output is still protected by a placeholder. Queue them beside
+        completed async decodes so a forced prefix reset can leave the published
+        row intact for discard accounting without first appending its stale
+        token to runner state.
         """
         now = time.perf_counter_ns()
         self.async_decode.enqueue_completed_decode_step(

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass, fields, replace
 from functools import partial
@@ -35,6 +36,7 @@ from vllm_tt_plugin.async_decode import (
     AsyncTTModelRunnerOutput,
     CompletedDecodeStep,
     DeferredDecodeOutput,
+    SubmittedStepContext,
     TTAsyncDecodeController,
 )
 from vllm_tt_plugin.config import (
@@ -328,6 +330,18 @@ class TTModelRunner:
         self.async_decode_scheduling = bool(
             self.scheduler_config.async_scheduling
             and (self.parallel_config.data_parallel_size == 1 or contract_version >= 1)
+        )
+
+    def _uses_async_scheduler(self) -> bool:
+        """Whether upstream publishes outputs through placeholder accounting.
+
+        This is intentionally broader than ``async_decode_scheduling``: a
+        contract-v0 standard-DP runner executes synchronously but still sits
+        behind ``AsyncScheduler`` and therefore needs lifecycle-deferred host
+        state for its sampled outputs.
+        """
+        return bool(
+            getattr(getattr(self, "scheduler_config", None), "async_scheduling", False)
         )
 
     def get_supported_generation_tasks(self) -> list[GenerationTask]:
@@ -1652,8 +1666,13 @@ class TTModelRunner:
                     sampled_token_ids=sampled,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask,
+                    defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
+        if TTModelRunner._uses_async_scheduler(self):
+            return self.defer_state_apply_and_build_runner_output(
+                sampled, logprobs, req_ids=req_ids
+            )
         return self.apply_and_build_runner_output(sampled, logprobs, req_ids=req_ids)
 
     @torch.no_grad()
@@ -1813,8 +1832,19 @@ class TTModelRunner:
                     sampled_token_ids=sampled_token_ids,
                     logprobs=logprobs,
                     intermediate_mask=intermediate_mask.numpy(),
+                    defer_state_apply=TTModelRunner._uses_async_scheduler(self),
                 )
 
+        if TTModelRunner._uses_async_scheduler(self):
+            return self.defer_state_apply_and_build_runner_output(
+                sampled_token_ids,
+                logprobs,
+                req_ids=(
+                    row_req_ids
+                    if is_prefill
+                    else list(self.input_batch.req_ids[: self.input_batch.num_reqs])
+                ),
+            )
         return self.apply_and_build_runner_output(
             sampled_token_ids,
             logprobs,
@@ -1830,6 +1860,7 @@ class TTModelRunner:
         logprobs: LogprobsLists | None,
         intermediate_mask: np.ndarray,
         req_id_to_index: dict[str, int] | None = None,
+        defer_state_apply: bool = False,
     ) -> ModelRunnerOutput:
         """Build a prefill output that emits no token for intermediate chunks.
 
@@ -1842,11 +1873,14 @@ class TTModelRunner:
             "request; block-output models must disable chunked prefill"
         )
         final_idx_np = np.where(~intermediate_mask)[0]
+        final_tokens = None
+        final_req_ids: list[str] = []
         if final_idx_np.shape[0] > 0:
             final_idx_tensor = torch.from_numpy(final_idx_np.astype(np.int64))
             final_tokens = sampled_token_ids[final_idx_tensor]
             final_req_ids = [req_ids[int(i)] for i in final_idx_np]
-            self._apply_sampled_tokens_to_state(final_tokens, req_ids=final_req_ids)
+            if not defer_state_apply:
+                self._apply_sampled_tokens_to_state(final_tokens, req_ids=final_req_ids)
 
         num_reqs = len(req_ids)
         sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
@@ -1857,7 +1891,7 @@ class TTModelRunner:
             for i in range(num_reqs)
         ]
 
-        return ModelRunnerOutput(
+        runner_output = ModelRunnerOutput(
             req_ids=req_ids,
             req_id_to_index=(
                 dict(req_id_to_index)
@@ -1869,6 +1903,11 @@ class TTModelRunner:
             prompt_logprobs_dict=dict.fromkeys(req_ids, None),
             pooler_output=[],
         )
+        if defer_state_apply and final_tokens is not None:
+            self._enqueue_deferred_state_apply(
+                final_tokens, final_req_ids, runner_output
+            )
+        return runner_output
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
@@ -2531,6 +2570,52 @@ class TTModelRunner:
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
         )
+
+    def _enqueue_deferred_state_apply(
+        self,
+        sampled_token_ids: torch.Tensor,
+        req_ids: list[str],
+        runner_output: ModelRunnerOutput,
+    ) -> None:
+        """Queue sampled host state until scheduler lifecycle is known.
+
+        Final prefills and contract-v0 decode are sampled synchronously, but
+        under AsyncScheduler their published output is still protected by a
+        placeholder. Queue them beside completed async decodes so a forced
+        prefix reset can leave the published row intact for discard accounting
+        without first appending its stale token to runner state.
+        """
+        now = time.perf_counter_ns()
+        self.async_decode.enqueue_completed_decode_step(
+            CompletedDecodeStep(
+                sampled_token_ids=sampled_token_ids,
+                logprobs=None,
+                context=SubmittedStepContext(
+                    req_ids=list(req_ids),
+                    req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+                    submit_time_ns=now,
+                ),
+                completion_time_ns=now,
+                runner_output=runner_output,
+            )
+        )
+
+    def defer_state_apply_and_build_runner_output(
+        self,
+        sampled_token_ids: torch.Tensor,
+        logprobs: LogprobsLists | None = None,
+        req_ids: list[str] | None = None,
+        req_id_to_index: dict[str, int] | None = None,
+    ) -> ModelRunnerOutput:
+        assert req_ids is not None, "deferred synchronous output needs request IDs"
+        runner_output = self._build_runner_output(
+            sampled_token_ids=sampled_token_ids,
+            logprobs=logprobs,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
+        )
+        self._enqueue_deferred_state_apply(sampled_token_ids, req_ids, runner_output)
+        return runner_output
 
     def warmup_model(self) -> None:
         # Two-phase warmup: compile first, then capture traces.

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -20,6 +20,27 @@ from vllm_tt_plugin.logger import init_tt_logger
 logger = init_tt_logger(__name__)
 
 
+# ``SchedulerOutput`` has no backend metadata field. Like lane step state, this
+# TT-only signal is attached to the mutable output object and therefore follows
+# it through the executor serialization boundary. Counts, rather than a set of
+# request IDs, identify exactly how many newest in-flight frames a wholesale
+# prefix-cache reset made stale.
+_TT_FORCED_RESET_DISCARD_COUNTS_ATTR = "_tt_forced_reset_discard_counts"
+
+
+def set_tt_forced_reset_discard_counts(
+    scheduler_output: SchedulerOutput, counts: dict[str, int]
+) -> None:
+    if counts:
+        setattr(scheduler_output, _TT_FORCED_RESET_DISCARD_COUNTS_ATTR, dict(counts))
+
+
+def get_tt_forced_reset_discard_counts(
+    scheduler_output: SchedulerOutput,
+) -> dict[str, int]:
+    return dict(getattr(scheduler_output, _TT_FORCED_RESET_DISCARD_COUNTS_ATTR, {}))
+
+
 class TTSchedulingMode(Enum):
     DEFAULT = "default"
     DECODE_ONLY = "decode_only"
@@ -87,6 +108,7 @@ class TTScheduler(AsyncScheduler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._forced_mode = TTSchedulingMode.DEFAULT
+        self._pending_forced_reset_discard_counts: dict[str, int] = {}
         self._output_tokens_per_step = get_tt_output_tokens_per_step(self.vllm_config)
         self._is_block_output_model = is_tt_block_output_model(self.vllm_config)
         if self._is_block_output_model:
@@ -387,6 +409,12 @@ class TTScheduler(AsyncScheduler):
     def _finalize_scheduler_output(
         self, scheduler_output: SchedulerOutput
     ) -> SchedulerOutput:
+        pending_reset_discards = getattr(
+            self, "_pending_forced_reset_discard_counts", {}
+        )
+        if pending_reset_discards:
+            set_tt_forced_reset_discard_counts(scheduler_output, pending_reset_discards)
+            self._pending_forced_reset_discard_counts = {}
         return scheduler_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
@@ -469,7 +497,33 @@ class TTScheduler(AsyncScheduler):
                 logger.error("%s", message)
                 return False
             raise RuntimeError(message)
-        return super().reset_prefix_cache(reset_running_requests, reset_connector)
+        # AsyncScheduler turns every outstanding placeholder into one discard
+        # when it preempts all running requests. Preserve that scheduler-owned
+        # boundary for the runner: the stale frames must still be published so
+        # AsyncScheduler consumes its counters, but must not be appended to the
+        # runner's cached request state before resumed-prefill inputs are built.
+        reset_candidates = (
+            [
+                (request, request.num_output_placeholders)
+                for request in self.running
+                if request.num_output_placeholders > 0
+            ]
+            if reset_running_requests
+            else []
+        )
+        try:
+            return super().reset_prefix_cache(reset_running_requests, reset_connector)
+        finally:
+            for request, placeholder_count in reset_candidates:
+                if (
+                    request.status == RequestStatus.PREEMPTED
+                    and request.async_tokens_to_discard > 0
+                ):
+                    count = min(placeholder_count, request.async_tokens_to_discard)
+                    pending = self._pending_forced_reset_discard_counts
+                    pending[request.request_id] = (
+                        pending.get(request.request_id, 0) + count
+                    )
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         """Reserve the complete physical output emitted by each block step.

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -26,7 +26,6 @@ logger = init_tt_logger(__name__)
 # request IDs, identify exactly how many newest in-flight frames a wholesale
 # prefix-cache reset made stale.
 _TT_FORCED_RESET_DISCARD_COUNTS_ATTR = "_tt_forced_reset_discard_counts"
-_TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR = "_tt_unreserved_resumed_prefill_req_ids"
 
 
 def set_tt_forced_reset_discard_counts(
@@ -40,29 +39,6 @@ def get_tt_forced_reset_discard_counts(
     scheduler_output: SchedulerOutput,
 ) -> dict[str, int]:
     return dict(getattr(scheduler_output, _TT_FORCED_RESET_DISCARD_COUNTS_ATTR, {}))
-
-
-def set_tt_unreserved_resumed_prefill_req_ids(
-    scheduler_output: SchedulerOutput, req_ids: set[str]
-) -> None:
-    if req_ids:
-        setattr(
-            scheduler_output,
-            _TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR,
-            frozenset(req_ids),
-        )
-
-
-def get_tt_unreserved_resumed_prefill_req_ids(
-    scheduler_output: SchedulerOutput,
-) -> frozenset[str]:
-    return frozenset(
-        getattr(
-            scheduler_output,
-            _TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR,
-            (),
-        )
-    )
 
 
 class TTSchedulingMode(Enum):
@@ -114,6 +90,11 @@ class TTScheduler(AsyncScheduler):
       them. ``Request.async_tokens_to_discard`` serves the wholesale
       ``reset_prefix_cache`` teardown only; wiring ordinary preemption into it
       drops valid tokens and silently truncates the response.
+      A preempted request with an outstanding output placeholder stays in the
+      waiting queue until that valid frame is accounted for. Resuming earlier
+      would replay and sample against the old token history, producing a second
+      physical frame for the same single placeholder and advancing seeded RNG
+      state for a token that must be discarded.
 
     Supports ``set_forced_mode`` for lane coordination:
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
@@ -386,22 +367,47 @@ class TTScheduler(AsyncScheduler):
             or any(request.is_prefill_chunk for request in self.running)
         )
 
-    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        # NOTE: `throttle_prefills` accepted for interface compatibility with the base
-        #        scheduler but unused - TT separates prefill/decode explicitly.
-        # Capture this before upstream mutates PREEMPTED requests during
-        # scheduling. When a resume starts with an older output placeholder
-        # outstanding, vLLM does not reserve another placeholder for the
-        # replay's final-prefill sample; that duplicate row must be suppressed.
-        # Keep this signal step-local: UniProc's two-batch queue consumes the
-        # older frame before another prefill chunk can schedule, so a later
-        # final chunk owns a new placeholder and must emit its token.
-        self._resume_with_outstanding_output_req_ids = {
-            request.request_id
-            for request in getattr(self, "requests", {}).values()
+    def _take_preempted_requests_with_pending_outputs(self) -> RequestQueue | None:
+        """Temporarily remove resumes that still own an in-flight output.
+
+        Ordinary preemption preserves already-submitted frames. Waiting for the
+        corresponding placeholder to be consumed makes the accepted token part
+        of request history before resumed prefill is built, so replay samples
+        the next logical token and receives a fresh placeholder.
+
+        The temporary queue follows upstream's skipped-waiting convention:
+        ``prepend_request`` while collecting and ``prepend_requests`` while
+        restoring preserve FCFS order, while priority queues reorder by their
+        normal priority key.
+        """
+        deferred = [
+            request
+            for request in self.waiting
             if request.status == RequestStatus.PREEMPTED
             and request.num_output_placeholders > 0
-        }
+        ]
+        if not deferred:
+            return None
+
+        deferred_queue = create_request_queue(self.policy)
+        for request in deferred:
+            deferred_queue.prepend_request(request)
+        self.waiting.remove_requests(deferred)
+        return deferred_queue
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        deferred_resumes = self._take_preempted_requests_with_pending_outputs()
+        try:
+            return self._schedule_without_pending_output_resumes(throttle_prefills)
+        finally:
+            if deferred_resumes:
+                self.waiting.prepend_requests(deferred_resumes)
+
+    def _schedule_without_pending_output_resumes(
+        self, throttle_prefills: bool = False
+    ) -> SchedulerOutput:
+        # NOTE: `throttle_prefills` accepted for interface compatibility with the base
+        #        scheduler but unused - TT separates prefill/decode explicitly.
         has_pending_prefill = self._has_pending_prefill()
         # A partial prefill occupies ``running`` but cannot produce a decode
         # token, so it must not make the decode fallback below look viable.
@@ -452,12 +458,6 @@ class TTScheduler(AsyncScheduler):
         if pending_reset_discards:
             set_tt_forced_reset_discard_counts(scheduler_output, pending_reset_discards)
             self._pending_forced_reset_discard_counts = {}
-        resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
-        set_tt_unreserved_resumed_prefill_req_ids(
-            scheduler_output,
-            set(resumed_req_ids)
-            & getattr(self, "_resume_with_outstanding_output_req_ids", set()),
-        )
         return scheduler_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -26,6 +26,7 @@ logger = init_tt_logger(__name__)
 # request IDs, identify exactly how many newest in-flight frames a wholesale
 # prefix-cache reset made stale.
 _TT_FORCED_RESET_DISCARD_COUNTS_ATTR = "_tt_forced_reset_discard_counts"
+_TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR = "_tt_unreserved_resumed_prefill_req_ids"
 
 
 def set_tt_forced_reset_discard_counts(
@@ -39,6 +40,29 @@ def get_tt_forced_reset_discard_counts(
     scheduler_output: SchedulerOutput,
 ) -> dict[str, int]:
     return dict(getattr(scheduler_output, _TT_FORCED_RESET_DISCARD_COUNTS_ATTR, {}))
+
+
+def set_tt_unreserved_resumed_prefill_req_ids(
+    scheduler_output: SchedulerOutput, req_ids: set[str]
+) -> None:
+    if req_ids:
+        setattr(
+            scheduler_output,
+            _TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR,
+            frozenset(req_ids),
+        )
+
+
+def get_tt_unreserved_resumed_prefill_req_ids(
+    scheduler_output: SchedulerOutput,
+) -> frozenset[str]:
+    return frozenset(
+        getattr(
+            scheduler_output,
+            _TT_UNRESERVED_RESUMED_PREFILL_REQ_IDS_ATTR,
+            (),
+        )
+    )
 
 
 class TTSchedulingMode(Enum):
@@ -365,6 +389,19 @@ class TTScheduler(AsyncScheduler):
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         # NOTE: `throttle_prefills` accepted for interface compatibility with the base
         #        scheduler but unused - TT separates prefill/decode explicitly.
+        # Capture this before upstream mutates PREEMPTED requests during
+        # scheduling. When a resume starts with an older output placeholder
+        # outstanding, vLLM does not reserve another placeholder for the
+        # replay's final-prefill sample; that duplicate row must be suppressed.
+        # Keep this signal step-local: UniProc's two-batch queue consumes the
+        # older frame before another prefill chunk can schedule, so a later
+        # final chunk owns a new placeholder and must emit its token.
+        self._resume_with_outstanding_output_req_ids = {
+            request.request_id
+            for request in getattr(self, "requests", {}).values()
+            if request.status == RequestStatus.PREEMPTED
+            and request.num_output_placeholders > 0
+        }
         has_pending_prefill = self._has_pending_prefill()
         # A partial prefill occupies ``running`` but cannot produce a decode
         # token, so it must not make the decode fallback below look viable.
@@ -415,6 +452,12 @@ class TTScheduler(AsyncScheduler):
         if pending_reset_discards:
             set_tt_forced_reset_discard_counts(scheduler_output, pending_reset_discards)
             self._pending_forced_reset_discard_counts = {}
+        resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+        set_tt_unreserved_resumed_prefill_req_ids(
+            scheduler_output,
+            set(resumed_req_ids)
+            & getattr(self, "_resume_with_outstanding_output_req_ids", set()),
+        )
         return scheduler_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -457,7 +457,7 @@ class TTWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | None:
-        """Run the device forward for a non-DP or lane-DP step.
+        """Run this rank's front-packed or lane-DP device forward.
 
         Returns ``None``: the forward leaves a pending sampler that the engine
         finalizes via ``sample_tokens``. The runner dispatches plain

--- a/tests/test_block_model_runner.py
+++ b/tests/test_block_model_runner.py
@@ -85,13 +85,11 @@ def _captured_runner(width: int, num_tokens: tuple[int, int]):
 def test_captured_ar_capacity_overrun_leaves_batch_unmutated():
     """The deferred-apply path validates every live row before mutating any:
     an oversized AR step on a later row must not leave earlier rows applied."""
-    runner, states, (outputs_a, outputs_b) = _captured_runner(1, (0, 32))
+    runner, _, (outputs_a, outputs_b) = _captured_runner(1, (0, 32))
     tokens = torch.arange(2, dtype=torch.int32).reshape(2, 1)
 
     with pytest.raises(ValueError, match="exceed the max model length"):
-        TTModelRunner._apply_sampled_tokens_to_state(
-            runner, tokens, req_ids=["a", "b"], request_states=states
-        )
+        TTModelRunner._apply_sampled_tokens_to_state(runner, tokens, req_ids=["a", "b"])
 
     # Row 0 fit, but must not have been applied before row 1's rejection.
     assert runner.input_batch.num_tokens.tolist() == [0, 32]
@@ -103,12 +101,10 @@ def test_captured_block_overrun_clips_only_the_overflowing_row():
     """A block canvas past max_model_len must not kill the engine: the
     deferred-apply path keeps only the slice that fits for that row and
     applies the others in full."""
-    runner, states, (outputs_a, outputs_b) = _captured_runner(16, (0, 17))
+    runner, _, (outputs_a, outputs_b) = _captured_runner(16, (0, 17))
     blocks = torch.arange(32, dtype=torch.int32).reshape(2, 16)
 
-    TTModelRunner._apply_sampled_tokens_to_state(
-        runner, blocks, req_ids=["a", "b"], request_states=states
-    )
+    TTModelRunner._apply_sampled_tokens_to_state(runner, blocks, req_ids=["a", "b"])
 
     assert runner.input_batch.num_tokens.tolist() == [16, 32]
     assert runner.input_batch.token_ids_cpu[0, :16].tolist() == list(range(16))

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -36,7 +36,6 @@ from vllm_tt_plugin.config import store_tt_output_tokens_per_step
 from vllm_tt_plugin.scheduler import (
     TTScheduler,
     get_tt_forced_reset_discard_counts,
-    get_tt_unreserved_resumed_prefill_req_ids,
 )
 
 BLOCK_SIZE = 128
@@ -808,30 +807,29 @@ def test_ordinary_async_preemption_keeps_inflight_token_for_resume():
 
     resumed = scheduler.schedule()
     assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
-    assert get_tt_unreserved_resumed_prefill_req_ids(resumed) == frozenset()
 
 
-def test_resume_before_inflight_output_suppresses_duplicate_prefill_frame():
+def test_preempted_request_waits_for_inflight_output_before_resume():
     scheduler, request, submitted = _scheduled(output_width=1, async_scheduling=True)
     scheduler.running.remove(request)
     scheduler._preempt_request(request, time.monotonic())
 
-    resumed = scheduler.schedule()
-    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
-    assert get_tt_unreserved_resumed_prefill_req_ids(resumed) == frozenset(
-        {request.request_id}
-    )
-    # Resumed replay did not reserve a second output: its final-prefill sample
-    # predicts the same logical token as the still-valid older frame.
+    blocked = scheduler.schedule()
+    assert blocked.total_num_scheduled_tokens == 0
+    assert request.status == RequestStatus.PREEMPTED
     assert request.num_output_placeholders == 1
 
     older = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
     assert older[0].outputs[0].new_token_ids == [7]
     assert request.num_output_placeholders == 0
 
-    duplicate = scheduler.update_from_output(resumed, _runner_output(resumed, []))
-    assert duplicate[0].outputs == []
-    assert list(request.output_token_ids) == [7]
+    resumed = scheduler.schedule()
+    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
+    assert request.num_output_placeholders == 1
+
+    following = scheduler.update_from_output(resumed, _runner_output(resumed, [8]))
+    assert following[0].outputs[0].new_token_ids == [8]
+    assert list(request.output_token_ids) == [7, 8]
     assert request.num_output_placeholders == 0
 
 

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -32,7 +33,10 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
 
 from vllm_tt_plugin.config import store_tt_output_tokens_per_step
-from vllm_tt_plugin.scheduler import TTScheduler
+from vllm_tt_plugin.scheduler import (
+    TTScheduler,
+    get_tt_forced_reset_discard_counts,
+)
 
 BLOCK_SIZE = 128
 CANVAS = 16
@@ -76,6 +80,7 @@ def _scheduler(
     *,
     diffusion_checkpoint: bool = False,
     max_model_len: int = MAX_MODEL_LEN,
+    async_scheduling: bool = False,
 ) -> TTScheduler:
     model_config = ModelConfig(
         model=str(LOCAL_MODEL_CONFIG),
@@ -106,7 +111,7 @@ def _scheduler(
             parallel_config=ParallelConfig(),
             device_config=DeviceConfig(device="cpu"),
         )
-    config.scheduler_config.async_scheduling = False
+    config.scheduler_config.async_scheduling = async_scheduling
     if diffusion_checkpoint:
         # Reproduce the platform hook's post-update state, including
         # invalidation of ModelConfig.is_diffusion's cached True value.
@@ -164,8 +169,9 @@ def _scheduled(
     *,
     output_width: int = CANVAS,
     ignore_eos: bool = True,
+    async_scheduling: bool = False,
 ) -> tuple[TTScheduler, Request, SchedulerOutput]:
-    scheduler = _scheduler(output_width)
+    scheduler = _scheduler(output_width, async_scheduling=async_scheduling)
     request = _request(max_tokens, ignore_eos=ignore_eos)
     scheduler.add_request(request)
     return scheduler, request, scheduler.schedule()
@@ -785,6 +791,46 @@ def test_ar_prefix_cache_reset_delegates_to_upstream_preemption():
     assert scheduler.running == []
     assert request.status == RequestStatus.PREEMPTED
     assert request.async_tokens_to_discard == 1
+    assert request.num_output_placeholders == 0
+
+
+def test_ordinary_async_preemption_keeps_inflight_token_for_resume():
+    scheduler, request, submitted = _scheduled(output_width=1, async_scheduling=True)
+    scheduler.running.remove(request)
+    scheduler._preempt_request(request, time.monotonic())
+
+    resumed = scheduler.schedule()
+    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
+    assert request.num_output_placeholders == 2
+
+    outputs = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
+    assert outputs[0].outputs[0].new_token_ids == [7]
+    assert list(request.output_token_ids) == [7]
+    assert request.num_output_placeholders == 1
+
+    resumed_outputs = scheduler.update_from_output(
+        resumed, _runner_output(resumed, [8])
+    )
+    assert resumed_outputs[0].outputs[0].new_token_ids == [8]
+    assert list(request.output_token_ids) == [7, 8]
+    assert request.num_output_placeholders == 0
+
+
+def test_forced_reset_discards_stale_frame_before_following_valid_frame():
+    scheduler, request, submitted = _scheduled(output_width=1, async_scheduling=True)
+
+    assert scheduler.reset_prefix_cache(reset_running_requests=True)
+    resumed = scheduler.schedule()
+
+    assert get_tt_forced_reset_discard_counts(resumed) == {request.request_id: 1}
+    stale = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
+    assert not stale
+    assert request.async_tokens_to_discard == 0
+    assert list(request.output_token_ids) == []
+
+    valid = scheduler.update_from_output(resumed, _runner_output(resumed, [8]))
+    assert valid[0].outputs[0].new_token_ids == [8]
+    assert list(request.output_token_ids) == [8]
     assert request.num_output_placeholders == 0
 
 

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -36,6 +36,7 @@ from vllm_tt_plugin.config import store_tt_output_tokens_per_step
 from vllm_tt_plugin.scheduler import (
     TTScheduler,
     get_tt_forced_reset_discard_counts,
+    get_tt_unreserved_resumed_prefill_req_ids,
 )
 
 BLOCK_SIZE = 128
@@ -807,6 +808,31 @@ def test_ordinary_async_preemption_keeps_inflight_token_for_resume():
 
     resumed = scheduler.schedule()
     assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
+    assert get_tt_unreserved_resumed_prefill_req_ids(resumed) == frozenset()
+
+
+def test_resume_before_inflight_output_suppresses_duplicate_prefill_frame():
+    scheduler, request, submitted = _scheduled(output_width=1, async_scheduling=True)
+    scheduler.running.remove(request)
+    scheduler._preempt_request(request, time.monotonic())
+
+    resumed = scheduler.schedule()
+    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
+    assert get_tt_unreserved_resumed_prefill_req_ids(resumed) == frozenset(
+        {request.request_id}
+    )
+    # Resumed replay did not reserve a second output: its final-prefill sample
+    # predicts the same logical token as the still-valid older frame.
+    assert request.num_output_placeholders == 1
+
+    older = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
+    assert older[0].outputs[0].new_token_ids == [7]
+    assert request.num_output_placeholders == 0
+
+    duplicate = scheduler.update_from_output(resumed, _runner_output(resumed, []))
+    assert duplicate[0].outputs == []
+    assert list(request.output_token_ids) == [7]
+    assert request.num_output_placeholders == 0
 
 
 def test_forced_reset_discards_stale_frame_before_following_valid_frame():

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -799,15 +799,14 @@ def test_ordinary_async_preemption_keeps_inflight_token_for_resume():
     scheduler.running.remove(request)
     scheduler._preempt_request(request, time.monotonic())
 
-    resumed = scheduler.schedule()
-    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
-    assert resumed.scheduled_cached_reqs.is_context_phase(request.request_id)
     assert request.num_output_placeholders == 1
-
     outputs = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
     assert outputs[0].outputs[0].new_token_ids == [7]
     assert list(request.output_token_ids) == [7]
     assert request.num_output_placeholders == 0
+
+    resumed = scheduler.schedule()
+    assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
 
 
 def test_forced_reset_discards_stale_frame_before_following_valid_frame():

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -801,18 +801,12 @@ def test_ordinary_async_preemption_keeps_inflight_token_for_resume():
 
     resumed = scheduler.schedule()
     assert request.request_id in resumed.scheduled_cached_reqs.resumed_req_ids
-    assert request.num_output_placeholders == 2
+    assert resumed.scheduled_cached_reqs.is_context_phase(request.request_id)
+    assert request.num_output_placeholders == 1
 
     outputs = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
     assert outputs[0].outputs[0].new_token_ids == [7]
     assert list(request.output_token_ids) == [7]
-    assert request.num_output_placeholders == 1
-
-    resumed_outputs = scheduler.update_from_output(
-        resumed, _runner_output(resumed, [8])
-    )
-    assert resumed_outputs[0].outputs[0].new_token_ids == [8]
-    assert list(request.output_token_ids) == [7, 8]
     assert request.num_output_placeholders == 0
 
 
@@ -824,7 +818,7 @@ def test_forced_reset_discards_stale_frame_before_following_valid_frame():
 
     assert get_tt_forced_reset_discard_counts(resumed) == {request.request_id: 1}
     stale = scheduler.update_from_output(submitted, _runner_output(submitted, [7]))
-    assert not stale
+    assert stale[0].outputs == []
     assert request.async_tokens_to_discard == 0
     assert list(request.output_token_ids) == []
 

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -3,6 +3,7 @@
 """Host-only coverage for the explicit TT decode reload contract."""
 
 import threading
+from collections import deque
 from types import SimpleNamespace
 
 import numpy as np
@@ -580,28 +581,9 @@ def test_contract_v0_keeps_legacy_call_shape_and_warns_once(monkeypatch):
     assert len(warnings) == 1
 
 
-def test_invalidated_async_result_updates_neither_runner_nor_published_output():
-    request_state = SimpleNamespace(output_token_ids=[])
-    runner_output = SimpleNamespace(
-        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
-    )
-    runner = SimpleNamespace(
-        _output_tokens_per_step=1,
-        scheduler_config=SimpleNamespace(async_scheduling=True),
-        requests={},
-        input_batch=SimpleNamespace(
-            req_id_to_index={},
-            num_tokens=np.zeros(1, dtype=np.int32),
-            token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
-        ),
-        model_config=SimpleNamespace(max_model_len=8),
-    )
-    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
-        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
-    )
-    controller = TTAsyncDecodeController(runner)
-    completed = CompletedDecodeStep(
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+def _completed_step(token: int, runner_output=None) -> CompletedDecodeStep:
+    return CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[token]], dtype=torch.int32),
         logprobs=None,
         context=SubmittedStepContext(
             req_ids=["request"],
@@ -612,24 +594,124 @@ def test_invalidated_async_result_updates_neither_runner_nor_published_output():
         runner_output=runner_output,
     )
 
-    controller.apply_completed_decode_step(completed, skip_req_ids={"request"})
+
+def _async_apply_runner(request_state):
+    runner = SimpleNamespace(
+        _output_tokens_per_step=1,
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        requests={"request": request_state},
+        input_batch=SimpleNamespace(
+            req_id_to_index={},
+            num_tokens=np.zeros(1, dtype=np.int32),
+            token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
+        ),
+        model_config=SimpleNamespace(max_model_len=8),
+        _steady_decode_lock=threading.Lock(),
+        _completed_decode_steps=deque(),
+        _pending_async_steps=deque(),
+        _pending_async_overlap_ok=deque(),
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    return runner
+
+
+def test_finished_async_result_updates_neither_runner_nor_published_output():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner_output = SimpleNamespace(
+        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
+    )
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    completed = _completed_step(7, runner_output)
+
+    controller.apply_completed_decode_step(
+        completed,
+        suppress_output_req_ids={"request"},
+        skip_state_req_ids={"request"},
+    )
 
     assert request_state.output_token_ids == []
     assert runner_output.sampled_token_ids == [[]]
 
 
-def test_invalidated_result_ids_come_from_current_scheduler_lifecycle():
+@pytest.mark.parametrize("lifecycle", ["preempted", "resumed"])
+def test_ordinary_preemption_or_resume_keeps_inflight_token(lifecycle):
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner_output = SimpleNamespace(
+        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
+    )
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    scheduler_output = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids={"request"} if lifecycle == "preempted" else set(),
+        scheduled_cached_reqs=_cached_reqs(
+            ["request"], resumed=["request"] if lifecycle == "resumed" else []
+        ),
+    )
+
+    controller.apply_completed_decode_step(
+        _completed_step(7, runner_output),
+        suppress_output_req_ids=controller.suppressed_output_req_ids(scheduler_output),
+    )
+
+    assert request_state.output_token_ids == [7]
+    assert runner_output.sampled_token_ids == [[7]]
+
+
+def test_only_finished_result_ids_are_suppressed_from_scheduler_output():
     scheduler_output = SimpleNamespace(
         finished_req_ids={"finished"},
         preempted_req_ids={"preempted"},
         scheduled_cached_reqs=_cached_reqs(["resumed"], resumed=["resumed"]),
     )
 
-    assert TTAsyncDecodeController.invalidated_req_ids(scheduler_output) == {
-        "finished",
-        "preempted",
-        "resumed",
+    assert TTAsyncDecodeController.suppressed_output_req_ids(scheduler_output) == {
+        "finished"
     }
+
+
+def test_forced_reset_skips_only_newest_counted_runner_state_frames():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    outputs = [
+        SimpleNamespace(req_id_to_index={"request": 0}, sampled_token_ids=[[token]])
+        for token in (5, 6, 7)
+    ]
+    runner._completed_decode_steps.extend(
+        _completed_step(token, output) for token, output in zip((5, 6, 7), outputs)
+    )
+
+    controller.apply_ready_completed_decode_steps(
+        forced_reset_discard_counts={"request": 2}
+    )
+
+    assert request_state.output_token_ids == [5]
+    assert [output.sampled_token_ids for output in outputs] == [
+        [[5]],
+        [[6]],
+        [[7]],
+    ]
+
+
+def test_forced_reset_discard_count_requires_all_stale_frames():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    runner._completed_decode_steps.append(
+        _completed_step(
+            7,
+            SimpleNamespace(req_id_to_index={"request": 0}, sampled_token_ids=[[7]]),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="missing completed frames"):
+        controller.apply_ready_completed_decode_steps(
+            forced_reset_discard_counts={"request": 2}
+        )
 
 
 def test_unscheduled_live_request_keeps_accepted_token_in_cached_state():

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -743,7 +743,7 @@ def test_forced_reset_discard_count_requires_all_stale_frames():
         )
     )
 
-    with pytest.raises(RuntimeError, match="missing completed frames"):
+    with pytest.raises(RuntimeError, match="Not enough completed outputs"):
         controller.apply_ready_completed_decode_steps(
             forced_reset_discard_counts={"request": 2}
         )

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -177,54 +177,6 @@ def test_submit_decode_delivers_page_table_only_refresh():
     assert calls[1]["reset_sampling_state"] is False
 
 
-def test_v0_preserves_legacy_dp_greater_than_one_disable():
-    runner = SimpleNamespace(
-        model=SimpleNamespace(),
-        scheduler_config=SimpleNamespace(async_scheduling=True),
-        parallel_config=SimpleNamespace(data_parallel_size=4),
-        async_decode_scheduling=True,
-    )
-
-    TTModelRunner._preserve_v0_async_decode_selection(runner)
-    assert not runner.async_decode_scheduling
-
-
-def test_v1_keeps_platform_async_for_dp_greater_than_one():
-    runner = SimpleNamespace(
-        model=SimpleNamespace(decode_input_update_contract=1),
-        scheduler_config=SimpleNamespace(async_scheduling=True),
-        parallel_config=SimpleNamespace(data_parallel_size=4),
-        async_decode_scheduling=True,
-    )
-
-    TTModelRunner._preserve_v0_async_decode_selection(runner)
-    assert runner.async_decode_scheduling
-
-
-def test_v0_keeps_legacy_rank_local_async_decode():
-    runner = SimpleNamespace(
-        model=SimpleNamespace(),
-        scheduler_config=SimpleNamespace(async_scheduling=True),
-        parallel_config=SimpleNamespace(data_parallel_size=1),
-        async_decode_scheduling=True,
-    )
-
-    TTModelRunner._preserve_v0_async_decode_selection(runner)
-    assert runner.async_decode_scheduling
-
-
-def test_disabled_upstream_async_stays_disabled_for_v1():
-    runner = SimpleNamespace(
-        model=SimpleNamespace(decode_input_update_contract=1),
-        scheduler_config=SimpleNamespace(async_scheduling=False),
-        parallel_config=SimpleNamespace(data_parallel_size=4),
-        async_decode_scheduling=False,
-    )
-
-    TTModelRunner._preserve_v0_async_decode_selection(runner)
-    assert not runner.async_decode_scheduling
-
-
 def test_v0_preserves_host_to_device_overlap_predicate():
     common_runner = dict(
         async_decode_scheduling=True,

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -177,21 +177,48 @@ def test_submit_decode_delivers_page_table_only_refresh():
     assert calls[1]["reset_sampling_state"] is False
 
 
-def test_standard_dp_async_requires_contract_v1():
+def test_v0_standard_dp_disables_runner_async_decode():
     runner = SimpleNamespace(
         model=SimpleNamespace(),
-        scheduler_config=SimpleNamespace(async_scheduling=True),
         parallel_config=SimpleNamespace(data_parallel_size=4),
-        trace_mode="decode_only",
+        async_decode_scheduling=True,
     )
 
-    TTModelRunner._configure_async_decode_scheduling(runner)
+    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
     assert not runner.async_decode_scheduling
 
-    runner.model.decode_input_update_contract = 1
-    TTModelRunner._configure_async_decode_scheduling(runner)
+
+def test_v1_standard_dp_keeps_runner_async_decode():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(decode_input_update_contract=1),
+        parallel_config=SimpleNamespace(data_parallel_size=4),
+        async_decode_scheduling=True,
+    )
+
+    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
     assert runner.async_decode_scheduling
-    assert TTAsyncDecodeController(runner).steady_decode_base_enabled()
+
+
+def test_v0_single_process_keeps_runner_async_decode():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(),
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        async_decode_scheduling=True,
+    )
+
+    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    assert runner.async_decode_scheduling
+
+
+def test_disabled_upstream_async_stays_disabled_for_v1_standard_dp():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(decode_input_update_contract=1),
+        parallel_config=SimpleNamespace(data_parallel_size=4),
+        async_decode_scheduling=False,
+    )
+
+    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    assert not runner.async_decode_scheduling
 
 
 def test_v0_preserves_host_to_device_overlap_predicate():

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -177,47 +177,51 @@ def test_submit_decode_delivers_page_table_only_refresh():
     assert calls[1]["reset_sampling_state"] is False
 
 
-def test_v0_standard_dp_disables_runner_async_decode():
+def test_v0_preserves_legacy_dp_greater_than_one_disable():
     runner = SimpleNamespace(
         model=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
         parallel_config=SimpleNamespace(data_parallel_size=4),
         async_decode_scheduling=True,
     )
 
-    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    TTModelRunner._preserve_v0_async_decode_selection(runner)
     assert not runner.async_decode_scheduling
 
 
-def test_v1_standard_dp_keeps_runner_async_decode():
+def test_v1_keeps_platform_async_for_dp_greater_than_one():
     runner = SimpleNamespace(
         model=SimpleNamespace(decode_input_update_contract=1),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
         parallel_config=SimpleNamespace(data_parallel_size=4),
         async_decode_scheduling=True,
     )
 
-    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    TTModelRunner._preserve_v0_async_decode_selection(runner)
     assert runner.async_decode_scheduling
 
 
-def test_v0_single_process_keeps_runner_async_decode():
+def test_v0_keeps_legacy_rank_local_async_decode():
     runner = SimpleNamespace(
         model=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
         parallel_config=SimpleNamespace(data_parallel_size=1),
         async_decode_scheduling=True,
     )
 
-    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    TTModelRunner._preserve_v0_async_decode_selection(runner)
     assert runner.async_decode_scheduling
 
 
-def test_disabled_upstream_async_stays_disabled_for_v1_standard_dp():
+def test_disabled_upstream_async_stays_disabled_for_v1():
     runner = SimpleNamespace(
         model=SimpleNamespace(decode_input_update_contract=1),
+        scheduler_config=SimpleNamespace(async_scheduling=False),
         parallel_config=SimpleNamespace(data_parallel_size=4),
         async_decode_scheduling=False,
     )
 
-    TTModelRunner._disable_async_decode_for_v0_standard_dp(runner)
+    TTModelRunner._preserve_v0_async_decode_selection(runner)
     assert not runner.async_decode_scheduling
 
 

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+"""Host-only coverage for the explicit TT decode reload contract."""
+
+import threading
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm_tt_plugin.async_decode import (
+    CompletedDecodeStep,
+    DeferredDecodeOutput,
+    SubmittedStepContext,
+    TTAsyncDecodeController,
+)
+from vllm_tt_plugin.model_input import TTSamplingParams
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+
+def _controller(*, trace_mode="decode_only", supports_async=True):
+    runner = SimpleNamespace(
+        model=SimpleNamespace(
+            model_capabilities={"supports_async_decode": supports_async}
+        ),
+        trace_mode=trace_mode,
+    )
+    return TTAsyncDecodeController(runner)
+
+
+def _decode_input(*, device_sampling=True, layout_changed=False, page=0):
+    return SimpleNamespace(
+        perform_device_sampling=device_sampling,
+        decode_layout_changed=layout_changed,
+        block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
+    )
+
+
+def _commit(controller, model_input):
+    plan = controller.plan_decode_reload(model_input)
+    controller.commit_decode_submission(model_input, plan)
+    return plan
+
+
+def _sampling_params(rows=1):
+    return TTSamplingParams(
+        temperature=torch.ones(rows),
+        top_k=torch.full((rows,), 32),
+        top_p=torch.ones(rows),
+        presence_penalty=torch.zeros(rows),
+        frequency_penalty=torch.zeros(rows),
+        repetition_penalty=torch.ones(rows),
+        seed=torch.full((rows,), -1),
+        num_logprobs=torch.full((rows,), -2),
+        enable_log_probs=torch.zeros(rows, dtype=torch.bool),
+    )
+
+
+def _submission_input(*, device_sampling=True, layout_changed=True):
+    return SimpleNamespace(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=_sampling_params(),
+        perform_device_sampling=device_sampling,
+        prompt_tokens=None,
+        output_tokens=None,
+        decode_layout_changed=layout_changed,
+        slot_remap=torch.tensor([0], dtype=torch.int32),
+    )
+
+
+def _accepted_decode_hooks(runner):
+    runner.note_decode_layout_consumed = lambda: None
+    runner.note_decode_state_slots_settled = lambda: None
+    return runner
+
+
+def test_first_and_steady_device_decode_commands():
+    controller = _controller()
+
+    first = _commit(controller, _decode_input(page=1))
+    steady = _commit(controller, _decode_input(page=1))
+
+    assert first.reload_inputs
+    assert first.reload_sampling_params
+    assert first.reset_sampling_state
+    assert not first.overlap_safe
+    assert not steady.reload_inputs
+    assert not steady.reload_page_table
+    assert not steady.reload_sampling_params
+    assert not steady.reset_sampling_state
+    assert steady.overlap_safe
+
+
+def test_page_table_only_refresh_is_overlap_safe():
+    controller = _controller()
+    _commit(controller, _decode_input(page=1))
+
+    plan = _commit(controller, _decode_input(page=2))
+
+    assert not plan.reload_inputs
+    assert plan.reload_page_table
+    assert plan.overlap_safe
+
+
+def test_standard_dp_async_requires_contract_v1():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        parallel_config=SimpleNamespace(data_parallel_size=4),
+        trace_mode="decode_only",
+    )
+
+    TTModelRunner._configure_async_decode_scheduling(runner)
+    assert not runner.async_decode_scheduling
+
+    runner.model.decode_input_update_contract = 1
+    TTModelRunner._configure_async_decode_scheduling(runner)
+    assert runner.async_decode_scheduling
+    assert TTAsyncDecodeController(runner).steady_decode_base_enabled()
+
+
+def test_v0_preserves_host_to_device_overlap_predicate():
+    common_runner = dict(
+        async_decode_scheduling=True,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        trace_mode="decode_only",
+    )
+    model_input = SimpleNamespace(
+        prompt_lens=None,
+        perform_device_sampling=True,
+        decode_layout_changed=False,
+        grammar_bitmask=[None],
+        prompt_tokens=None,
+        output_tokens=None,
+        allowed_token_ids_mask_list=[None],
+        bad_words_token_ids_list=[{}],
+        max_num_logprobs=[None],
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+    )
+
+    v0 = TTAsyncDecodeController(
+        SimpleNamespace(model=SimpleNamespace(), **common_runner)
+    )
+    v0._decode_chain_valid = True
+    v0._previous_device_sampling = False
+    assert v0.can_use_steady_decode_fast_path(model_input)
+
+    v1 = TTAsyncDecodeController(
+        SimpleNamespace(
+            model=SimpleNamespace(
+                decode_input_update_contract=1,
+                model_capabilities={"supports_async_decode": True},
+            ),
+            **common_runner,
+        )
+    )
+    v1._decode_chain_valid = True
+    v1._previous_device_sampling = False
+    assert not v1.can_use_steady_decode_fast_path(model_input)
+
+
+def test_failed_deferred_readback_is_terminal():
+    calls = 0
+
+    class FailedReadback(DeferredDecodeOutput):
+        def __init__(self):
+            self._completion_event = threading.Event()
+            self._init_deferred()
+
+        def _get_output_impl(self):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("readback failed")
+
+    readback = FailedReadback()
+    for _ in range(2):
+        try:
+            readback.ensure_finalized()
+        except RuntimeError as exc:
+            assert str(exc) == "readback failed"
+        else:
+            raise AssertionError("terminal readback failure was not replayed")
+
+    assert calls == 1
+    assert readback.is_resolved()
+
+
+def test_state_slot_ownership_commits_only_after_accepted_decode():
+    runner = SimpleNamespace(
+        tt_per_lane_max_num_seqs=2,
+        _req_state_slot={"a": 1, "b": 0},
+        _pending_state_slot_settle=None,
+    )
+
+    remap = TTModelRunner._decode_state_slot_remap(runner, ["a", "b"])
+
+    assert remap.tolist() == [1, 0]
+    assert runner._req_state_slot == {"a": 1, "b": 0}
+    assert runner._pending_state_slot_settle == {"a": 0, "b": 1}
+
+    TTModelRunner.note_decode_state_slots_settled(runner)
+    assert runner._req_state_slot == {"a": 0, "b": 1}
+    assert runner._pending_state_slot_settle is None
+
+
+def test_host_sampling_and_host_to_device_transition_reload():
+    controller = _controller()
+
+    first_host = _commit(controller, _decode_input(device_sampling=False))
+    second_host = _commit(controller, _decode_input(device_sampling=False))
+    device = _commit(controller, _decode_input(device_sampling=True))
+
+    assert first_host.reload_inputs
+    assert second_host.reload_inputs
+    assert not second_host.reload_sampling_params
+    assert device.reload_inputs
+    assert device.reload_sampling_params
+    assert device.reset_sampling_state
+
+
+def test_prefill_layout_trace_and_capability_force_input_reload():
+    controller = _controller()
+    _commit(controller, _decode_input())
+    controller.note_prefill_submitted()
+    assert _commit(controller, _decode_input()).reload_inputs
+    assert _commit(controller, _decode_input(layout_changed=True)).reload_inputs
+
+    no_trace = _controller(trace_mode="none")
+    _commit(no_trace, _decode_input())
+    assert _commit(no_trace, _decode_input()).reload_inputs
+
+    no_residency = _controller(supports_async=False)
+    _commit(no_residency, _decode_input())
+    assert _commit(no_residency, _decode_input()).reload_inputs
+
+
+def test_scheduler_context_phase_distinguishes_chunked_prefill_from_decode():
+    input_batch = SimpleNamespace(
+        req_id_to_index={"request": 0},
+        num_computed_tokens_cpu=np.array([2], dtype=np.int32),
+        num_tokens=np.array([8], dtype=np.int32),
+    )
+    runner = SimpleNamespace(
+        model=SimpleNamespace(decode_input_update_contract=1),
+        input_batch=input_batch,
+        _decode_layout_changed_since_last_decode=False,
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller._decode_chain_valid = True
+    controller._previous_device_sampling = True
+    cached_reqs = SimpleNamespace(
+        req_ids=["request"],
+        resumed_req_ids=set(),
+        is_context_phase=lambda req_id: True,
+    )
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=cached_reqs,
+        num_scheduled_tokens={"request": 4},
+    )
+
+    assert not controller.steady_decode_scheduler_invariants_met(
+        scheduler_output, decode_layout_changed=False
+    )
+    # A decode may schedule several speculative tokens; only the scheduler's
+    # phase marker, not a token-count heuristic, classifies it.
+    cached_reqs.is_context_phase = lambda req_id: False
+    runner.requests = {}
+    scheduler_output.pending_structured_output_tokens = None
+    input_batch.no_penalties = True
+    input_batch.no_allowed_token_ids = True
+    input_batch.sampling = SimpleNamespace(
+        bad_words_token_ids={}, has_active_logitsprocs=lambda: False
+    )
+    input_batch.max_num_logprobs = None
+    runner.model_config = SimpleNamespace(logits_processors=[])
+    runner.check_perform_device_sampling = lambda **kwargs: True
+    assert controller.steady_decode_scheduler_invariants_met(
+        scheduler_output, decode_layout_changed=False
+    )
+
+
+def test_contract_v1_receives_commands_without_legacy_reset():
+    captured = {}
+
+    class Model:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return torch.zeros((1, 1))
+
+    runner = _accepted_decode_hooks(
+        SimpleNamespace(
+            model=Model(),
+            trace_mode="decode_only",
+            kv_caches=object(),
+            request_specific_rope=False,
+        )
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    submission = controller.submit_decode(_submission_input(), read_from_device=True)
+
+    assert submission.reload_plan is not None
+    assert "reset_batch" not in captured
+    assert captured["reload_inputs"] is True
+    assert captured["reload_page_table"] is False
+    assert captured["reload_sampling_params"] is True
+    assert captured["reset_sampling_state"] is True
+    assert captured["slot_remap"].tolist() == [0]
+
+
+def test_contract_v1_host_sampling_still_receives_commands_and_remap():
+    captured = {}
+
+    class Model:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return torch.zeros((1, 1))
+
+    runner = _accepted_decode_hooks(
+        SimpleNamespace(
+            model=Model(),
+            trace_mode="decode_only",
+            kv_caches=object(),
+            request_specific_rope=False,
+        )
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(device_sampling=False), read_from_device=True
+    )
+
+    assert captured["reload_inputs"] is True
+    assert captured["reload_sampling_params"] is False
+    assert captured["reset_sampling_state"] is False
+    assert captured["slot_remap"].tolist() == [0]
+
+
+def test_contract_v0_keeps_legacy_call_shape_and_warns_once(monkeypatch):
+    calls = []
+    warnings = []
+    monkeypatch.setattr(
+        "vllm_tt_plugin.async_decode.logger.warning",
+        lambda *args: warnings.append(args),
+    )
+
+    class Model:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            calls.append(kwargs)
+            return torch.zeros((1, 1))
+
+    runner = _accepted_decode_hooks(
+        SimpleNamespace(
+            model=Model(),
+            trace_mode="decode_only",
+            kv_caches=object(),
+            request_specific_rope=False,
+        )
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = _submission_input()
+
+    first = controller.submit_decode(model_input, read_from_device=True)
+    second = controller.submit_decode(model_input, read_from_device=True)
+
+    assert first.reload_plan is None
+    assert second.reload_plan is None
+    assert all(call["reset_batch"] is True for call in calls)
+    assert all("reload_inputs" not in call for call in calls)
+    # Slot-remap delivery in both sampling modes predates this contract in the
+    # standalone plugin and therefore remains unchanged for version 0.
+    assert all(call["slot_remap"].tolist() == [0] for call in calls)
+    assert len(warnings) == 1
+
+
+def test_invalidated_async_result_updates_neither_runner_nor_published_output():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner_output = SimpleNamespace(
+        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
+    )
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        requests={},
+        input_batch=SimpleNamespace(
+            req_id_to_index={},
+            num_tokens=np.zeros(1, dtype=np.int32),
+            token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
+        ),
+        model_config=SimpleNamespace(max_model_len=8),
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    controller = TTAsyncDecodeController(runner)
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["request"],
+            req_id_to_index={"request": 0},
+            request_states=(request_state,),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+        runner_output=runner_output,
+    )
+
+    controller.apply_completed_decode_step(completed, skip_req_ids={"request"})
+
+    assert request_state.output_token_ids == []
+    assert runner_output.sampled_token_ids == [[]]
+
+
+def test_unscheduled_live_request_keeps_accepted_token_in_cached_state():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"request": request_state},
+        input_batch=SimpleNamespace(req_id_to_index={}),
+        model_config=SimpleNamespace(max_model_len=8),
+    )
+
+    TTModelRunner._apply_sampled_tokens_to_state(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["request"],
+        request_states=(request_state,),
+    )
+
+    assert request_state.output_token_ids == [7]

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -697,6 +697,58 @@ def test_forced_reset_skips_only_newest_counted_runner_state_frames():
     ]
 
 
+def test_async_scheduled_final_prefill_uses_forced_reset_lifecycle():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    runner.async_decode = controller
+    runner_output = SimpleNamespace(
+        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
+    )
+
+    TTModelRunner._enqueue_deferred_state_apply(
+        runner,
+        torch.tensor([[7]], dtype=torch.int32),
+        ["request"],
+        runner_output,
+    )
+
+    # Sampling completed and its output is publishable, but the runner waits
+    # for the next SchedulerOutput before committing host state.
+    assert request_state.output_token_ids == []
+    assert runner_output.sampled_token_ids == [[7]]
+
+    controller.apply_ready_completed_decode_steps(
+        forced_reset_discard_counts={"request": 1}
+    )
+
+    # The stale prefill frame stays published so AsyncScheduler consumes its
+    # discard counter, while runner state remains at the committed prefix.
+    assert request_state.output_token_ids == []
+    assert runner_output.sampled_token_ids == [[7]]
+
+
+def test_async_scheduled_final_prefill_applies_on_ordinary_next_step():
+    request_state = SimpleNamespace(output_token_ids=[])
+    runner = _async_apply_runner(request_state)
+    controller = TTAsyncDecodeController(runner)
+    runner.async_decode = controller
+    runner_output = SimpleNamespace(
+        req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
+    )
+    TTModelRunner._enqueue_deferred_state_apply(
+        runner,
+        torch.tensor([[7]], dtype=torch.int32),
+        ["request"],
+        runner_output,
+    )
+
+    controller.apply_ready_completed_decode_steps()
+
+    assert request_state.output_token_ids == [7]
+    assert runner_output.sampled_token_ids == [[7]]
+
+
 def test_forced_reset_discard_count_requires_all_stale_frames():
     request_state = SimpleNamespace(output_token_ids=[])
     runner = _async_apply_runner(request_state)

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -347,6 +347,7 @@ def test_transition_applies_drained_token_before_host_authoritative_reload():
         token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
     )
     runner = SimpleNamespace(
+        _output_tokens_per_step=1,
         requests={"request": request_state},
         input_batch=input_batch,
         model_config=SimpleNamespace(max_model_len=8),
@@ -585,6 +586,7 @@ def test_invalidated_async_result_updates_neither_runner_nor_published_output():
         req_id_to_index={"request": 0}, sampled_token_ids=[[7]]
     )
     runner = SimpleNamespace(
+        _output_tokens_per_step=1,
         scheduler_config=SimpleNamespace(async_scheduling=True),
         requests={},
         input_batch=SimpleNamespace(
@@ -633,6 +635,7 @@ def test_invalidated_result_ids_come_from_current_scheduler_lifecycle():
 def test_unscheduled_live_request_keeps_accepted_token_in_cached_state():
     request_state = SimpleNamespace(output_token_ids=[])
     runner = SimpleNamespace(
+        _output_tokens_per_step=1,
         requests={"request": request_state},
         input_batch=SimpleNamespace(req_id_to_index={}),
         model_config=SimpleNamespace(max_model_len=8),

--- a/tests/test_decode_reload_contract.py
+++ b/tests/test_decode_reload_contract.py
@@ -6,7 +6,9 @@ import threading
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
+from vllm.v1.core.sched.output import CachedRequestData
 
 from vllm_tt_plugin.async_decode import (
     CompletedDecodeStep,
@@ -14,7 +16,7 @@ from vllm_tt_plugin.async_decode import (
     SubmittedStepContext,
     TTAsyncDecodeController,
 )
-from vllm_tt_plugin.model_input import TTSamplingParams
+from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
 
 
@@ -56,12 +58,13 @@ def _sampling_params(rows=1):
     )
 
 
-def _submission_input(*, device_sampling=True, layout_changed=True):
+def _submission_input(*, device_sampling=True, layout_changed=True, page=0):
+    page_table = torch.tensor([[page]], dtype=torch.int32)
     return SimpleNamespace(
         input_tokens=torch.zeros((1, 1), dtype=torch.int32),
         input_positions=torch.zeros((1,), dtype=torch.int32),
-        block_tables=torch.zeros((1, 1), dtype=torch.int32),
-        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables=page_table,
+        block_tables_per_group=[page_table],
         block_tables_per_layer=None,
         unpadded_batch_size=1,
         tt_sampling_params=_sampling_params(),
@@ -77,6 +80,20 @@ def _accepted_decode_hooks(runner):
     runner.note_decode_layout_consumed = lambda: None
     runner.note_decode_state_slots_settled = lambda: None
     return runner
+
+
+def _cached_reqs(req_ids, *, context_phase=(), resumed=()):
+    req_ids = list(req_ids)
+    context_phase = set(context_phase)
+    return CachedRequestData(
+        req_ids=req_ids,
+        resumed_req_ids=set(resumed),
+        new_token_ids=[[] for _ in req_ids],
+        all_token_ids={},
+        new_block_ids=[None for _ in req_ids],
+        num_computed_tokens=[1 for _ in req_ids],
+        num_output_tokens=[0 if req_id in context_phase else 1 for req_id in req_ids],
+    )
 
 
 def test_first_and_steady_device_decode_commands():
@@ -96,6 +113,24 @@ def test_first_and_steady_device_decode_commands():
     assert steady.overlap_safe
 
 
+def test_reload_plan_rejects_incoherent_command_combinations():
+    with pytest.raises(AssertionError, match="reset_sampling_state requires"):
+        TTDecodeReloadPlan(
+            reload_inputs=False,
+            reload_page_table=False,
+            reload_sampling_params=True,
+            reset_sampling_state=True,
+        )
+
+    with pytest.raises(AssertionError, match="reload_page_table"):
+        TTDecodeReloadPlan(
+            reload_inputs=True,
+            reload_page_table=True,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+
+
 def test_page_table_only_refresh_is_overlap_safe():
     controller = _controller()
     _commit(controller, _decode_input(page=1))
@@ -105,6 +140,40 @@ def test_page_table_only_refresh_is_overlap_safe():
     assert not plan.reload_inputs
     assert plan.reload_page_table
     assert plan.overlap_safe
+
+
+def test_submit_decode_delivers_page_table_only_refresh():
+    calls = []
+
+    class Model:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            calls.append(kwargs)
+            return torch.zeros((1, 1))
+
+    runner = _accepted_decode_hooks(
+        SimpleNamespace(
+            model=Model(),
+            trace_mode="decode_only",
+            kv_caches=object(),
+            request_specific_rope=False,
+        )
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(layout_changed=True, page=1), read_from_device=True
+    )
+    controller.submit_decode(
+        _submission_input(layout_changed=False, page=2), read_from_device=True
+    )
+
+    assert calls[1]["reload_inputs"] is False
+    assert calls[1]["reload_page_table"] is True
+    assert calls[1]["reload_sampling_params"] is False
+    assert calls[1]["reset_sampling_state"] is False
 
 
 def test_standard_dp_async_requires_contract_v1():
@@ -191,21 +260,52 @@ def test_failed_deferred_readback_is_terminal():
 
 
 def test_state_slot_ownership_commits_only_after_accepted_decode():
+    class Model:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": True}
+        fail = True
+
+        def decode_forward(self, **kwargs):
+            if self.fail:
+                raise RuntimeError("submission failed")
+            return torch.zeros((1, 1))
+
     runner = SimpleNamespace(
+        model=Model(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
         tt_per_lane_max_num_seqs=2,
         _req_state_slot={"a": 1, "b": 0},
         _pending_state_slot_settle=None,
+        _decode_layout_changed_since_last_decode=True,
     )
+    runner.note_decode_layout_consumed = lambda: (
+        TTModelRunner.note_decode_layout_consumed(runner)
+    )
+    runner.note_decode_state_slots_settled = lambda: (
+        TTModelRunner.note_decode_state_slots_settled(runner)
+    )
+    controller = TTAsyncDecodeController(runner)
 
     remap = TTModelRunner._decode_state_slot_remap(runner, ["a", "b"])
+    model_input = _submission_input(layout_changed=True)
+    model_input.slot_remap = remap
 
     assert remap.tolist() == [1, 0]
     assert runner._req_state_slot == {"a": 1, "b": 0}
     assert runner._pending_state_slot_settle == {"a": 0, "b": 1}
 
-    TTModelRunner.note_decode_state_slots_settled(runner)
+    with pytest.raises(RuntimeError, match="submission failed"):
+        controller.submit_decode(model_input, read_from_device=True)
+    assert runner._req_state_slot == {"a": 1, "b": 0}
+    assert runner._decode_layout_changed_since_last_decode
+
+    runner.model.fail = False
+    controller.submit_decode(model_input, read_from_device=True)
     assert runner._req_state_slot == {"a": 0, "b": 1}
     assert runner._pending_state_slot_settle is None
+    assert not runner._decode_layout_changed_since_last_decode
 
 
 def test_host_sampling_and_host_to_device_transition_reload():
@@ -239,6 +339,51 @@ def test_prefill_layout_trace_and_capability_force_input_reload():
     assert _commit(no_residency, _decode_input()).reload_inputs
 
 
+def test_transition_applies_drained_token_before_host_authoritative_reload():
+    request_state = SimpleNamespace(output_token_ids=[])
+    input_batch = SimpleNamespace(
+        req_id_to_index={"request": 0},
+        num_tokens=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
+    )
+    runner = SimpleNamespace(
+        requests={"request": request_state},
+        input_batch=input_batch,
+        model_config=SimpleNamespace(max_model_len=8),
+        model=SimpleNamespace(
+            decode_input_update_contract=1,
+            model_capabilities={"supports_async_decode": True},
+        ),
+        trace_mode="decode_only",
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    controller = TTAsyncDecodeController(runner)
+    _commit(controller, _decode_input())
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["request"],
+            req_id_to_index={"request": 0},
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+    )
+
+    controller.apply_completed_decode_step(completed)
+    controller.note_prefill_submitted()
+    plan = controller.plan_decode_reload(_decode_input())
+
+    next_position = int(input_batch.num_tokens[0]) - 1
+    assert next_position == 3
+    assert input_batch.token_ids_cpu[0, next_position] == 7
+    assert request_state.output_token_ids == [7]
+    assert plan.reload_inputs
+    assert plan.reset_sampling_state
+
+
 def test_scheduler_context_phase_distinguishes_chunked_prefill_from_decode():
     input_batch = SimpleNamespace(
         req_id_to_index={"request": 0},
@@ -253,11 +398,7 @@ def test_scheduler_context_phase_distinguishes_chunked_prefill_from_decode():
     controller = TTAsyncDecodeController(runner)
     controller._decode_chain_valid = True
     controller._previous_device_sampling = True
-    cached_reqs = SimpleNamespace(
-        req_ids=["request"],
-        resumed_req_ids=set(),
-        is_context_phase=lambda req_id: True,
-    )
+    cached_reqs = _cached_reqs(["request"], context_phase=["request"])
     scheduler_output = SimpleNamespace(
         scheduled_new_reqs=[],
         scheduled_cached_reqs=cached_reqs,
@@ -269,7 +410,7 @@ def test_scheduler_context_phase_distinguishes_chunked_prefill_from_decode():
     )
     # A decode may schedule several speculative tokens; only the scheduler's
     # phase marker, not a token-count heuristic, classifies it.
-    cached_reqs.is_context_phase = lambda req_id: False
+    scheduler_output.scheduled_cached_reqs = _cached_reqs(["request"])
     runner.requests = {}
     scheduler_output.pending_structured_output_tokens = None
     input_batch.no_penalties = True
@@ -282,6 +423,57 @@ def test_scheduler_context_phase_distinguishes_chunked_prefill_from_decode():
     runner.check_perform_device_sampling = lambda **kwargs: True
     assert controller.steady_decode_scheduler_invariants_met(
         scheduler_output, decode_layout_changed=False
+    )
+
+
+def test_scheduler_prediction_rejects_every_front_packed_layout_transition():
+    req_ids = ["a", "b"]
+    input_batch = SimpleNamespace(
+        req_id_to_index={"a": 0, "b": 1},
+        no_penalties=True,
+        no_allowed_token_ids=True,
+        sampling=SimpleNamespace(
+            bad_words_token_ids={}, has_active_logitsprocs=lambda: False
+        ),
+        max_num_logprobs=None,
+    )
+    runner = SimpleNamespace(
+        model=SimpleNamespace(decode_input_update_contract=1),
+        input_batch=input_batch,
+        requests={req_id: SimpleNamespace(sampling_params=None) for req_id in req_ids},
+        model_config=SimpleNamespace(logits_processors=[]),
+        _decode_layout_changed_since_last_decode=False,
+        check_perform_device_sampling=lambda **kwargs: True,
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller._decode_chain_valid = True
+    controller._previous_device_sampling = True
+
+    def output(ids, *, context=(), resumed=(), scheduled_counts=None):
+        ids = list(ids)
+        return SimpleNamespace(
+            num_scheduled_tokens=scheduled_counts or {req_id: 1 for req_id in ids},
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=_cached_reqs(
+                ids, context_phase=context, resumed=resumed
+            ),
+            pending_structured_output_tokens=False,
+        )
+
+    assert controller.steady_decode_scheduler_invariants_met(output(req_ids))
+    assert not controller.steady_decode_scheduler_invariants_met(output(["a"]))
+    assert not controller.steady_decode_scheduler_invariants_met(
+        output(["a", "b", "c"])
+    )
+    assert not controller.steady_decode_scheduler_invariants_met(
+        output(req_ids, resumed=["b"])
+    )
+    assert not controller.steady_decode_scheduler_invariants_met(
+        output(req_ids, context=["b"])
+    )
+    # A speculative decode may schedule several tokens and remains decode work.
+    assert controller.steady_decode_scheduler_invariants_met(
+        output(req_ids, scheduled_counts={"a": 1, "b": 4})
     )
 
 
@@ -412,7 +604,6 @@ def test_invalidated_async_result_updates_neither_runner_nor_published_output():
         context=SubmittedStepContext(
             req_ids=["request"],
             req_id_to_index={"request": 0},
-            request_states=(request_state,),
             submit_time_ns=1,
         ),
         completion_time_ns=2,
@@ -423,6 +614,20 @@ def test_invalidated_async_result_updates_neither_runner_nor_published_output():
 
     assert request_state.output_token_ids == []
     assert runner_output.sampled_token_ids == [[]]
+
+
+def test_invalidated_result_ids_come_from_current_scheduler_lifecycle():
+    scheduler_output = SimpleNamespace(
+        finished_req_ids={"finished"},
+        preempted_req_ids={"preempted"},
+        scheduled_cached_reqs=_cached_reqs(["resumed"], resumed=["resumed"]),
+    )
+
+    assert TTAsyncDecodeController.invalidated_req_ids(scheduler_output) == {
+        "finished",
+        "preempted",
+        "resumed",
+    }
 
 
 def test_unscheduled_live_request_keeps_accepted_token_in_cached_state():
@@ -437,7 +642,6 @@ def test_unscheduled_live_request_keeps_accepted_token_in_cached_state():
         runner,
         sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
         req_ids=["request"],
-        request_states=(request_state,),
     )
 
     assert request_state.output_token_ids == [7]

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -447,7 +447,6 @@ def test_async_lane_decode_uses_batch_extraction():
     context = SubmittedStepContext(
         req_ids=["req-4"],
         req_id_to_index={"req-4": 0},
-        request_states=(),
         submit_time_ns=123,
     )
     model_input = object()

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -279,7 +279,9 @@ def test_get_output_tokens_skips_all_intermediate_prefill_rows():
 def test_finish_lane_sync_suppresses_intermediate_prefill_output():
     # The chunk ends at position 3 but the request has 8 tokens, so the step
     # contributes KV state only.
-    model_input = SimpleNamespace(prompt_lens=[3])
+    model_input = SimpleNamespace(
+        prompt_lens=[3], suppressed_prefill_output_req_ids=frozenset()
+    )
 
     def extract_output(
         runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
@@ -321,6 +323,51 @@ def test_finish_lane_sync_suppresses_intermediate_prefill_output():
     )
 
     assert output.req_ids == ["request"]
+    assert output.sampled_token_ids == [[]]
+
+
+def test_finish_lane_sync_suppresses_resumed_prefill_duplicate():
+    model_input = SimpleNamespace(
+        prompt_lens=[8],
+        suppressed_prefill_output_req_ids=frozenset({"request"}),
+    )
+
+    def extract_output(
+        runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
+    ):
+        assert is_decode is False
+        return torch.tensor([[42]], dtype=torch.int32), None
+
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=lambda model_input,
+        grammar_output,
+        *,
+        lane_total: model_input,
+        lane_batch=SimpleNamespace(
+            extract_output=extract_output,
+            req_ids={0: "request"},
+            num_tokens=[8],
+        ),
+        apply_and_build_runner_output=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("duplicate resumed-prefill output must not be applied")
+        ),
+        _output_tokens_per_step=1,
+    )
+    runner._build_chunked_prefill_output = lambda **kwargs: (
+        TTModelRunner._build_chunked_prefill_output(runner, **kwargs)
+    )
+
+    output = TTModelRunner._finish_lane_sync(
+        runner,
+        None,
+        tt_out=object(),
+        tt_log_probs=None,
+        model_input=model_input,
+        scheduled_rows=[0],
+        is_decode=False,
+        lane_total=1,
+    )
+
     assert output.sampled_token_ids == [[]]
 
 

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -279,9 +279,7 @@ def test_get_output_tokens_skips_all_intermediate_prefill_rows():
 def test_finish_lane_sync_suppresses_intermediate_prefill_output():
     # The chunk ends at position 3 but the request has 8 tokens, so the step
     # contributes KV state only.
-    model_input = SimpleNamespace(
-        prompt_lens=[3], suppressed_prefill_output_req_ids=frozenset()
-    )
+    model_input = SimpleNamespace(prompt_lens=[3])
 
     def extract_output(
         runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
@@ -323,51 +321,6 @@ def test_finish_lane_sync_suppresses_intermediate_prefill_output():
     )
 
     assert output.req_ids == ["request"]
-    assert output.sampled_token_ids == [[]]
-
-
-def test_finish_lane_sync_suppresses_resumed_prefill_duplicate():
-    model_input = SimpleNamespace(
-        prompt_lens=[8],
-        suppressed_prefill_output_req_ids=frozenset({"request"}),
-    )
-
-    def extract_output(
-        runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
-    ):
-        assert is_decode is False
-        return torch.tensor([[42]], dtype=torch.int32), None
-
-    runner = SimpleNamespace(
-        _apply_grammar_to_input=lambda model_input,
-        grammar_output,
-        *,
-        lane_total: model_input,
-        lane_batch=SimpleNamespace(
-            extract_output=extract_output,
-            req_ids={0: "request"},
-            num_tokens=[8],
-        ),
-        apply_and_build_runner_output=lambda *args, **kwargs: (_ for _ in ()).throw(
-            AssertionError("duplicate resumed-prefill output must not be applied")
-        ),
-        _output_tokens_per_step=1,
-    )
-    runner._build_chunked_prefill_output = lambda **kwargs: (
-        TTModelRunner._build_chunked_prefill_output(runner, **kwargs)
-    )
-
-    output = TTModelRunner._finish_lane_sync(
-        runner,
-        None,
-        tt_out=object(),
-        tt_log_probs=None,
-        model_input=model_input,
-        scheduled_rows=[0],
-        is_decode=False,
-        lane_total=1,
-    )
-
     assert output.sampled_token_ids == [[]]
 
 

--- a/tests/test_lane_model_runner.py
+++ b/tests/test_lane_model_runner.py
@@ -342,6 +342,7 @@ def test_submit_prefill_forwards_plan_empty_slots_to_model():
         trace_mode="none",
         request_specific_rope=False,
         model=FakeModel(),
+        async_decode=SimpleNamespace(note_prefill_submitted=lambda: None),
     )
     model_input = SimpleNamespace(
         input_tokens=torch.zeros((1, 1), dtype=torch.int32),
@@ -393,6 +394,8 @@ def test_submit_decode_forwards_slot_remap_to_model(perform_device_sampling):
         trace_mode="none",
         request_specific_rope=False,
         model=FakeModel(),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: None,
     )
     remap = torch.tensor([1, 0], dtype=torch.int32)
     model_input = SimpleNamespace(
@@ -405,7 +408,7 @@ def test_submit_decode_forwards_slot_remap_to_model(perform_device_sampling):
         perform_device_sampling=perform_device_sampling,
         prompt_tokens=None,
         output_tokens=None,
-        reset_batch=False,
+        decode_layout_changed=False,
         slot_remap=remap,
     )
 

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -144,6 +144,24 @@ def test_idle_step_propagates_finished_req_ids():
     assert lanes[1].scheduled_modes == [TTSchedulingMode.DECODE_ONLY]
 
 
+def test_step_plan_reports_exact_lane_layout_changes():
+    lane = FakeLane(running=1)
+    coordinator = _make_coordinator([lane], per_lane_max=2)
+
+    first_decode = coordinator.schedule()
+    assert get_tt_step_plan(first_decode).decode_layout_changed
+
+    # The same request keeps the same stable lane row.
+    second_decode = coordinator.schedule()
+    assert not get_tt_step_plan(second_decode).decode_layout_changed
+
+    # A live request omitted from a prefill step still owns its row; unlike a
+    # front-packed batch, unscheduled membership is not a layout transition.
+    empty = SchedulerOutput.make_empty()
+    prefill_plan = coordinator._build_step_plan([empty], empty, is_decode=False)
+    assert not prefill_plan.decode_layout_changed
+
+
 def test_decode_fallback_when_forced_prefill_schedules_nothing():
     # Lane 0 has running decodes (and a finished req to report); lane 1 has a
     # queued request that forces prefill. Prefill schedules nothing, so the

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -22,7 +22,9 @@ from vllm_tt_plugin.lane_scheduler import (
 from vllm_tt_plugin.scheduler import (
     TTSchedulingMode,
     get_tt_forced_reset_discard_counts,
+    get_tt_unreserved_resumed_prefill_req_ids,
     set_tt_forced_reset_discard_counts,
+    set_tt_unreserved_resumed_prefill_req_ids,
 )
 
 
@@ -371,6 +373,7 @@ def test_merge_combines_nonempty_lane_outputs():
     lane0.preempted_req_ids = {"pre-0"}
     lane0.num_invalid_spec_tokens = {"a": 3}
     set_tt_forced_reset_discard_counts(lane0, {"a": 1})
+    set_tt_unreserved_resumed_prefill_req_ids(lane0, {"a"})
 
     lane1 = SchedulerOutput.make_empty()
     lane1.scheduled_new_reqs = ["new-b", "new-c"]
@@ -390,6 +393,7 @@ def test_merge_combines_nonempty_lane_outputs():
     lane1.free_encoder_mm_hashes = ["h1"]
     # lane1 reports no preemption and no invalid spec tokens.
     set_tt_forced_reset_discard_counts(lane1, {"b": 2})
+    set_tt_unreserved_resumed_prefill_req_ids(lane1, {"b"})
 
     merged = merge_lane_scheduler_outputs([lane0, lane1])
 
@@ -416,6 +420,7 @@ def test_merge_combines_nonempty_lane_outputs():
     assert merged.preempted_req_ids == {"pre-0"}
     assert merged.num_invalid_spec_tokens == {"a": 3}
     assert get_tt_forced_reset_discard_counts(merged) == {"a": 1, "b": 2}
+    assert get_tt_unreserved_resumed_prefill_req_ids(merged) == frozenset({"a", "b"})
 
 
 def test_merge_preserves_none_for_absent_optional_fields():

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -22,9 +22,7 @@ from vllm_tt_plugin.lane_scheduler import (
 from vllm_tt_plugin.scheduler import (
     TTSchedulingMode,
     get_tt_forced_reset_discard_counts,
-    get_tt_unreserved_resumed_prefill_req_ids,
     set_tt_forced_reset_discard_counts,
-    set_tt_unreserved_resumed_prefill_req_ids,
 )
 
 
@@ -373,7 +371,6 @@ def test_merge_combines_nonempty_lane_outputs():
     lane0.preempted_req_ids = {"pre-0"}
     lane0.num_invalid_spec_tokens = {"a": 3}
     set_tt_forced_reset_discard_counts(lane0, {"a": 1})
-    set_tt_unreserved_resumed_prefill_req_ids(lane0, {"a"})
 
     lane1 = SchedulerOutput.make_empty()
     lane1.scheduled_new_reqs = ["new-b", "new-c"]
@@ -393,7 +390,6 @@ def test_merge_combines_nonempty_lane_outputs():
     lane1.free_encoder_mm_hashes = ["h1"]
     # lane1 reports no preemption and no invalid spec tokens.
     set_tt_forced_reset_discard_counts(lane1, {"b": 2})
-    set_tt_unreserved_resumed_prefill_req_ids(lane1, {"b"})
 
     merged = merge_lane_scheduler_outputs([lane0, lane1])
 
@@ -420,7 +416,6 @@ def test_merge_combines_nonempty_lane_outputs():
     assert merged.preempted_req_ids == {"pre-0"}
     assert merged.num_invalid_spec_tokens == {"a": 3}
     assert get_tt_forced_reset_discard_counts(merged) == {"a": 1, "b": 2}
-    assert get_tt_unreserved_resumed_prefill_req_ids(merged) == frozenset({"a", "b"})
 
 
 def test_merge_preserves_none_for_absent_optional_fields():

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -19,7 +19,11 @@ from vllm_tt_plugin.lane_scheduler import (
     get_tt_step_plan,
     merge_lane_scheduler_outputs,
 )
-from vllm_tt_plugin.scheduler import TTSchedulingMode
+from vllm_tt_plugin.scheduler import (
+    TTSchedulingMode,
+    get_tt_forced_reset_discard_counts,
+    set_tt_forced_reset_discard_counts,
+)
 
 
 class FakeLane:
@@ -182,6 +186,25 @@ def test_decode_fallback_when_forced_prefill_schedules_nothing():
         TTSchedulingMode.PREFILL_ONLY,
         TTSchedulingMode.DECODE_ONLY,
     ]
+
+
+def test_decode_fallback_carries_forced_reset_discard_counts():
+    lane0 = FakeLane(running=1)
+    lane1 = FakeLane(waiting=1)
+    coordinator = _make_coordinator([lane0, lane1])
+    lane_schedule = lane0.schedule
+
+    def _schedule():
+        output = lane_schedule()
+        if lane0.scheduled_modes[-1] == TTSchedulingMode.PREFILL_ONLY:
+            set_tt_forced_reset_discard_counts(output, {"stale": 2})
+        return output
+
+    lane0.schedule = _schedule
+
+    output = coordinator.schedule()
+
+    assert get_tt_forced_reset_discard_counts(output) == {"stale": 2}
 
 
 def test_no_fallback_when_no_running_requests():
@@ -347,6 +370,7 @@ def test_merge_combines_nonempty_lane_outputs():
     lane0.free_encoder_mm_hashes = ["h0"]
     lane0.preempted_req_ids = {"pre-0"}
     lane0.num_invalid_spec_tokens = {"a": 3}
+    set_tt_forced_reset_discard_counts(lane0, {"a": 1})
 
     lane1 = SchedulerOutput.make_empty()
     lane1.scheduled_new_reqs = ["new-b", "new-c"]
@@ -365,6 +389,7 @@ def test_merge_combines_nonempty_lane_outputs():
     lane1.finished_req_ids = {"fin-1"}
     lane1.free_encoder_mm_hashes = ["h1"]
     # lane1 reports no preemption and no invalid spec tokens.
+    set_tt_forced_reset_discard_counts(lane1, {"b": 2})
 
     merged = merge_lane_scheduler_outputs([lane0, lane1])
 
@@ -390,6 +415,7 @@ def test_merge_combines_nonempty_lane_outputs():
     # Optional fields reported by exactly one lane survive the merge.
     assert merged.preempted_req_ids == {"pre-0"}
     assert merged.num_invalid_spec_tokens == {"a": 3}
+    assert get_tt_forced_reset_discard_counts(merged) == {"a": 1, "b": 2}
 
 
 def test_merge_preserves_none_for_absent_optional_fields():

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -12,6 +12,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 import vllm_tt_plugin  # noqa: F401  (activates tt platform / ttnn import)
 from vllm_tt_plugin.input_batch import InputBatch
 from vllm_tt_plugin.model_runner import TTModelRunner
+from vllm_tt_plugin.scheduler import set_tt_unreserved_resumed_prefill_req_ids
 
 # region Constants
 VOCAB_SIZE = 64
@@ -125,7 +126,6 @@ def test_cached_chunked_prefill_classification(
         num_computed_tokens=[num_computed_tokens],
         num_output_tokens=[0],
     )
-
     model_input = TTModelRunner._prepare_model_inputs(runner, scheduler_output, None)
 
     assert model_input is not None
@@ -173,6 +173,32 @@ def test_resumed_replay_past_prompt_length_remains_prefill():
         num_computed_tokens + num_scheduled_tokens
     ]
     assert model_input.intermediate_prefill_mask.tolist() == [True]
+
+
+def test_resumed_context_phase_marks_its_unreserved_output_for_suppression():
+    batch, request = _batch_with_one_request(
+        prompt_len=4,
+        output_len=0,
+        num_computed_tokens=0,
+    )
+    runner = _fake_runner(batch, request)
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"r": 4}
+    scheduler_output.total_num_scheduled_tokens = 4
+    scheduler_output.scheduled_cached_reqs = CachedRequestData(
+        req_ids=["r"],
+        resumed_req_ids={"r"},
+        new_token_ids=[[]],
+        all_token_ids={},
+        new_block_ids=[None],
+        num_computed_tokens=[0],
+        num_output_tokens=[0],
+    )
+    set_tt_unreserved_resumed_prefill_req_ids(scheduler_output, {"r"})
+
+    model_input = TTModelRunner._prepare_model_inputs(runner, scheduler_output, None)
+
+    assert model_input.suppressed_prefill_output_req_ids == frozenset({"r"})
 
 
 # endregion Prefill classification

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -12,7 +12,6 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 import vllm_tt_plugin  # noqa: F401  (activates tt platform / ttnn import)
 from vllm_tt_plugin.input_batch import InputBatch
 from vllm_tt_plugin.model_runner import TTModelRunner
-from vllm_tt_plugin.scheduler import set_tt_unreserved_resumed_prefill_req_ids
 
 # region Constants
 VOCAB_SIZE = 64
@@ -173,32 +172,6 @@ def test_resumed_replay_past_prompt_length_remains_prefill():
         num_computed_tokens + num_scheduled_tokens
     ]
     assert model_input.intermediate_prefill_mask.tolist() == [True]
-
-
-def test_resumed_context_phase_marks_its_unreserved_output_for_suppression():
-    batch, request = _batch_with_one_request(
-        prompt_len=4,
-        output_len=0,
-        num_computed_tokens=0,
-    )
-    runner = _fake_runner(batch, request)
-    scheduler_output = SchedulerOutput.make_empty()
-    scheduler_output.num_scheduled_tokens = {"r": 4}
-    scheduler_output.total_num_scheduled_tokens = 4
-    scheduler_output.scheduled_cached_reqs = CachedRequestData(
-        req_ids=["r"],
-        resumed_req_ids={"r"},
-        new_token_ids=[[]],
-        all_token_ids={},
-        new_block_ids=[None],
-        num_computed_tokens=[0],
-        num_output_tokens=[0],
-    )
-    set_tt_unreserved_resumed_prefill_req_ids(scheduler_output, {"r"})
-
-    model_input = TTModelRunner._prepare_model_inputs(runner, scheduler_output, None)
-
-    assert model_input.suppressed_prefill_output_req_ids == frozenset({"r"})
 
 
 # endregion Prefill classification

--- a/tests/test_sample_time_grammar.py
+++ b/tests/test_sample_time_grammar.py
@@ -282,6 +282,44 @@ def test_finish_front_packed_sync_applies_grammar_before_sampling():
     assert output.sampled.tolist() == [[42]]
 
 
+def test_v0_sync_decode_defers_state_under_upstream_async_scheduler():
+    order: list[str] = []
+
+    def apply_grammar(model_input, grammar_output, *, lane_total):
+        order.append("grammar")
+        return model_input
+
+    def sample_sync(fwd):
+        order.append("sample")
+        return [torch.tensor([[42]], dtype=torch.int32)], []
+
+    def defer_output(sampled, logprobs, **kwargs):
+        order.append("defer")
+        assert kwargs["req_ids"] == ["req-0"]
+        return SimpleNamespace(sampled=sampled)
+
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(async_scheduling=True),
+        # Contract-v0 standard DP disables device async decode, but the engine
+        # still uses AsyncScheduler placeholder accounting.
+        async_decode_scheduling=False,
+        input_batch=SimpleNamespace(req_ids=["req-0"], num_reqs=1),
+        _apply_grammar_to_input=apply_grammar,
+        _sample_sync_forward=sample_sync,
+        defer_state_apply_and_build_runner_output=defer_output,
+        apply_and_build_runner_output=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("async scheduler output must defer runner state")
+        ),
+    )
+
+    output = TTModelRunner._finish_front_packed_sync(
+        runner, _grammar(1), fwd=_sync_forward(_model_input())
+    )
+
+    assert order == ["grammar", "sample", "defer"]
+    assert output.sampled.tolist() == [[42]]
+
+
 def test_finish_front_packed_sync_with_no_forward_builds_empty_output():
     captured: dict = {}
 

--- a/tests/test_sample_time_grammar.py
+++ b/tests/test_sample_time_grammar.py
@@ -235,7 +235,7 @@ def test_finish_async_decode_sets_bitmask_when_grammar_present():
 
 
 # --------------------------------------------------------------------------
-# _finish_nondp_sync / _finish_lane_sync (grammar applied before sampling)
+# _finish_front_packed_sync / _finish_lane_sync (grammar before sampling)
 # --------------------------------------------------------------------------
 
 
@@ -251,18 +251,18 @@ def _sync_forward(model_input: TTModelInput) -> _SyncForward:
     )
 
 
-def test_finish_nondp_sync_applies_grammar_before_sampling():
+def test_finish_front_packed_sync_applies_grammar_before_sampling():
     order: list[str] = []
 
     def apply_grammar(model_input, grammar_output, *, lane_total):
         order.append("grammar")
         assert lane_total is None
-        return replace(model_input, reset_batch=True)  # mark it was applied
+        return replace(model_input, decode_layout_changed=True)  # mark it was applied
 
     def sample_sync(fwd):
         order.append("sample")
         # Grammar must already be on the input the sampler runs against.
-        assert fwd.model_input.reset_batch is True
+        assert fwd.model_input.decode_layout_changed is True
         return [torch.tensor([[42]], dtype=torch.int32)], []
 
     def build_output(sampled, logprobs, **kwargs):
@@ -276,13 +276,13 @@ def test_finish_nondp_sync_applies_grammar_before_sampling():
     )
     fwd = _sync_forward(_model_input())
 
-    output = TTModelRunner._finish_nondp_sync(runner, _grammar(1), fwd=fwd)
+    output = TTModelRunner._finish_front_packed_sync(runner, _grammar(1), fwd=fwd)
 
     assert order == ["grammar", "sample", "build"]
     assert output.sampled.tolist() == [[42]]
 
 
-def test_finish_nondp_sync_with_no_forward_builds_empty_output():
+def test_finish_front_packed_sync_with_no_forward_builds_empty_output():
     captured: dict = {}
 
     def build_output(sampled, logprobs, **kwargs):
@@ -292,7 +292,7 @@ def test_finish_nondp_sync_with_no_forward_builds_empty_output():
 
     runner = SimpleNamespace(apply_and_build_runner_output=build_output)
 
-    output = TTModelRunner._finish_nondp_sync(runner, None, fwd=None)
+    output = TTModelRunner._finish_front_packed_sync(runner, None, fwd=None)
 
     assert output == "empty"
     assert captured["sampled"].numel() == 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
+from vllm.v1.request import RequestStatus
 
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
@@ -20,7 +21,12 @@ def _scheduler(*, running=(), waiting=0, skipped_waiting=0, mode):
     scheduler.policy = SchedulingPolicy.FCFS
     scheduler.waiting = create_request_queue(scheduler.policy)
     for _ in range(waiting):
-        scheduler.waiting.add_request(object())
+        scheduler.waiting.add_request(
+            SimpleNamespace(
+                status=RequestStatus.WAITING,
+                num_output_placeholders=0,
+            )
+        )
     scheduler.skipped_waiting = create_request_queue(scheduler.policy)
     for _ in range(skipped_waiting):
         scheduler.skipped_waiting.add_request(object())

--- a/tests/test_state_slots.py
+++ b/tests/test_state_slots.py
@@ -25,7 +25,10 @@ SLOTS = 8
 def _runner(slots=SLOTS):
     """Fake runner: the state-slot map, the live-request set and the slot capacity."""
     return SimpleNamespace(
-        tt_per_lane_max_num_seqs=slots, _req_state_slot={}, requests={}
+        tt_per_lane_max_num_seqs=slots,
+        _req_state_slot={},
+        _pending_state_slot_settle=None,
+        requests={},
     )
 
 
@@ -37,6 +40,7 @@ def _prefill(runner, row_req_ids):
 
 def _decode(runner, row_req_ids):
     remap = TTModelRunner._decode_state_slot_remap(runner, list(row_req_ids))
+    TTModelRunner.note_decode_state_slots_settled(runner)
     return None if remap is None else remap.tolist()
 
 
@@ -113,12 +117,11 @@ def test_state_follows_the_request_across_row_moves():
     )
 
 
-def test_building_the_decode_remap_advances_the_ownership_map():
-    """Not a pure query: it records the post-gather layout.
+def test_accepting_the_decode_remap_advances_the_ownership_map():
+    """An accepted decode records the post-gather layout.
 
-    So the remap it returns has to reach the device. A caller that built it and then
-    dropped it would leave the map claiming a move that never happened, and every
-    later step would read the wrong slot behind an identity remap.
+    Building only proposes the move; the helper also models successful submission.
+    A raised decode must leave the ownership map at its pre-gather layout.
     """
     r = _runner()
     r._req_state_slot.update({"A": 3, "B": 1})


### PR DESCRIPTION
## Summary

- make the standalone plugin runner the reload-policy owner for contract-v1 tt-metal adapters
- negotiate through `decode_input_update_contract`, preserving the version-0 call shape and historical reload/drain behavior while adapters migrate
- keep async eligibility independent of contract version and gate it once through `model_capabilities["supports_async_decode"]`
- preserve ordinary preemption output and delay resume until its outstanding placeholder is accounted, preventing duplicate sampling and seeded-RNG advancement
- keep forced prefix-reset handling separate: reset-counted results remain published for vLLM discard accounting but are excluded from runner host state
- centralize exact layout changes, slot remaps, page-table refreshes, sampling resets, seed-state requirements, and async drain boundaries

This replaces the plugin portion of tenstorrent/vllm#456 and incorporates the applicable review fixes from tenstorrent/vllm#458.

## Design specification

[docs/DECODE_RELOAD_CONTRACT.md](https://github.com/tenstorrent/vllm-tt-plugin/blob/tcheda/issue-449-reload-contract/docs/DECODE_RELOAD_CONTRACT.md) is the normative description of command and mode semantics, rollout behavior, async-decode requirements, position advancement, slot remapping, lifecycle accounting, sampling state, and seeding edge cases. It also explains why pending output finalization and lifecycle-aware host-state application occur on opposite sides of scheduler batch mutation.

## Paired adapter change

Pair with tenstorrent/tt-metal#51646 after this PR merges. That PR implements the strict version-1 commands and independently fixes decode-only seed initialization for `seed=None`; it does not rely on tenstorrent/tt-metal#51556.

## Validation

- [Current plugin CI: pre-commit and Python 3.10/3.12 unit tests passed](https://github.com/tenstorrent/vllm-tt-plugin/actions/runs/33196249222)
- local pre-commit, Python compileall, and `git diff --check`
- requested independent extra-high review of the earlier follow-up findings

## Current paired device nightlies

Both runs use this PR at exact SHA `3a7e9646f5cda42c65c1dffa83cc7a4f80603600` across all configured models, SKUs, and tiers:

- [Pre-adapter comparison: current tt-metal `main`](https://github.com/tenstorrent/tt-metal/actions/runs/33196649113)
- [Post-adapter comparison: tt-metal#51646](https://github.com/tenstorrent/tt-metal/actions/runs/33196652335)

Fixes tenstorrent/vllm#449
