### PR TITLE
platform: gate chunked prefill on a model capability instead of a type allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,12 +168,6 @@ together:**
   reasoning and tool parsers line.
 - `docs/vllm-overrides.txt`, re-checked against the new `common.txt` (upstream
   may have relaxed the opencv floor)
-- `src/vllm_tt_plugin/platform.py`, `_VLLM_UNSET_MAX_NUM_BATCHED_TOKENS`.
-  Must match the no-device-memory branch of vLLM
-  `EngineArgs.get_batch_defaults` (`OPENAI_API_SERVER` and `LLM_CLASS`).
-  TT reports no device memory, so we never take the H100 16384/8192 branch.
-  A silent retune of those defaults would raise (or fail to raise) an
-  operator-set 2048/8192 that this plugin can no longer tell from unset.
 
 The pin is spread across a sourced shell script that installs with `--no-deps`,
 so what resolved and what the docs claim can diverge silently. After

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,12 @@ together:**
   reasoning and tool parsers line.
 - `docs/vllm-overrides.txt`, re-checked against the new `common.txt` (upstream
   may have relaxed the opencv floor)
+- `src/vllm_tt_plugin/platform.py`, `_VLLM_UNSET_MAX_NUM_BATCHED_TOKENS`.
+  Must match the no-device-memory branch of vLLM
+  `EngineArgs.get_batch_defaults` (`OPENAI_API_SERVER` and `LLM_CLASS`).
+  TT reports no device memory, so we never take the H100 16384/8192 branch.
+  A silent retune of those defaults would raise (or fail to raise) an
+  operator-set 2048/8192 that this plugin can no longer tell from unset.
 
 The pin is spread across a sourced shell script that installs with `--no-deps`,
 so what resolved and what the docs claim can diverge silently. After

--- a/README.md
+++ b/README.md
@@ -467,13 +467,15 @@ clear error before anything reaches the device:
 - Speculative decoding is not currently supported.
 - LoRA is not currently supported.
 - Chunked prefill is gated on the model's declared capability, not on a
-  `model_type` allowlist. vLLM enables it by default, so a declaring model
-  normally serves with prefill split across steps; pass
+  `model_type` allowlist. vLLM enables it by default; pass
   `--no-enable-chunked-prefill` to opt out. When it is disabled,
-  `max_num_batched_tokens` is bumped to `max_model_len`. When it is enabled the
-  scheduler budget is passed through unchanged: the resume offsets it produces
-  need an alignment that depends on the model's program config and on the length
-  of each remaining span, and the tt-metal generator corrects them itself.
+  `max_num_batched_tokens` is bumped to `max_model_len`. When it is enabled
+  and the operator did not pass `--max-num-batched-tokens`, the same
+  full-prompt budget is kept: vLLM's unset defaults (2048 for `vllm serve`,
+  8192 for `LLM()`) would otherwise silently drop the per-step size. Pass
+  `--max-num-batched-tokens` to set the split size. Resume offsets need an
+  alignment that depends on the model's program config and on the length of
+  each remaining span, and the tt-metal generator corrects them itself.
 - Where chunked prefill is active, multimodal inputs are never split across a
   chunk boundary.
 - Prompt logprobs are rejected at request validation time.

--- a/README.md
+++ b/README.md
@@ -360,9 +360,11 @@ selects the TT-owned runtime classes through vLLM's extension points:
 The execution model matches TT hardware characteristics:
 
 - A TT step is either prefill-only or decode-only.
-- Token-chunked prefill is available for Gemma 4: a long prompt is split across
+- Token-chunked prefill is available to any model whose tt-metal class declares
+  `model_capabilities['supports_chunked_prefill']`: a long prompt is split across
   prefill steps and only the chunk that completes the prompt emits a token.
-  Every other model type keeps prefill unsplit.
+  Today that is the `tt_transformers` Llama, Qwen and Mistral text bridges plus
+  Gemma 4. Every other model keeps prefill unsplit.
 - Async scheduling overlaps decode submission with host-side scheduling when
   the model declares support.
 - For Galaxy-generator models (Llama3 70B, Qwen3-32B) and GPT-OSS,
@@ -464,8 +466,14 @@ clear error before anything reaches the device:
   internal implementation, not exposed at the vLLM level.
 - Speculative decoding is not currently supported.
 - LoRA is not currently supported.
-- Chunked prefill is disabled for every model type except Gemma 4, and
-  `max_num_batched_tokens` is bumped to `max_model_len` when it is disabled.
+- Chunked prefill is gated on the model's declared capability, not on a
+  `model_type` allowlist. vLLM enables it by default, so a declaring model
+  normally serves with prefill split across steps; pass
+  `--no-enable-chunked-prefill` to opt out. When it is disabled,
+  `max_num_batched_tokens` is bumped to `max_model_len`. When it is enabled the
+  scheduler budget is passed through unchanged: the resume offsets it produces
+  need an alignment that depends on the model's program config and on the length
+  of each remaining span, and the tt-metal generator corrects them itself.
 - Where chunked prefill is active, multimodal inputs are never split across a
   chunk boundary.
 - Prompt logprobs are rejected at request validation time.

--- a/README.md
+++ b/README.md
@@ -468,14 +468,14 @@ clear error before anything reaches the device:
 - LoRA is not currently supported.
 - Chunked prefill is gated on the model's declared capability, not on a
   `model_type` allowlist. vLLM enables it by default; pass
-  `--no-enable-chunked-prefill` to opt out. When it is disabled,
-  `max_num_batched_tokens` is bumped to `max_model_len`. When it is enabled
-  and the operator did not pass `--max-num-batched-tokens`, the same
-  full-prompt budget is kept: vLLM's unset defaults (2048 for `vllm serve`,
-  8192 for `LLM()`) would otherwise silently drop the per-step size. Pass
-  `--max-num-batched-tokens` to set the split size. Resume offsets need an
-  alignment that depends on the model's program config and on the length of
-  each remaining span, and the tt-metal generator corrects them itself.
+  `--no-enable-chunked-prefill` to opt out. When it stays on,
+  `max_num_batched_tokens` is left as vLLM set it (2048 for `vllm serve` /
+  `server_example_tt.py`, 8192 for `LLM()`, or an explicit
+  `--max-num-batched-tokens`). When it is disabled, a budget smaller than
+  `max_model_len` is raised to `max_model_len` so a full prompt still fits in
+  one step. Resume offsets need an alignment that depends on the model's
+  program config and on the length of each remaining span, and the tt-metal
+  generator corrects them itself.
 - Where chunked prefill is active, multimodal inputs are never split across a
   chunk boundary.
 - Prompt logprobs are rejected at request validation time.

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -20,9 +20,10 @@ The current TT path is more specialized than upstream vLLM:
 
 - A TT step is treated as either all-prefill or all-decode.
 - TT does not support mixed prefill+decode batches.
-- Token-chunked prefill is supported, but only for model types whose tt-metal
-  generator can resume a prefill (never for block-output models); a chunk
-  continuation is prefill work and only ever runs in a prefill step.
+- Token-chunked prefill is supported, but only for models whose tt-metal class
+  declares that its generator can resume a prefill (never for block-output
+  models); a chunk continuation is prefill work and only ever runs in a prefill
+  step.
 - CPU-device work overlap is a decode optimization.
 - Standard multi-process DP runs independent per-rank engines.
 - Single-process lane-DP coordinates lanes within one process and executes one
@@ -158,8 +159,9 @@ The reason for this policy is simple: TT wants a homogeneous batch type per
 step.
 
 At configuration time the platform turns requested chunked prefill off for
-every model type whose tt-metal generator cannot resume a prefill — and for
-every block-output model, which cannot resume a split prompt — and zeroes
+every model that does not declare
+`model_capabilities['supports_chunked_prefill']` — and for every block-output
+model, which cannot resume a split prompt — and zeroes
 `long_prefill_token_threshold` (the base scheduler applies that cap before it
 consults `enable_chunked_prefill`, so leaving it set would still split a
 prefill). When chunked prefill is off and `max_num_batched_tokens` is smaller
@@ -169,7 +171,7 @@ prompt can be admitted instead of leaving an unschedulable request in
 
 ### Chunked prefill
 
-For a model type that supports it, the base scheduler may give a long prompt
+For a model that declares support, the base scheduler may give a long prompt
 only part of the token budget. The request then moves to `running` with
 `is_prefill_chunk` set, and later prefill steps schedule the next chunk until
 the prompt is fully computed.
@@ -465,8 +467,8 @@ The current TT path is more constrained:
 
 - it treats prefill and decode as separate batch modes
 - it avoids mixed prefill+decode batches
-- it allows chunked prefill only for model types validated for it, and always
-  on the prefill side of the split
+- it allows chunked prefill only for models that declare support for it, and
+  always on the prefill side of the split
 
 ### 2. Async queueing model
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -164,13 +164,12 @@ every model that does not declare
 model, which cannot resume a split prompt, and zeroes
 `long_prefill_token_threshold` (the base scheduler applies that cap before it
 consults `enable_chunked_prefill`, so leaving it set would still split a
-prefill). When chunked prefill is off and `max_num_batched_tokens` is smaller
-than `max_model_len`, it raises that token budget to `max_model_len` so a full
-prompt can be admitted instead of leaving an unschedulable request in
-`waiting`. When chunked prefill stays on and the operator did not pass
-`--max-num-batched-tokens`, the same full-prompt budget is kept: vLLM's unset
-defaults of 2048 (`vllm serve`) and 8192 (`LLM()`) would otherwise become the
-per-step size. An explicit `--max-num-batched-tokens` is left alone.
+prefill). When chunked prefill stays on, `max_num_batched_tokens` is left as
+vLLM set it (2048 for `vllm serve` / `server_example_tt.py`, 8192 for `LLM()`,
+or an explicit `--max-num-batched-tokens`). When chunked prefill is off and
+`max_num_batched_tokens` is smaller than `max_model_len`, it raises that token
+budget to `max_model_len` so a full prompt can be admitted instead of leaving
+an unschedulable request in `waiting`.
 
 ### Chunked prefill
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -160,14 +160,17 @@ step.
 
 At configuration time the platform turns requested chunked prefill off for
 every model that does not declare
-`model_capabilities['supports_chunked_prefill']` — and for every block-output
-model, which cannot resume a split prompt — and zeroes
+`model_capabilities['supports_chunked_prefill']`, and for every block-output
+model, which cannot resume a split prompt, and zeroes
 `long_prefill_token_threshold` (the base scheduler applies that cap before it
 consults `enable_chunked_prefill`, so leaving it set would still split a
 prefill). When chunked prefill is off and `max_num_batched_tokens` is smaller
 than `max_model_len`, it raises that token budget to `max_model_len` so a full
 prompt can be admitted instead of leaving an unschedulable request in
-`waiting`.
+`waiting`. When chunked prefill stays on and the operator did not pass
+`--max-num-batched-tokens`, the same full-prompt budget is kept: vLLM's unset
+defaults of 2048 (`vllm serve`) and 8192 (`LLM()`) would otherwise become the
+per-step size. An explicit `--max-num-batched-tokens` is left alone.
 
 ### Chunked prefill
 

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -139,10 +139,6 @@ _GALAXY_GENERATOR_VERSIONS = {
     "TT_QWEN3_TEXT_VER": "qwen3_32b_galaxy",
 }
 
-# HF ``model_type`` values whose tt-metal generator accepts a ``chunk_start_idx``
-# prefill, i.e. the ones token-chunked prefill has been validated against.
-_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4", "gemma4_unified"}
-
 
 def _disable_chunked_prefill(vllm_config: "VllmConfig", reason: str) -> None:
     """Disable split prefills and restore a full-prompt scheduler budget."""
@@ -176,20 +172,41 @@ def _disable_chunked_prefill(vllm_config: "VllmConfig", reason: str) -> None:
     scheduler_config.long_prefill_token_threshold = 0
 
 
-def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
-    """Restrict token-chunked prefill to the model types that support it."""
+def _apply_chunked_prefill_policy(
+    vllm_config: "VllmConfig",
+    model_capabilities: dict | None,
+    model_class: type,
+) -> None:
+    """Restrict token-chunked prefill to the models that declare support for it."""
     scheduler_config = vllm_config.scheduler_config
-    model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
+    model_desc = f"TT model {model_class.__name__} ({model_class.__module__})"
 
-    if model_type in _CHUNKED_PREFILL_MODEL_TYPES:
-        # A chunk boundary inside a multimodal item would split its embeddings
-        # from their positions. Only meaningful while prefill can be split, and
-        # vLLM rejects the flag outright when one item exceeds the token budget,
-        # so it stays off for every model type below.
-        scheduler_config.disable_chunked_mm_input = True
+    supports_chunked_prefill = (
+        model_capabilities.get("supports_chunked_prefill", False)
+        if model_capabilities
+        else False
+    )
+    if not supports_chunked_prefill or not scheduler_config.enable_chunked_prefill:
+        _disable_chunked_prefill(vllm_config, model_desc)
         return
 
-    _disable_chunked_prefill(vllm_config, f"`model_type={model_type}`")
+    # A chunk boundary inside a multimodal item would split its embeddings from
+    # their positions. Only meaningful while prefill can be split, and vLLM
+    # rejects the flag outright when one item exceeds the token budget, so it
+    # stays off for every model that does not reach here.
+    scheduler_config.disable_chunked_mm_input = True
+
+    # The only signal from outside the process that chunked prefill is active and
+    # at what budget: the scheduler config is absent from /metrics and an
+    # intermediate chunk emits no token, so it raises no iteration stats either.
+    # CI gates its device tests on this line, so it is logged unconditionally.
+    logger.info(
+        "Chunked prefill enabled for %s: max_num_batched_tokens=%d, "
+        "long_prefill_token_threshold=%d.",
+        model_desc,
+        scheduler_config.max_num_batched_tokens,
+        scheduler_config.long_prefill_token_threshold,
+    )
 
 
 def _renormalize_mamba_cache_config(vllm_config: "VllmConfig") -> None:
@@ -1443,8 +1460,6 @@ class TTPlatform(Platform):
 
     @classmethod
     def _apply_check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
-        _apply_chunked_prefill_policy(vllm_config)
-
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )
@@ -1567,6 +1582,10 @@ class TTPlatform(Platform):
         model_capabilities: dict | None = getattr(
             model_class, "model_capabilities", None
         )
+
+        # Rewrites scheduler_config; nothing between here and the closing
+        # ``verify_max_model_len`` reads the fields it touches.
+        _apply_chunked_prefill_policy(vllm_config, model_capabilities, model_class)
         output_tokens_per_step = cls._resolve_output_tokens_per_step(model_class)
         store_tt_output_tokens_per_step(vllm_config, output_tokens_per_step)
         is_block_output_model = is_tt_block_output_model(vllm_config)

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -140,55 +140,6 @@ _GALAXY_GENERATOR_VERSIONS = {
 }
 
 
-# vLLM fills an unset ``max_num_batched_tokens`` from this pair when the
-# platform reports no device memory: 2048 for ``vllm serve``, 8192 for ``LLM()``.
-# Keep in step with the no-device branch of ``EngineArgs.get_batch_defaults``
-# when the pinned vLLM version is bumped (AGENTS.md section 3).
-_VLLM_UNSET_MAX_NUM_BATCHED_TOKENS = frozenset({2048, 8192})
-
-
-def _cli_set_max_num_batched_tokens() -> bool:
-    """True when argv carries ``--max-num-batched-tokens``.
-
-    Explicit budgets equal to 2048/8192 set programmatically
-    (``LLM(max_num_batched_tokens=2048)``) or via a vLLM ``--config`` file
-    never appear here and are treated as unset.
-    """
-    for arg in sys.argv:
-        name, _, _ = arg.partition("=")
-        if name in ("--max-num-batched-tokens", "--max_num_batched_tokens"):
-            return True
-    return False
-
-
-def _raise_vllm_default_token_budget(vllm_config: "VllmConfig") -> None:
-    """Keep a full prompt in one step when the operator did not set a budget.
-
-    Before chunked prefill was capability-gated, Llama/Qwen/Mistral always had
-    it forced off, which made this plugin raise ``max_num_batched_tokens`` to
-    ``max_model_len``. Leaving vLLM's 2048/8192 fallback in place would drop
-    the per-step prefill size by 16x on a 32k model with no flag change. An
-    explicit ``--max-num-batched-tokens`` is left alone.
-    """
-    scheduler_config = vllm_config.scheduler_config
-    max_model_len = vllm_config.model_config.max_model_len
-    budget = scheduler_config.max_num_batched_tokens
-    if budget >= max_model_len:
-        return
-    if budget not in _VLLM_UNSET_MAX_NUM_BATCHED_TOKENS:
-        return
-    if _cli_set_max_num_batched_tokens():
-        return
-    logger.info(
-        "max_num_batched_tokens=%d is vLLM's unset default; raising it to "
-        "max_model_len=%d so a full prompt still fits in one step. Pass "
-        "--max-num-batched-tokens to set the budget.",
-        budget,
-        max_model_len,
-    )
-    scheduler_config.max_num_batched_tokens = max_model_len
-
-
 def _disable_chunked_prefill(vllm_config: "VllmConfig", reason: str) -> None:
     """Disable split prefills and restore a full-prompt scheduler budget."""
     scheduler_config = vllm_config.scheduler_config
@@ -254,8 +205,6 @@ def _apply_chunked_prefill_policy(
     # rejects the flag outright when one item exceeds the token budget, so it
     # stays off for every model that does not reach here.
     scheduler_config.disable_chunked_mm_input = True
-
-    _raise_vllm_default_token_budget(vllm_config)
 
     # The only signal from outside the process that chunked prefill is active and
     # at what budget: the scheduler config is absent from /metrics and an

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -142,11 +142,18 @@ _GALAXY_GENERATOR_VERSIONS = {
 
 # vLLM fills an unset ``max_num_batched_tokens`` from this pair when the
 # platform reports no device memory: 2048 for ``vllm serve``, 8192 for ``LLM()``.
+# Keep in step with the no-device branch of ``EngineArgs.get_batch_defaults``
+# when the pinned vLLM version is bumped (AGENTS.md section 3).
 _VLLM_UNSET_MAX_NUM_BATCHED_TOKENS = frozenset({2048, 8192})
 
 
 def _cli_set_max_num_batched_tokens() -> bool:
-    """True when this process was launched with an explicit token budget."""
+    """True when argv carries ``--max-num-batched-tokens``.
+
+    Explicit budgets equal to 2048/8192 set programmatically
+    (``LLM(max_num_batched_tokens=2048)``) or via a vLLM ``--config`` file
+    never appear here and are treated as unset.
+    """
     for arg in sys.argv:
         name, _, _ = arg.partition("=")
         if name in ("--max-num-batched-tokens", "--max_num_batched_tokens"):

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -140,6 +140,48 @@ _GALAXY_GENERATOR_VERSIONS = {
 }
 
 
+# vLLM fills an unset ``max_num_batched_tokens`` from this pair when the
+# platform reports no device memory: 2048 for ``vllm serve``, 8192 for ``LLM()``.
+_VLLM_UNSET_MAX_NUM_BATCHED_TOKENS = frozenset({2048, 8192})
+
+
+def _cli_set_max_num_batched_tokens() -> bool:
+    """True when this process was launched with an explicit token budget."""
+    for arg in sys.argv:
+        name, _, _ = arg.partition("=")
+        if name in ("--max-num-batched-tokens", "--max_num_batched_tokens"):
+            return True
+    return False
+
+
+def _raise_vllm_default_token_budget(vllm_config: "VllmConfig") -> None:
+    """Keep a full prompt in one step when the operator did not set a budget.
+
+    Before chunked prefill was capability-gated, Llama/Qwen/Mistral always had
+    it forced off, which made this plugin raise ``max_num_batched_tokens`` to
+    ``max_model_len``. Leaving vLLM's 2048/8192 fallback in place would drop
+    the per-step prefill size by 16x on a 32k model with no flag change. An
+    explicit ``--max-num-batched-tokens`` is left alone.
+    """
+    scheduler_config = vllm_config.scheduler_config
+    max_model_len = vllm_config.model_config.max_model_len
+    budget = scheduler_config.max_num_batched_tokens
+    if budget >= max_model_len:
+        return
+    if budget not in _VLLM_UNSET_MAX_NUM_BATCHED_TOKENS:
+        return
+    if _cli_set_max_num_batched_tokens():
+        return
+    logger.info(
+        "max_num_batched_tokens=%d is vLLM's unset default; raising it to "
+        "max_model_len=%d so a full prompt still fits in one step. Pass "
+        "--max-num-batched-tokens to set the budget.",
+        budget,
+        max_model_len,
+    )
+    scheduler_config.max_num_batched_tokens = max_model_len
+
+
 def _disable_chunked_prefill(vllm_config: "VllmConfig", reason: str) -> None:
     """Disable split prefills and restore a full-prompt scheduler budget."""
     scheduler_config = vllm_config.scheduler_config
@@ -186,8 +228,18 @@ def _apply_chunked_prefill_policy(
         if model_capabilities
         else False
     )
-    if not supports_chunked_prefill or not scheduler_config.enable_chunked_prefill:
-        _disable_chunked_prefill(vllm_config, model_desc)
+    output_tokens_per_step = (
+        model_capabilities.get("output_tokens_per_step", 1) if model_capabilities else 1
+    )
+    if (
+        not supports_chunked_prefill
+        or not scheduler_config.enable_chunked_prefill
+        or output_tokens_per_step > 1
+    ):
+        reason = model_desc
+        if supports_chunked_prefill and output_tokens_per_step > 1:
+            reason = f"{model_desc} (block-output)"
+        _disable_chunked_prefill(vllm_config, reason)
         return
 
     # A chunk boundary inside a multimodal item would split its embeddings from
@@ -195,6 +247,8 @@ def _apply_chunked_prefill_policy(
     # rejects the flag outright when one item exceeds the token budget, so it
     # stays off for every model that does not reach here.
     scheduler_config.disable_chunked_mm_input = True
+
+    _raise_vllm_default_token_budget(vllm_config)
 
     # The only signal from outside the process that chunked prefill is active and
     # at what budget: the scheduler config is absent from /metrics and an
@@ -1648,9 +1702,9 @@ class TTPlatform(Platform):
                     + ", ".join(missing_hooks)
                 )
 
-            # Gemma4 autoregressive models support token-chunked prefill, but
-            # block-output models cannot resume a split prompt. Capability wins
-            # over the model-type policy once the output width is known.
+            # Block-output models cannot resume a split prompt. The policy
+            # already disables this from output_tokens_per_step; keep the
+            # same guard after the width is stored on the config.
             _disable_chunked_prefill(vllm_config, "block-output models")
 
             # Independently of the MODELS_CONFIG_MAP hook prevented during

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 """Which models keep token-chunked prefill."""
 
+import sys
 from types import SimpleNamespace
 
 # vLLM's own bootstrap resolves the platform plugin, which imports this module.
@@ -39,7 +40,7 @@ def _apply(config, capabilities):
 
 
 def test_declared_support_keeps_chunked_prefill():
-    config = _vllm_config()
+    config = _vllm_config(max_num_batched_tokens=3000)
 
     _apply(config, {"supports_chunked_prefill": True})
 
@@ -51,7 +52,9 @@ def test_declared_support_leaves_the_scheduler_budget_alone():
     # The resume offsets the scheduler hands out are corrected by the tt-metal
     # generator, which derives the alignment from the model's own program config
     # per padded suffix length. No single number the plugin could round to would
-    # satisfy that, so it rounds nothing and passes the operator's budget through.
+    # satisfy that, so an operator-set budget is passed through. vLLM's unset
+    # defaults of 2048 and 8192 are the exception: those are raised to
+    # max_model_len so an upgrade does not silently shrink the per-step size.
     config = _vllm_config(
         max_num_batched_tokens=3000, long_prefill_token_threshold=1000
     )
@@ -118,5 +121,66 @@ def test_declared_support_with_the_flag_off_falls_back_to_the_unsplit_policy():
     _apply(config, {"supports_chunked_prefill": True})
 
     assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+    assert config.scheduler_config.disable_chunked_mm_input is False
+
+
+def test_vllm_serve_default_budget_is_raised_to_max_model_len(monkeypatch):
+    # A declaring model used to take the disable path, which raised the
+    # budget to max_model_len. Keep that default so ``vllm serve`` with no
+    # --max-num-batched-tokens does not silently drop to 2048.
+    monkeypatch.setattr(sys, "argv", ["vllm", "serve", "some-model"])
+    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 16384
+
+
+def test_llm_class_default_budget_is_raised_to_max_model_len(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["python", "offline.py"])
+    config = _vllm_config(max_num_batched_tokens=8192, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 16384
+
+
+def test_explicit_hyphen_cli_budget_is_kept(monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv", ["vllm", "serve", "some-model", "--max-num-batched-tokens", "2048"]
+    )
+    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+
+
+def test_explicit_underscore_cli_budget_is_kept(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["vllm", "serve", "some-model", "--max_num_batched_tokens=2048"],
+    )
+    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+
+
+def test_block_output_model_loses_chunked_prefill_even_when_declared():
+    config = _vllm_config(max_num_batched_tokens=3000, max_model_len=16384)
+
+    _apply(
+        config,
+        {"supports_chunked_prefill": True, "output_tokens_per_step": 256},
+    )
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.max_num_batched_tokens == 16384
     assert config.scheduler_config.long_prefill_token_threshold == 0
     assert config.scheduler_config.disable_chunked_mm_input is False

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 """Which models keep token-chunked prefill."""
 
-import sys
 from types import SimpleNamespace
 
 # vLLM's own bootstrap resolves the platform plugin, which imports this module.
@@ -49,12 +48,9 @@ def test_declared_support_keeps_chunked_prefill():
 
 
 def test_declared_support_leaves_the_scheduler_budget_alone():
-    # The resume offsets the scheduler hands out are corrected by the tt-metal
-    # generator, which derives the alignment from the model's own program config
-    # per padded suffix length. No single number the plugin could round to would
-    # satisfy that, so an operator-set budget is passed through. vLLM's unset
-    # defaults of 2048 and 8192 are the exception: those are raised to
-    # max_model_len so an upgrade does not silently shrink the per-step size.
+    # Resume offsets are floored by the tt-metal generator, so the plugin
+    # passes max_num_batched_tokens through. That includes vLLM's unset
+    # 2048/8192 defaults: chunked prefill is on, so those *are* the split size.
     config = _vllm_config(
         max_num_batched_tokens=3000, long_prefill_token_threshold=1000
     )
@@ -63,6 +59,24 @@ def test_declared_support_leaves_the_scheduler_budget_alone():
 
     assert config.scheduler_config.max_num_batched_tokens == 3000
     assert config.scheduler_config.long_prefill_token_threshold == 1000
+
+
+def test_vllm_serve_default_budget_is_kept():
+    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+
+
+def test_llm_class_default_budget_is_kept():
+    config = _vllm_config(max_num_batched_tokens=8192, max_model_len=16384)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 8192
 
 
 def test_undeclared_model_loses_chunked_prefill_and_gets_a_full_prompt_budget():
@@ -123,53 +137,6 @@ def test_declared_support_with_the_flag_off_falls_back_to_the_unsplit_policy():
     assert config.scheduler_config.enable_chunked_prefill is False
     assert config.scheduler_config.long_prefill_token_threshold == 0
     assert config.scheduler_config.disable_chunked_mm_input is False
-
-
-def test_vllm_serve_default_budget_is_raised_to_max_model_len(monkeypatch):
-    # A declaring model used to take the disable path, which raised the
-    # budget to max_model_len. Keep that default so ``vllm serve`` with no
-    # --max-num-batched-tokens does not silently drop to 2048.
-    monkeypatch.setattr(sys, "argv", ["vllm", "serve", "some-model"])
-    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
-
-    _apply(config, {"supports_chunked_prefill": True})
-
-    assert config.scheduler_config.enable_chunked_prefill is True
-    assert config.scheduler_config.max_num_batched_tokens == 16384
-
-
-def test_llm_class_default_budget_is_raised_to_max_model_len(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["python", "offline.py"])
-    config = _vllm_config(max_num_batched_tokens=8192, max_model_len=16384)
-
-    _apply(config, {"supports_chunked_prefill": True})
-
-    assert config.scheduler_config.enable_chunked_prefill is True
-    assert config.scheduler_config.max_num_batched_tokens == 16384
-
-
-def test_explicit_hyphen_cli_budget_is_kept(monkeypatch):
-    monkeypatch.setattr(
-        sys, "argv", ["vllm", "serve", "some-model", "--max-num-batched-tokens", "2048"]
-    )
-    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
-
-    _apply(config, {"supports_chunked_prefill": True})
-
-    assert config.scheduler_config.max_num_batched_tokens == 2048
-
-
-def test_explicit_underscore_cli_budget_is_kept(monkeypatch):
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["vllm", "serve", "some-model", "--max_num_batched_tokens=2048"],
-    )
-    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=16384)
-
-    _apply(config, {"supports_chunked_prefill": True})
-
-    assert config.scheduler_config.max_num_batched_tokens == 2048
 
 
 def test_block_output_model_loses_chunked_prefill_even_when_declared():

--- a/tests/test_chunked_prefill_policy.py
+++ b/tests/test_chunked_prefill_policy.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
-"""Which model types keep token-chunked prefill, and what is forced off."""
+"""Which models keep token-chunked prefill."""
 
 from types import SimpleNamespace
 
@@ -12,9 +12,12 @@ import vllm  # noqa: F401
 from vllm_tt_plugin.platform import _apply_chunked_prefill_policy
 
 
+class _FakeModel:
+    """Stand-in for the resolved TT model class; the policy only reads its name."""
+
+
 def _vllm_config(
     *,
-    model_type: str,
     enable_chunked_prefill: bool = True,
     max_num_batched_tokens: int = 2048,
     max_model_len: int = 16384,
@@ -27,61 +30,74 @@ def _vllm_config(
             long_prefill_token_threshold=long_prefill_token_threshold,
             disable_chunked_mm_input=False,
         ),
-        model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(model_type=model_type),
-            max_model_len=max_model_len,
-        ),
+        model_config=SimpleNamespace(max_model_len=max_model_len),
     )
 
 
-def test_gemma4_keeps_chunked_prefill_and_its_token_budget():
-    config = _vllm_config(model_type="gemma4")
+def _apply(config, capabilities):
+    _apply_chunked_prefill_policy(config, capabilities, _FakeModel)
 
-    _apply_chunked_prefill_policy(config)
+
+def test_declared_support_keeps_chunked_prefill():
+    config = _vllm_config()
+
+    _apply(config, {"supports_chunked_prefill": True})
 
     assert config.scheduler_config.enable_chunked_prefill is True
-    assert config.scheduler_config.max_num_batched_tokens == 2048
-    assert config.scheduler_config.long_prefill_token_threshold == 512
     assert config.scheduler_config.disable_chunked_mm_input is True
 
 
-def test_unified_gemma4_checkpoint_also_keeps_chunked_prefill():
-    config = _vllm_config(model_type="gemma4_unified")
+def test_declared_support_leaves_the_scheduler_budget_alone():
+    # The resume offsets the scheduler hands out are corrected by the tt-metal
+    # generator, which derives the alignment from the model's own program config
+    # per padded suffix length. No single number the plugin could round to would
+    # satisfy that, so it rounds nothing and passes the operator's budget through.
+    config = _vllm_config(
+        max_num_batched_tokens=3000, long_prefill_token_threshold=1000
+    )
 
-    _apply_chunked_prefill_policy(config)
+    _apply(config, {"supports_chunked_prefill": True})
 
-    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 3000
+    assert config.scheduler_config.long_prefill_token_threshold == 1000
 
 
-def test_other_model_type_loses_chunked_prefill_and_gets_a_full_prompt_budget():
-    config = _vllm_config(model_type="llama")
+def test_undeclared_model_loses_chunked_prefill_and_gets_a_full_prompt_budget():
+    config = _vllm_config()
 
-    _apply_chunked_prefill_policy(config)
+    _apply(config, {"supports_prefix_caching": True})
 
     assert config.scheduler_config.enable_chunked_prefill is False
     assert config.scheduler_config.max_num_batched_tokens == 16384
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+
+
+def test_model_without_any_capabilities_loses_chunked_prefill():
+    config = _vllm_config()
+
+    _apply(config, None)
+
+    assert config.scheduler_config.enable_chunked_prefill is False
 
 
 def test_unsplit_prefill_leaves_chunked_mm_input_enabled():
     # vLLM raises outright when this is set and one mm item is larger than
     # max_num_batched_tokens, e.g. a VL model pinned to a short max_model_len.
     # With prefill never split the flag is inert, so it must stay off.
-    config = _vllm_config(
-        model_type="qwen2_5_vl", max_num_batched_tokens=2048, max_model_len=2048
-    )
+    config = _vllm_config(max_num_batched_tokens=2048, max_model_len=2048)
 
-    _apply_chunked_prefill_policy(config)
+    _apply(config, {"supports_prefix_caching": True})
 
     assert config.scheduler_config.enable_chunked_prefill is False
     assert config.scheduler_config.disable_chunked_mm_input is False
 
 
-def test_other_model_type_zeroes_the_long_prefill_threshold():
+def test_undeclared_model_zeroes_the_long_prefill_threshold():
     # The base scheduler applies this cap before it consults
     # enable_chunked_prefill, so leaving it set would still split a prefill.
-    config = _vllm_config(model_type="llama", enable_chunked_prefill=False)
+    config = _vllm_config(enable_chunked_prefill=False)
 
-    _apply_chunked_prefill_policy(config)
+    _apply(config, None)
 
     assert config.scheduler_config.long_prefill_token_threshold == 0
     # Chunked prefill was already off, so the token budget is left alone.
@@ -89,8 +105,18 @@ def test_other_model_type_zeroes_the_long_prefill_threshold():
 
 
 def test_token_budget_is_left_alone_when_it_already_covers_the_model_len():
-    config = _vllm_config(model_type="llama", max_num_batched_tokens=32768)
+    config = _vllm_config(max_num_batched_tokens=32768)
 
-    _apply_chunked_prefill_policy(config)
+    _apply(config, None)
 
     assert config.scheduler_config.max_num_batched_tokens == 32768
+
+
+def test_declared_support_with_the_flag_off_falls_back_to_the_unsplit_policy():
+    config = _vllm_config(enable_chunked_prefill=False)
+
+    _apply(config, {"supports_chunked_prefill": True})
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+    assert config.scheduler_config.disable_chunked_mm_input is False

--- a/tests/tt/conftest.py
+++ b/tests/tt/conftest.py
@@ -4,6 +4,20 @@ import openai
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def reset_tt_platform_class_state():
+    """Neutralize the host-suite fixture of the same name.
+
+    These tests drive a server over HTTP and never touch ``TTPlatform`` class
+    state, so there is nothing to save and restore. The host version imports the
+    platform at setup time, and in a file that does not import vLLM at module
+    scope that import lands while ``vllm.platforms`` is still half-initialized
+    by the plugin entry point, so the first test of the file errors out on
+    ``cannot import name 'current_platform'``.
+    """
+    yield
+
+
 def pytest_addoption(parser):
     """Add TT-specific command line options."""
     parser.addoption(
@@ -25,6 +39,17 @@ def pytest_addoption(parser):
         default=32,
         help="Max batch size for testing (default: 32)",
     )
+    parser.addoption(
+        "--tt-chunked-prefill-budget",
+        action="store",
+        type=int,
+        default=0,
+        help=(
+            "The served max_num_batched_tokens, when the server runs with chunked "
+            "prefill enabled. Tests that need a prompt long enough to be split "
+            "across engine steps size it from this and skip when it is 0 (default)."
+        ),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -43,6 +68,12 @@ def tt_model_name(request):
 def max_batch_size(request):
     """Returns the max batch size for testing."""
     return request.config.getoption("--tt-max-num-seqs")
+
+
+@pytest.fixture(scope="session")
+def chunked_prefill_budget(request):
+    """The served ``max_num_batched_tokens``, or 0 when chunked prefill is off."""
+    return request.config.getoption("--tt-chunked-prefill-budget")
 
 
 @pytest.fixture(scope="session")

--- a/tests/tt/test_chunked_prefill.py
+++ b/tests/tt/test_chunked_prefill.py
@@ -26,9 +26,11 @@ import pytest
 
 from tests.tt.utils import RequestConfig, run_concurrent_batch
 
-# The passphrase sits this far into the filler, so a prompt split into several
-# chunks plants it past a boundary and recalling it needs K/V written at a
-# nonzero chunk_start_idx to be correct.
+# The passphrase sits this far into the filler. A prompt of about one budget
+# plants it in the first chunk, so the resumed tail must attend back to the
+# prefix that chunk wrote. A prompt several times the budget plants it past a
+# chunk boundary, so recalling it also needs K/V written at a nonzero
+# chunk_start_idx.
 NEEDLE_POSITION = 0.75
 
 # Four prompts of roughly one budget each overflow every step, so each step
@@ -128,6 +130,29 @@ def test_a_solo_split_prefill_recalls_its_needle(tt_server, tt_model_name, budge
 
     assert _recalled(output, passphrase), (
         f"a solo split prefill lost the passphrase planted {NEEDLE_POSITION:.0%} "
+        f"into its prompt: want {passphrase!r}, got {output!r}"
+    )
+
+
+def test_a_long_split_prefill_recalls_its_needle(tt_server, tt_model_name, budget):
+    """Prompt long enough that a resumed span pins q_chunk_size=256.
+
+    tt_transformers uses q_chunk_size 64 when the padded remaining span is
+    below 2048 and 256 at or above it. The budget-sized solo prompt only
+    resumes a short tail, so it never hits the 256 alignment. Three budgets
+    of filler leave a remaining span that pads to 2048 or more.
+    """
+    passphrase = "cobalt-heron-256"
+    prompt = _needle_prompt(3 * budget, passphrase, seed=0xC402, nonce="Long.\n")
+
+    (output,) = run_concurrent_batch(
+        tt_server,
+        tt_model_name,
+        [RequestConfig(prompt=prompt, max_tokens=24, temperature=0)],
+    )
+
+    assert _recalled(output, passphrase), (
+        f"a long split prefill lost the passphrase planted {NEEDLE_POSITION:.0%} "
         f"into its prompt: want {passphrase!r}, got {output!r}"
     )
 

--- a/tests/tt/test_chunked_prefill.py
+++ b/tests/tt/test_chunked_prefill.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+"""Scheduler-driven chunked prefill against a live TT server.
+
+Requires a server started with ``--enable-chunked-prefill`` and run with
+``--tt-chunked-prefill-budget=<max_num_batched_tokens>``; every test here skips
+without it.
+
+The failure mode is silent. A resume offset the model cannot honour makes the
+request attend the wrong prefix, and nothing raises: throughput checks pass and
+the response is fluent. So each prompt carries a passphrase in its own body and
+is asked to repeat it, which fails loudly when part of that prompt's K/V is
+wrong.
+
+Concurrency is the point, not prompt length. A single prefill in flight gets the
+whole token budget every step, so every boundary it lands on is a multiple of
+that budget. Boundaries only go ragged when several prefills share a step and one
+is admitted into what is left of it, which is when a resume offset the model
+cannot honour reaches the generator. A block-size-aligned-but-not-q_chunk-aligned
+offset scored 10/20 here against 20/20 with chunked prefill off.
+"""
+
+import random
+
+import pytest
+
+from tests.tt.utils import RequestConfig, run_concurrent_batch
+
+# The passphrase sits this far into the filler, so a prompt split into several
+# chunks plants it past a boundary and recalling it needs K/V written at a
+# nonzero chunk_start_idx to be correct.
+NEEDLE_POSITION = 0.75
+
+# Four prompts of roughly one budget each overflow every step, so each step
+# admits someone into a ragged remainder. Three rounds is twelve samples, and a
+# per-request failure rate of ~50% (what the misaligned-offset bug produced)
+# survives that with probability 2**-12.
+CONCURRENCY = 4
+ROUNDS = 3
+
+# Roughly one token per filler word for every tokenizer in scope. Prompts are
+# sized in words rather than measured, so the test needs no tokenizer.
+FILLER_WORDS = [
+    "alpha",
+    "bravo",
+    "charlie",
+    "delta",
+    "echo",
+    "foxtrot",
+    "golf",
+    "hotel",
+    "india",
+    "juliett",
+    "kilo",
+    "lima",
+    "mike",
+    "november",
+    "oscar",
+    "papa",
+    "quebec",
+    "romeo",
+    "sierra",
+    "tango",
+]
+
+
+def _needle_prompt(num_words: int, passphrase: str, seed: int, nonce: str) -> str:
+    """Filler with ``passphrase`` planted inside it and a question about it.
+
+    ``nonce`` keeps every prompt distinct so prefix caching never serves one
+    request from another's blocks, which would mask exactly what is under test.
+    """
+    rng = random.Random(seed)
+    words = [rng.choice(FILLER_WORDS) for _ in range(num_words)]
+    at = int(num_words * NEEDLE_POSITION)
+    words[at:at] = f"The secret passphrase is {passphrase}.".split()
+    return (
+        f"{nonce}Read the following text and answer the question at the end.\n\n"
+        + " ".join(words)
+        + "\n\nQuestion: what is the secret passphrase?"
+        + "\nAnswer: the secret passphrase is"
+    )
+
+
+def _recalled(output: str | None, passphrase: str) -> bool:
+    return passphrase.lower() in (output or "").lower()
+
+
+@pytest.fixture(scope="module")
+def budget(chunked_prefill_budget):
+    """The served ``max_num_batched_tokens``.
+
+    This is a claim by whoever launched the test, not a fact read back from the
+    server, and the tests cannot check it themselves. Nothing client-visible
+    distinguishes a split prefill from an unsplit one: the scheduler config is
+    absent from ``/metrics``, and an intermediate chunk emits no token, so it
+    raises no iteration stats either. Passphrase recall also succeeds perfectly
+    well on an unsplit prefill, so against a server that silently disabled
+    chunked prefill every test here would pass while testing nothing.
+
+    The workflow closes that hole instead, by requiring the server log to report
+    chunked prefill enabled at this budget before pytest runs. Anyone running
+    this by hand should check the same line.
+    """
+    if chunked_prefill_budget <= 0:
+        pytest.skip(
+            "Needs a server with chunked prefill enabled; pass "
+            "--tt-chunked-prefill-budget=<max_num_batched_tokens>"
+        )
+    return chunked_prefill_budget
+
+
+def test_a_solo_split_prefill_recalls_its_needle(tt_server, tt_model_name, budget):
+    """One prompt, several engine steps, nothing else in flight.
+
+    Every boundary is a multiple of the whole budget here, so this is the
+    well-behaved case. A failure means multi-step prefill is broken outright,
+    before any question of which offsets the model can honour.
+    """
+    passphrase = "cobalt-heron-42"
+    prompt = _needle_prompt(budget, passphrase, seed=0xC401, nonce="Solo.\n")
+
+    (output,) = run_concurrent_batch(
+        tt_server,
+        tt_model_name,
+        [RequestConfig(prompt=prompt, max_tokens=24, temperature=0)],
+    )
+
+    assert _recalled(output, passphrase), (
+        f"a solo split prefill lost the passphrase planted {NEEDLE_POSITION:.0%} "
+        f"into its prompt: want {passphrase!r}, got {output!r}"
+    )
+
+
+def test_prefills_sharing_a_step_each_recall_their_own_needle(
+    tt_server, tt_model_name, budget
+):
+    """Several prompts that together overflow one step's token budget.
+
+    A request admitted into the remainder of a step gets whatever tokens were
+    left, which is a multiple of nothing, and resumes from there on the next
+    step. Every prompt carries its own passphrase, so a request reading the
+    wrong prefix shows up as that request answering wrongly rather than as a
+    change in aggregate throughput.
+    """
+    misses: list[str] = []
+    total = 0
+
+    for rnd in range(ROUNDS):
+        passphrases = [f"cobalt-heron-{rnd}-{i}" for i in range(CONCURRENCY)]
+        configs = [
+            RequestConfig(
+                prompt=_needle_prompt(
+                    budget, passphrase, seed=0xC401 + i, nonce=f"Round {rnd} doc {i}.\n"
+                ),
+                max_tokens=24,
+                temperature=0,
+            )
+            for i, passphrase in enumerate(passphrases)
+        ]
+
+        outputs = run_concurrent_batch(tt_server, tt_model_name, configs)
+        total += len(outputs)
+        for i, (passphrase, output) in enumerate(zip(passphrases, outputs)):
+            if not _recalled(output, passphrase):
+                misses.append(
+                    f"round {rnd} request {i}: want {passphrase!r}, got {output!r}"
+                )
+
+    assert not misses, (
+        f"{len(misses)} of {total} concurrent split prefills answered with a "
+        "passphrase that is not the one planted in their own prompt, so they "
+        "attended the wrong prefix:\n  " + "\n  ".join(misses)
+    )


### PR DESCRIPTION
Gates token-chunked prefill on a model-declared capability instead of a
hardcoded HF `model_type` allowlist. Pairs with
[tenstorrent/tt-metal#54302](https://github.com/tenstorrent/tt-metal/pull/54302),
which declares the capability this reads; the two must land together (metal first, this one second). #54302 in
turn depends on
[tt-metal#54435](https://github.com/tenstorrent/tt-metal/pull/54435), which makes
the resume offsets the scheduler produces safe; that has merged, and both
branches are rebased onto current `main` (plugin `46bc6d7`, which includes the
vLLM 0.26.0 upgrade and #78 / #100 / #105 / #108).

Implements the plugin half of #74.

## What changes

```python
# before
_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4", "gemma4_unified"}
```

Now `model_capabilities['supports_chunked_prefill']`, read off the resolved TT
model class the same way `supports_sample_on_device`, `supports_async_decode`
and `supports_prefix_caching` already are. That brings in the `tt_transformers`
Llama, Qwen2, Qwen3 and Mistral text bridges and takes Gemma 4 off the allowlist
without changing its behaviour.

None of the chunked-prefill machinery itself changes. `model_runner.py`,
`scheduler.py`, `lane_scheduler.py` and `input_batch.py` were already
model-agnostic; the allowlist was the only gate.

## Operator-visible behaviour change

vLLM enables chunked prefill unless told otherwise, so this turns it **on by
default** for Llama, Qwen and Mistral. `max_num_batched_tokens` then follows
upstream: 2048 for `vllm serve` / `server_example_tt.py`, 8192 for `LLM()`,
or an explicit `--max-num-batched-tokens`. A long prompt is split across
steps at that budget. `--no-enable-chunked-prefill` restores the old unsplit
shape (and a budget smaller than `max_model_len` is raised so a full prompt
still fits in one step).

A model with `output_tokens_per_step > 1` never takes the enabled path, even if
it also declares `supports_chunked_prefill`.

README and `docs/SCHEDULING.md` are updated; both previously said the feature was
Gemma 4 only.

## Where the alignment contract went

A resume offset must be a multiple of the model's chunked-SDPA `q_chunk_size` and
of its paged KV block size, or the op reads the wrong prefix and the K/V write
lands at a shifted page-table slice. Neither failure raises.

That correction lives entirely in the tt-metal generator
([#54435](https://github.com/tenstorrent/tt-metal/pull/54435)), which derives the
`q_chunk_size` from the model's own program config **per padded suffix length**
and floors each offset to `lcm(block_size, q_chunk_size)`. The plugin therefore
reads no alignment and rounds nothing. `max_num_batched_tokens` is
passed through, including vLLM's unset 2048/8192 defaults, which are the
split size while the feature is on.

An earlier revision of this PR required a `chunked_prefill_token_alignment` key
alongside the capability, validated it at config time, and rounded the budget and
the per-request threshold down to multiples of it. All of that is removed, for
three reasons:

1. **There is no single value to round to.** The alignment is 64 for a short
   remaining span and 256 for a long one, so no fixed budget multiple satisfies
   it.
2. **It bought nothing measurable.** The threshold caps tokens per *request*, but
   the step budget is shared, so a request admitted into what is left of a step
   still gets a ragged count and resumes ragged from then on. Measured on
   hardware, every continuation in a four-way concurrent run arrived unaligned
   with the rounding in place.
3. **It duplicated information the model already exposes**, and a declared
   constant that disagreed with the model's real program config would have been a
   silent wrong-prefix bug of exactly the kind it existed to prevent.

What survives is the log line, which is load-bearing for CI (below).

## Tests

`tests/test_chunked_prefill_policy.py` covers capability dicts: capability
absent, capability present, present with the flag off, no capability dict at
all, `disable_chunked_mm_input` left alone on the unsplit path, the threshold
zeroed for a model that cannot resume, the scheduler budget passed through
(including vLLM's unset 2048/8192), and a block-output model refused even
when it declares `supports_chunked_prefill`.

`tests/tt/test_chunked_prefill.py` runs against a live server. It skips unless
`--tt-chunked-prefill-budget=<max_num_batched_tokens>` is passed, so the
existing `pytest tests/tt` CI step collects it and moves on. Each prompt plants
a passphrase three quarters of the way into itself and is asked to repeat it; a
resume offset the model cannot honour makes it attend the wrong prefix without
raising, and a wrong answer is the only client-visible symptom.

Three cases:

- a budget-sized solo split (cheap sanity check)
- a prompt of three budgets, which exercises a resumed span that pins
  `q_chunk_size=256`
- several prompts overflowing a step's budget together, which is where a
  request is admitted into a ragged remainder

The concurrent case scored 10/20 against a too-weak alignment and 20/20 with
the correct one; the short solo case passed throughout and does not
discriminate.

**The tests cannot confirm the server has the feature on**, and passphrase recall
succeeds on an unsplit prefill, so against a server that silently disabled
chunked prefill they would pass while testing nothing. Verified: with the feature
off the suite still reports passed. There is no client-visible signal to check:
the scheduler config is absent from `/metrics`, and an intermediate chunk emits no
token so it raises no iteration stats either. The paired tt-metal CI step
therefore greps the server log for

```
Chunked prefill enabled for TT model <Class> (<module>): max_num_batched_tokens=N, long_prefill_token_threshold=M.
```

and fails unless `N` matches the budget the tests were told. The plugin logs that
line unconditionally on the enabled path so it is always greppable. A missing
`max_num_batched_tokens=` field prints both values instead of dying under
`pipefail` with no message.

`tests/tt/conftest.py` also neutralizes the host suite's autouse platform
fixture. It imports the platform at setup time, and in a `tests/tt` file that
does not import vLLM at module scope that lands while `vllm.platforms` is still
half-initialized, erroring the file's first test. Today it is masked because the
file that collects first happens to import vLLM; running one file alone, as the
new CI step does, is not.

## Test status

Host suite after rebase onto current `main`:
[unit-tests 3.10 and 3.12 passed](https://github.com/tenstorrent/vllm-tt-plugin/actions/runs/33617282456)
(`pytest tests --ignore=tests/tt`). Local T3K earlier: 343 passed.

On a T3K with Llama-3.1-8B-Instruct (pre-rebase head of this pair; the four
commits here are unchanged):

- `pytest tests/tt/test_chunked_prefill.py`: the three cases above.
- `pytest tests/tt` with the T3K leg's `-k` filter: 42 passed, 1 skipped.
  Unfiltered, 11 failed with chunked prefill on against 12 with it off, same
  families (`TestSeedingAndVariety`, `*_mixed_batch`) that #77 rewrites and the
  T3K leg already excludes.

The T3K chunked-prefill CI gate (log grep plus the three device tests) passed in
https://github.com/tenstorrent/tt-metal/actions/runs/33627798946,
job `Llama-3.1-8B-Instruct (chunked prefill) [wh_llmbox]`.

Two other reds on that matrix are not this change:

- `Qwen3-VL-32B-Instruct` structured output 0%: chunked prefill stayed off;
  same test already failed at 71.875% on the 31 Aug nightly.
- `Qwen3.6-27B (multimodal B=1)` server-ready timeout: chunked prefill stayed
  off; the wait expired during weight load, not extra warmup. The `batch=8`
  sibling passed.

## Not duplicating

`gh pr list --state open --search "chunked prefill"` on this repo returns this
PR, plus unrelated docs (#95) and stale block-table tail work (#104). #32
(DiffusionGemma block serving) has merged and was unrelated. Nothing else open
implements #74.

## AI assistance

Written with AI assistance (Claude, then Cursor Grok 4.6). Every line is to be
reviewed and defended by the human submitter.

