### PR TITLE
[test] Separate KV block size from canvas width

### DIFF
--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -34,7 +34,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm_tt_plugin.config import store_tt_output_tokens_per_step
 from vllm_tt_plugin.scheduler import TTScheduler
 
-BLOCK_SIZE = 16
+BLOCK_SIZE = 32
 CANVAS = 16
 MAX_MODEL_LEN = 256
 LOCAL_MODEL_CONFIG = Path(__file__).parent / "model_configs" / "qwen2"

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -34,7 +34,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm_tt_plugin.config import store_tt_output_tokens_per_step
 from vllm_tt_plugin.scheduler import TTScheduler
 
-BLOCK_SIZE = 32
+BLOCK_SIZE = 128
 CANVAS = 16
 MAX_MODEL_LEN = 256
 LOCAL_MODEL_CONFIG = Path(__file__).parent / "model_configs" / "qwen2"


### PR DESCRIPTION
## TL;DR
Makes the block-scheduler fixture distinguish KV cache paging granularity from both the output canvas width and the token tile size.

## Details
`BLOCK_SIZE` and `CANVAS` were both `16`, so replacing every read of `_output_tokens_per_step` with `block_size` could leave the suite green. We initially set `BLOCK_SIZE = 32`, but review correctly identified that this collided with `_TT_TOKEN_TILE_SIZE = 32`: a plausible `_TT_TOKEN_TILE_SIZE -> block_size` mutation became byte-identical in the truncation and alignment paths.

The final head uses `BLOCK_SIZE = 128`, leaving `CANVAS = 16` and `_TT_TOKEN_TILE_SIZE = 32` distinct. This catches both substitutions while remaining a valid upstream `BlockSize` literal.

## Related Artifacts

Resolves #82

## Validation

```text
PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/test_block_scheduler.py -q
33 passed in 8.19s
```

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.
