### PR TITLE
[ref] Use ttnn tile size for block-output alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,9 +532,9 @@ workflow job runs:
 PYTHONPATH=ci/host-stubs pytest tests/ --ignore=tests/tt
 ```
 
-The stub answers only the `ttnn` names the plugin touches and raises from
-anything that would reach a device, so a test that starts depending on real
-hardware fails loudly rather than passing against a fake.
+The stub answers only the device-independent `ttnn` names the plugin touches and
+raises from anything that would reach a device, so a test that starts depending
+on real hardware fails loudly rather than passing against a fake.
 
 ## Hybrid Attention Models
 

--- a/ci/host-stubs/ttnn/__init__.py
+++ b/ci/host-stubs/ttnn/__init__.py
@@ -20,11 +20,6 @@ Put this directory's parent on ``PYTHONPATH`` to use it:
 
 from enum import Enum
 
-# Hardware-fixed tile dimension used by tt-metal operator shapes. The host CI
-# only needs this constant for import-time provenance checks; device entry
-# points below continue to require real hardware.
-TILE_SIZE = 32
-
 
 def _no_device(name):
     def raise_no_device(*args, **kwargs):

--- a/ci/host-stubs/ttnn/__init__.py
+++ b/ci/host-stubs/ttnn/__init__.py
@@ -20,6 +20,11 @@ Put this directory's parent on ``PYTHONPATH`` to use it:
 
 from enum import Enum
 
+# Hardware-fixed tile dimension used by tt-metal operator shapes. The host CI
+# only needs this constant for import-time provenance checks; device entry
+# points below continue to require real hardware.
+TILE_SIZE = 32
+
 
 def _no_device(name):
     def raise_no_device(*args, **kwargs):

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -10,7 +10,6 @@ import weakref
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
-import ttnn
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 
@@ -53,12 +52,14 @@ _STANDARD_DP_VISIBLE_GROUPS_KEY = "_tt_standard_dp_visible_groups"
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"
-# tt-metal's fixed Tensix tile height. The DiffusionGemma vLLM adapter performs
-# the same tile alignment with ttnn.TILE_SIZE in
+# tt-metal's fixed Tensix tile height, matching ``ttnn.TILE_SIZE``. Keep this a
+# literal so importing admission logic cannot hard-crash hosts where tt-metal is
+# absent; tests/tt enforces the agreement with the real module. The DiffusionGemma
+# vLLM adapter performs the same tile alignment with ttnn.TILE_SIZE in
 # models/experimental/diffusion_gemma/tt/generator_vllm.py
 # (_aligned_prefill_len and _round_down_to_tile), so admission and the adapter
 # must agree on this hardware-fixed value.
-_TT_TOKEN_TILE_SIZE = ttnn.TILE_SIZE
+_TT_TOKEN_TILE_SIZE = 32
 _DIFFUSION_GEMMA_TT_ARCHITECTURES = {
     "DiffusionGemmaForBlockDiffusion": "TTDiffusionGemmaForBlockDiffusion",
     "DiffusionGemmaForCausalLM": "TTDiffusionGemmaForCausalLM",

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -10,6 +10,7 @@ import weakref
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
+import ttnn
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 
@@ -52,7 +53,12 @@ _STANDARD_DP_VISIBLE_GROUPS_KEY = "_tt_standard_dp_visible_groups"
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"
-_TT_TOKEN_TILE_SIZE = 32
+# tt-metal's fixed Tensix tile height. The DiffusionGemma vLLM adapter performs
+# the same tile alignment with ttnn.TILE_SIZE in
+# models/experimental/diffusion_gemma/tt/generator_vllm.py
+# (_aligned_prefill_len and _round_down_to_tile), so admission and the adapter
+# must agree on this hardware-fixed value.
+_TT_TOKEN_TILE_SIZE = ttnn.TILE_SIZE
 _DIFFUSION_GEMMA_TT_ARCHITECTURES = {
     "DiffusionGemmaForBlockDiffusion": "TTDiffusionGemmaForBlockDiffusion",
     "DiffusionGemmaForCausalLM": "TTDiffusionGemmaForCausalLM",

--- a/tests/tt/test_tile_size.py
+++ b/tests/tt/test_tile_size.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+import ttnn
+
+from vllm_tt_plugin.platform import _TT_TOKEN_TILE_SIZE
+
+
+def test_plugin_tile_matches_ttnn():
+    """Pin the admission constant to tt-metal's real tile dimension."""
+    assert _TT_TOKEN_TILE_SIZE == ttnn.TILE_SIZE == 32


### PR DESCRIPTION
## TL;DR
Keeps admission tile alignment on a startup-safe literal while enforcing agreement with real `ttnn.TILE_SIZE` where tt-metal is available.

## Details
Importing `ttnn` at module scope could hard-crash vLLM startup on hosts without tt-metal, so `_TT_TOKEN_TILE_SIZE` remains the literal `32`. A focused comment documents its hardware provenance and why the DiffusionGemma adapter must use the same alignment. The new `tests/tt/test_tile_size.py` runs only where `ttnn` is guaranteed and asserts `_TT_TOKEN_TILE_SIZE == ttnn.TILE_SIZE == 32`.

The host-CI stub no longer needs to fake this constant.

## Related Artifacts

Resolves #84

## Validation

```text
PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/test_block_scheduler.py tests/test_block_request_validation.py -q
102 passed in 3.35s

uv run --with ruff==0.14.0 ruff format --check src/vllm_tt_plugin/platform.py tests/tt/test_tile_size.py
2 files already formatted

uv run --with ruff==0.14.0 ruff check src/vllm_tt_plugin/platform.py tests/tt/test_tile_size.py
All checks passed!
```

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
