### PR TITLE
Gemma4: nearest-bucket decode pad and num_devices test fix

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1081,6 +1081,28 @@ class TTModelRunner:
         # the whole engine capacity.
         decode_pad_to = self.tt_per_lane_max_num_seqs
 
+        # Models that declare ``tt_supported_decode_batch_sizes`` (e.g. Gemma4)
+        # may pad only to the nearest supported size >= num_reqs, so B=1 is not
+        # forced through a B=max graph.
+        #
+        # A model must declare only the buckets it has actually captured a decode
+        # trace for on this instance: padding to a bucket with no captured trace
+        # leaves the device in an undefined state. There is deliberately no
+        # separate "warmed" list to fall back from -- a bucket that is not warmed
+        # is not supported.
+        decode_buckets = getattr(
+            getattr(self, "model", None), "tt_supported_decode_batch_sizes", None
+        )
+        if decode_buckets:
+            decode_pad_to = next(
+                (
+                    int(b)
+                    for b in sorted(int(x) for x in decode_buckets)
+                    if int(b) >= num_reqs and int(b) <= self.tt_per_lane_max_num_seqs
+                ),
+                self.tt_per_lane_max_num_seqs,
+            )
+
         # Second dim of each block table is (ceil(max_model_len / block_size)).
         # Slice/pad to ``self.max_num_blocks_per_req``: slicing handles
         # over-wide tables when the total KV-cache limit is tighter than

--- a/tests/test_num_available_blocks.py
+++ b/tests/test_num_available_blocks.py
@@ -21,6 +21,11 @@ deterministic budget source:
   yields a fixed per-model budget, isolating this function from the
   per-SKU tables that live on the model class.
 
+``num_devices`` is now an explicit parameter (added by #425, "forward-compat
+prep for newer vLLM", which did not update these tests). Each call below passes
+``cfg.device_config.num_devices`` so a test's device count stays expressed in one
+place -- the fixture default of 1, or the explicit override a test sets.
+
 Sliding-window headroom is gated per model class by the
 ``_HYBRID_KV_CACHE_GROUPS_ENABLED`` attribute, read off the resolved model
 class. ``_model_budget`` sets it explicitly on the stub class (defaulting
@@ -91,7 +96,7 @@ def test_default_branch_no_sliding(cfg):
         patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
         _fallback_arch(),
     ):
-        n = get_num_available_blocks_tt(cfg)
+        n = get_num_available_blocks_tt(cfg, cfg.device_config.num_devices)
 
     # Default branch: max_tokens_all_users = 131072, plus block_size*batch
     # padding (64*32 = 2048). num_blocks = ceil(133120 / 64) = 2080.
@@ -118,7 +123,7 @@ def test_lane_mode_kv_shape_matches_per_lane_standard_dp(cfg):
         patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
         _fallback_arch(),
     ):
-        n = get_num_available_blocks_tt(cfg)
+        n = get_num_available_blocks_tt(cfg, cfg.device_config.num_devices)
 
     # Per-lane batch is 32 // 4 = 8.
     # Default tokens (131072) + batch padding (64 * 8 = 512) = 131584 tokens
@@ -285,7 +290,7 @@ def test_sliding_window_adds_headroom(cfg):
         patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
         _model_budget(131_072, hybrid_enabled=True),
     ):
-        n = get_num_available_blocks_tt(cfg)
+        n = get_num_available_blocks_tt(cfg, cfg.device_config.num_devices)
 
     # Model budget (131072) + batch padding (64*32=2048) +
     # sliding overhead (1024 * 32 * 8 = 262144) = 395264 tokens ->
@@ -305,7 +310,7 @@ def test_n150_branch_unchanged_for_uniform_model(cfg):
         patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
         _model_budget(32768),
     ):
-        n = get_num_available_blocks_tt(cfg)
+        n = get_num_available_blocks_tt(cfg, cfg.device_config.num_devices)
 
     # Llama8B-N150 branch: 32768 + 64*32 padding = 34816 -> ceil/64 = 544.
     assert n == 544
@@ -324,7 +329,7 @@ def test_per_model_branch_with_sliding_window(cfg):
         patch("vllm_tt_plugin.worker.ttnn.get_arch_name", return_value="wormhole_b0"),
         _model_budget(65_536, hybrid_enabled=True),
     ):
-        n = get_num_available_blocks_tt(cfg)
+        n = get_num_available_blocks_tt(cfg, cfg.device_config.num_devices)
 
     # gemma-3-4b N300 branch: 65536 base + 64*32 padding + 1024*32*8 sliding
     # = 65536 + 2048 + 262144 = 329728 -> ceil/64 = 5152


### PR DESCRIPTION
## Summary

Two independent fixes, migrated from the `tenstorrent/vllm` fork branch as part of the fork → standalone-plugin move.

### 1. Pad decode to the nearest supported batch bucket

Models declaring `tt_supported_decode_batch_sizes` (Gemma4) pad decode to the smallest supported bucket `>= num_reqs` instead of always to per-lane wire capacity, so B=1 is not forced through a B=max graph.

A model must declare only buckets it has actually captured a decode trace for — padding to an uncaptured bucket leaves the device undefined. There is deliberately no separate "warmed" fallback list.

Measured, gemma-4-12B / p150x8, B=1 streaming TPOT, 5 reps:

| | median TPOT | tok/s/user |
|---|---|---|
| pad enabled | **24.67 ms** | **40.53** |
| pad disabled | 33.07 ms | 30.24 |

**+34%** B=1 decode. Confirmed engaging in a real eval run: `decode_batch=1` × 157, `decode_batch=32` × 2840.

Ported from `tenstorrent/vllm@1e2e291689` (#455). Re-implemented rather than cherry-picked — plugin `main`'s `model_runner.py` has diverged ~1360 lines and the original hunk context no longer exists. The companion commit `41643c38f2` is **not** ported: its functional content (zero-padding inactive block-table rows) is already on `main`; only comments differed.

### 2. Pass `num_devices` in `get_num_available_blocks_tt` tests

Pre-existing breakage, unrelated to Gemma4. `worker.py` calls `get_num_available_blocks_tt(vllm_config, num_devices)` but the tests passed config only — 5/88 failing with `TypeError`. The parameter was added by `aa5959d02` (#425, "forward-compat prep for newer vLLM"), which did not update the tests.

Each call site now passes `cfg.device_config.num_devices` rather than a literal, so a test's device count stays expressed in one place.

## Test plan

- [x] `pytest tests --ignore=tests/tt` — **329 passed**, matching `main`'s baseline
- [x] B=1 decode A/B above (pad on/off, same stack, server restart between arms)
- [x] gemma-4-12B `r1_gpqa_diamond`, 10 samples, p150x8 — **90**, ratio 1.142 vs reference 78.8, PASS
- [x] gemma-4-31B `r1_gpqa_diamond` ci-nightly, 40 samples, p150x8 — 80/80, PASS

## Dropped from this PR

Two commits were removed rather than rebased:

- **`e8a70ef`** "stop shadowing upstream's gemma4 parsers" — obsolete. #32 deleted the plugin's gemma4 parser modules and both registration hooks, so there is nothing left to shadow.
- **`abc9a55`** "recover gemma-4's final answer from an unterminated thought block" — dropped after review. It keyed on `Final Answer:` prose rather than the `<|channel>`/`<channel|>` protocol markers, and patched only the non-streaming path; that is answer extraction, not a parser fix. The 4/10 empty-content figure it cited did not reproduce (0/40 on 31B), and both eval runs above pass without it.