### PR TITLE
[bug] Release the model before closing the mesh in TTWorker.shutdown

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -75,6 +75,7 @@ import numpy as np
 
 logger = init_tt_logger(__name__)
 
+
 # Matches the upstream attention-layer naming convention used by registered
 # vLLM models (e.g. "model.language_model.layers.5.self_attn") as well as
 # bare "layers.5" forms used in TT spec hooks. The first capture group is
@@ -160,7 +161,7 @@ class TTModelRunner:
         self.device_config = vllm_config.device_config
         self._output_tokens_per_step = get_tt_output_tokens_per_step(vllm_config)
         self._is_block_output_model = is_tt_block_output_model(vllm_config)
-        self._persistent_capture_released = False
+        self._shutdown_complete = False
 
         if self.model_config.is_encoder_decoder:
             raise ValueError("Encoder-decoder models aren't yet supported for TT")
@@ -260,16 +261,35 @@ class TTModelRunner:
         )
 
     def shutdown(self) -> None:
-        """Deterministically release optional model-lifetime captures.
+        """Release what this runner holds on the mesh, while it is still open.
 
-        Called from ``TTWorker.shutdown`` while the mesh is still open. This
-        is intentionally not wired to ``__del__``: the runner sits in
-        reference cycles, so a destructor can fire during interpreter
-        teardown after the devices closed, where a device-side release is
-        worse than leaking the capture to process exit.
+        Called from ``TTWorker.shutdown`` because releasing a device-resident
+        object after its device closed is unsafe. Idempotent.
+
+        Explicit rather than a consequence of dropped references: the runner and
+        ``TTAsyncDecodeController`` reference each other, so refcounting never
+        reclaims either and a destructor runs whenever the cyclic collector gets
+        to it -- for interpreter teardown, after the devices closed.
+
+        Scope is the model and its caches. An in-flight async decode submission
+        is deliberately not released: its read destination and ttnn read events
+        may still be the target of a device read, and no wait for that can be
+        bounded against the close. Those leak to process exit, which is the safe
+        direction.
         """
-        if getattr(self, "_persistent_capture_released", False):
+        if getattr(self, "_shutdown_complete", False):
             return
+        self._shutdown_complete = True
+
+        # Neither ``_pending_samples`` nor ``_pending_async_steps`` is cleared: a
+        # step that ran but was not sampled sits in both, and between
+        # ``execute_model`` and ``sample_tokens`` this runner is its only holder
+        # -- the window a mid-step raise lands in -- so clearing them would free
+        # a buffer ttnn is writing into, moments before the close. The cost is
+        # that this runner is not reclaimed promptly, which is not a safety
+        # property; releasing the model below is.
+
+        # While the model is still alive, and before the mesh closes.
         release = getattr(
             getattr(self, "model", None), "release_persistent_capture", None
         )
@@ -278,7 +298,18 @@ class TTModelRunner:
                 release()
             except Exception:
                 logger.exception("Failed to release persistent model capture")
-        self._persistent_capture_released = True
+
+        self.model = None
+        self.kv_caches = []
+
+        async_decode = getattr(self, "async_decode", None)
+        if async_decode is not None:
+            # An engine-held async output keeps ``_controller``, so cut the
+            # controller's edge back to this runner: otherwise it walks into a
+            # runner whose model is gone and fails as a missing
+            # ``process_decode_output_host``.
+            async_decode.runner = None
+            self.async_decode = None
 
     @property
     def lane_batch(self) -> TTLaneInputBatch:

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -495,10 +495,31 @@ class TTWorker(WorkerBase):
         mesh left open wedges the board's ethernet cores for the *next*
         process ("Timed out while waiting for active ethernet core ... Try
         resetting the board").
+
+        Order matters: the model owns tensors, traces and captures allocated
+        *on* the mesh, so it must go before the mesh closes.
+        ``TTModelRunner.shutdown`` does that explicitly, because a plain ``del``
+        cannot establish the order -- the runner sits in reference cycles and is
+        reclaimed whenever the cyclic collector runs. ``__del__`` stays a
+        best-effort backstop and deliberately does not call it; see the note
+        there. What is not covered is in that method's scope paragraph.
         """
-        runner = getattr(self, "model_runner", None)
-        if runner is not None:
-            runner.shutdown()
+        if getattr(self, "model_runner", None) is not None:
+            try:
+                self.model_runner.shutdown()
+            except Exception:
+                # The close below must not be skipped: a mesh left open wedges
+                # the board for the next process.
+                logger.exception(
+                    "Model runner shutdown failed; closing the mesh anyway"
+                )
+            del self.model_runner
+        # init_device sets these alongside mesh_device, so clearing only
+        # mesh_device would leave two live references to a closed device.
+        self.device = None
+        device_config = getattr(self, "device_config", None)
+        if device_config is not None:
+            device_config.device = None
         mesh_device = getattr(self, "mesh_device", None)
         if mesh_device is not None:
             close_mesh_device(mesh_device, get_tt_config(self.vllm_config))
@@ -519,6 +540,10 @@ class TTWorker(WorkerBase):
 
     def __del__(self):
         # Delete model runner first in case there are model artifacts.
+        # Deliberately does NOT call ``TTModelRunner.shutdown``: from a
+        # destructor that risks raising something this ``suppress`` misses,
+        # which would skip the mesh close below.
+        #
         # Separate suppress blocks: init_device raises between opening the
         # mesh and assigning model_runner (sizing validation), and a missing
         # model_runner must not short-circuit closing the open mesh.

--- a/tests/test_block_model_runner.py
+++ b/tests/test_block_model_runner.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 
+import weakref
+from collections import deque
+from functools import partial
 from types import SimpleNamespace
 
 import numpy as np
@@ -11,6 +14,18 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 from vllm_tt_plugin.model_runner import TTModelRunner
 from vllm_tt_plugin.worker import TTWorker
+
+
+def _finish_step(runner, held, grammar=None):
+    """Stand-in for the runner-bound finishers queued in ``_pending_samples``."""
+    return held
+
+
+class _Weakrefable:
+    """Attribute bag that supports weak references, unlike SimpleNamespace."""
+
+    def __init__(self, **attrs):
+        self.__dict__.update(attrs)
 
 
 def _runner(width: int, *, num_tokens: int = 0, max_model_len: int = 32):
@@ -247,10 +262,139 @@ def test_worker_shutdown_closes_mesh_once_across_shutdown_and_del():
         side_effect=lambda mesh_device, _cfg: closed.append(mesh_device),
     ):
         worker.shutdown()
+        # Pin *when*: the first shutdown() closes the mesh itself. Deferring the
+        # close to __del__ would satisfy the counts below, but __del__ is not
+        # guaranteed to run at interpreter exit -- the mesh could stay open and
+        # wedge the board for the next process.
+        assert closed == [mesh]
+        assert worker.mesh_device is None
         worker.shutdown()
         worker.__del__()
 
     assert closed == [mesh]
+
+
+def test_worker_shutdown_releases_the_model_before_closing_the_mesh():
+    """The model owns tensors, traces and captures allocated on the mesh, so
+    they must be released before close_mesh_device -- and dropping references
+    cannot achieve that, since the runner and its async-decode controller
+    reference each other. So observe actual release with weakrefs.
+
+    Every liveness fact is sampled inside the patched close, not asserted after
+    it: "was it released" stays true once true, but "is it still alive" does
+    not, because the runner and its queued step form an isolated cycle any
+    gen-0 pass would collect. Cyclic collection is disabled across the call for
+    the same reason.
+    """
+    import gc
+    from unittest.mock import patch
+
+    at_close: dict = {}
+    order: list[str] = []
+    mesh = SimpleNamespace()
+    worker = TTWorker.__new__(TTWorker)
+    worker.mesh_device = mesh
+    worker.device = mesh
+    worker.device_config = SimpleNamespace(device=mesh)
+    worker.vllm_config = SimpleNamespace(additional_config=None)
+
+    def _attach_runner():
+        """Build the runner in a scope that leaves no strong reference."""
+        runner = TTModelRunner.__new__(TTModelRunner)
+        model = _Weakrefable(
+            release_persistent_capture=lambda: order.append("capture-released")
+        )
+        runner.model = model
+        runner.kv_caches = [SimpleNamespace()]
+        runner._shutdown_complete = False
+        # An async step that ran but was never sampled, with the ``_controller``
+        # back-edge an engine-held output really has.
+        controller = _Weakrefable(runner=runner)
+        in_flight = _Weakrefable(_controller=controller)
+        runner._pending_samples = deque([partial(_finish_step, runner, in_flight)])
+        runner.async_decode = controller
+        worker.model_runner = runner
+        return (
+            weakref.ref(model),
+            weakref.ref(runner),
+            weakref.ref(in_flight),
+            controller,
+        )
+
+    model_ref, runner_ref, in_flight_ref, controller = _attach_runner()
+
+    gc.disable()
+    try:
+        with patch(
+            "vllm_tt_plugin.worker.close_mesh_device",
+            side_effect=lambda _mesh, _cfg: (
+                order.append("mesh-closed"),
+                at_close.update(
+                    model_alive=model_ref() is not None,
+                    in_flight_alive=in_flight_ref() is not None,
+                    runner_alive=runner_ref() is not None,
+                    controller_cut=in_flight_ref()._controller.runner is None,
+                ),
+            ),
+        ):
+            worker.shutdown()
+    finally:
+        gc.enable()
+
+    assert order == ["capture-released", "mesh-closed"]
+    # The safety property: the model is gone before the close, not after.
+    assert at_close["model_alive"] is False
+    assert model_ref() is None
+    # The deliberate leak: an in-flight async read is not freed here.
+    assert at_close["in_flight_alive"] is True
+    assert at_close["runner_alive"] is True
+    # The cut: an engine-held output must not reach a runner whose model is gone.
+    assert controller.runner is None
+    assert at_close["controller_cut"] is True
+    assert not hasattr(worker, "model_runner")
+    assert worker.mesh_device is None
+    assert worker.device is None
+    assert worker.device_config.device is None
+
+
+def test_worker_shutdown_closes_the_mesh_even_if_the_runner_raises():
+    """A failing runner release must not stop the mesh from being closed."""
+    from unittest.mock import patch
+
+    closed = []
+    worker = TTWorker.__new__(TTWorker)
+    worker.mesh_device = SimpleNamespace()
+    worker.device = worker.mesh_device
+    worker.device_config = SimpleNamespace(device=worker.mesh_device)
+    worker.vllm_config = SimpleNamespace(additional_config=None)
+    worker.model_runner = SimpleNamespace(
+        shutdown=lambda: (_ for _ in ()).throw(RuntimeError("device fault"))
+    )
+
+    with patch(
+        "vllm_tt_plugin.worker.close_mesh_device",
+        side_effect=lambda mesh_device, _cfg: closed.append(mesh_device),
+    ):
+        worker.shutdown()
+
+    assert len(closed) == 1
+    assert worker.mesh_device is None
+
+
+def test_runner_shutdown_is_idempotent():
+    """Second call must not re-release the capture."""
+    releases = []
+    runner = TTModelRunner.__new__(TTModelRunner)
+    runner.model = SimpleNamespace(
+        release_persistent_capture=lambda: releases.append("released")
+    )
+
+    runner.shutdown()
+    runner.shutdown()
+
+    assert releases == ["released"]
+    assert runner.model is None
+    assert runner.kv_caches == []
 
 
 def test_worker_shutdown_releases_admission_handle(monkeypatch):
@@ -271,7 +415,6 @@ def test_worker_shutdown_releases_admission_handle(monkeypatch):
 def test_worker_wrapper_shutdown_releases_persistent_capture_once():
     releases = []
     runner = TTModelRunner.__new__(TTModelRunner)
-    runner._persistent_capture_released = False
     runner.model = SimpleNamespace(
         release_persistent_capture=lambda: releases.append("released")
     )


### PR DESCRIPTION
## TL;DR

`TTWorker.shutdown()` closed the ttnn mesh while the model's device tensors were still alive. `TTModelRunner.shutdown()` now releases them explicitly first — the capture, the model, the KV caches, and the async-decode controller's back-reference — and the worker guarantees the close happens regardless.

> **Descoped after four review rounds.** Earlier revisions also drained in-flight async decode steps, called `gc.unfreeze()/gc.collect()`, cleared the async step queues, and had `__del__` delegate here. Review established that each either could not do what its comment claimed or introduced a new teardown failure. All four are removed; the residual gap is stated below rather than half-solved. Details in the last section.

## Details

The model owns tensors, traces and persistent captures allocated **on** the mesh, so teardown must release them before the mesh closes. `__del__` encodes exactly that and says so. `shutdown()` did the reverse: `runner.shutdown()` released only the persistent capture, then `close_mesh_device` ran with the model still live, and the real release happened later in `__del__`'s `del self.model_runner` — after the close.

Reordering a `del` cannot fix it. `TTModelRunner.__init__` builds `TTAsyncDecodeController(self)` (`model_runner.py:238`) and the controller keeps `self.runner` (`async_decode.py:172`), so refcounting never reclaims either object; whatever the attribute held is freed whenever the cyclic collector next runs — for interpreter teardown, after the devices closed.

### What it does

`TTModelRunner.shutdown()` is idempotent and releases, in a documented order,
the model and its caches while the mesh is open: the model-owned capture, then
`model` and `kv_caches`, then the async-decode controller's back-reference (so
an engine-held async output cannot walk back into a runner whose model is gone).
**The method's own comments are the description** — I am deliberately not
restating them here; across thirteen review rounds the recurring defect in this
PR was a mechanism described in three places, two of which then drifted.

`TTWorker.shutdown()` keeps no local reference to the runner and wraps the
release in `try/except` — the close is the step that must not be skipped,
because a mesh left open wedges the board's ethernet cores for the next process.
It also clears `self.device` and `device_config.device`: `init_device` sets both
alongside `self.mesh_device` (`worker.py:244-245`), so clearing only the last
left two live references to a closed device.

`shutdown()` stays the hook: upstream guarantees it on orderly teardown, and
`__del__` is not guaranteed at interpreter exit. `__del__` is unchanged, with a
comment on why it must *not* call `shutdown()`.

### What it deliberately does not do

It does not release an in-flight async decode submission. Those hold the read
destination and events of a device read that may still be running, and there is
no wait available here that can also be bounded against the close. They are left
to leak to process exit — the safe direction.

An earlier revision cleared `_pending_samples`, which is the opposite of this
tradeoff: between `execute_model` and `sample_tokens` the *runner* is the sole
holder of such a submission (the engine only takes it once `sample_tokens` hands
the wrapper over), and that window is exactly where a mid-step raise lands, via
`run_engine_core`'s `finally` around `run_busy_loop` (`vllm/v1/engine/core.py:1236-1242`). An unsampled step is pinned by **both**
`_pending_samples` and `_pending_async_steps` — `register_pending_async_step`
files it in the second — and neither is cleared now, so the submission survives
to process exit. The test pins that: reintroducing the clear fails it.

The cost is that the runner itself is not reclaimed promptly. That is not a
safety property — releasing the model before the close is, and it is asserted
directly.

### Tests

The old test used a bare namespace with no model, so it could only observe that
`shutdown()` was *called*. `test_worker_shutdown_releases_the_model_before_closing_the_mesh`
reads weakrefs **inside** the patched `close_mesh_device`, asking the question
directly — was the model gone before this call — rather than inferring it from
finalizer ordering.

Every liveness fact is **sampled at that same instant** rather than asserted
later: "was it released" stays true once true, but "is it still alive" does not —
after the runner drop the runner, its `_pending_samples` deque, the partial and
the submission form an isolated cycle that any gen-0 pass would collect. Cyclic
collection is disabled across the call too, so the window itself cannot be
perturbed.

Two review rounds were needed to get this right: the first restored `gc.disable()`
(reproduced by allocating past the gen-0 threshold inside the window — unguarded
fails, guarded passes), the second pointed out that two of the leak assertions
still ran *after* `gc.enable()`, where a crossing is in fact more likely because
CPython keeps counting allocations while collection is off. Verified by forcing a
collection in exactly that spot: the sampled form passes, the assert-after-enable
form fails.

`test_worker_shutdown_closes_the_mesh_even_if_the_runner_raises` pins the close.
Full mutation matrix:

```text
baseline                                   24 passed
self.model = None removed                   2 failed
capture release skipped                     3 failed
async_decode.runner cut removed             1 failed
_pending_samples.clear() reintroduced       3 failed
worker try/except removed                   1 failed
```

(`SimpleNamespace` is not weakref-able, hence the small `_Weakrefable` helper.)

### What review removed, and why

| Removed | Why |
|---|---|
| Bounded drain thread | On expiry the daemon thread keeps doing device work while the caller closes the same mesh, and dereferences state `shutdown` just cleared (`runner.model` → the misleading `AttributeError` at `async_decode.py:603`). |
| `gc.unfreeze()` + `gc.collect()` | Its stated purpose was disproved twice, and it can run tt-metal finalizers concurrently with the close. |
| Clearing the async step queues | The opposite of harmless: it frees the read destination and unsynchronized ttnn read events of a step the runner may still be the sole holder of, moments before the close. |
| `__del__` → `shutdown()` | `Thread.start()` at interpreter shutdown raises `RuntimeError` (`PythonFinalizationError` only on 3.13+; this repo targets `>=3.10,<3.14` and validates on 3.12), which escapes the destructor's `suppress(AttributeError)` and skips `close_mesh_device` entirely — a regression. |

## Related Artifacts

Resolves #80

## Validation

Host suite on a Blackhole quiet box (`bh_quietbox_2`), tt-metal `python_env` (Python 3.12, vLLM 0.25.1):

```text
$ ruff check src tests
All checks passed!

$ PYTHONPATH=ci/host-stubs:src python -m pytest tests/ --ignore=tests/tt -q
332 passed, 16 warnings in 6.33s
```

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.
