### PR TITLE
[ref] Single-source the block-output sampling-neutralization table

### DIFF
--- a/src/vllm_tt_plugin/config.py
+++ b/src/vllm_tt_plugin/config.py
@@ -102,6 +102,56 @@ def is_tt_block_output_model(vllm_config: "VllmConfig") -> bool:
     return get_tt_output_tokens_per_step(vllm_config) > 1
 
 
+# ``SamplingParams`` fields that can force a step onto host sampling, and the
+# value that does not. Host sampling yields one token where a canvas is needed,
+# so ``_get_output_tokens`` raises and takes EngineCore with it.
+#
+# Mirrored from ``check_perform_device_sampling``; add a request-driven branch
+# there and you must add its field here. Pinned behaviorally, not by a second
+# list -- see ``tests/test_lane_input_batch.py``.
+BLOCK_HOST_SAMPLING_FORCERS: tuple[tuple[str, Any], ...] = (
+    ("min_p", 0.0),
+    ("min_tokens", 0),
+    ("logit_bias", None),
+    ("allowed_token_ids", None),
+    ("bad_words", None),
+    ("_bad_words_token_ids", None),
+    # Forces host sampling on any device count outside {8, 32} -- P150x4
+    # included -- and ``logprobs=0`` (OpenAI ``logprobs: true``) is enough. The
+    # worker-side ``disable_logprobs`` sentinel already blocks it; this entry is
+    # the second layer, so the table mirrors the predicate rather than depending
+    # on that sentinel.
+    ("logprobs", None),
+)
+
+# Response-shape controls a block-output model cannot honor. Kept out of
+# ``BLOCK_HOST_SAMPLING_FORCERS`` so that table stays an exact mirror of the
+# predicate.
+BLOCK_UNSUPPORTED_RESPONSE_CONTROLS: tuple[tuple[str, Any], ...] = (
+    ("prompt_logprobs", None),
+)
+
+# Penalties neither force host sampling nor change generation -- the model owns
+# its sampler and drops what it is handed. The cost is host waste: a non-neutral
+# value flips ``InputBatch.no_penalties``, and every block decode step then
+# rebuilds the prompt and output token-history tensors in
+# ``_prepare_model_inputs``, the output one growing with the session. The
+# frontend neutralizes them; mirror it here.
+BLOCK_PENALTY_NEUTRAL: tuple[tuple[str, Any], ...] = (
+    ("presence_penalty", 0.0),
+    ("frequency_penalty", 0.0),
+    ("repetition_penalty", 1.0),
+)
+
+# What TTScheduler applies to a request that reached the engine without frontend
+# validation.
+BLOCK_UNVALIDATED_SAMPLING_NEUTRAL: tuple[tuple[str, Any], ...] = (
+    BLOCK_HOST_SAMPLING_FORCERS
+    + BLOCK_PENALTY_NEUTRAL
+    + BLOCK_UNSUPPORTED_RESPONSE_CONTROLS
+)
+
+
 def store_tt_output_tokens_per_step(
     vllm_config: "VllmConfig", output_tokens_per_step: int
 ) -> None:

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1826,6 +1826,13 @@ class TTModelRunner:
         finish = self._pending_samples.popleft()
         return finish(grammar_output)
 
+    # Request-driven branches below decide host vs device sampling. A
+    # block-output model that lands on host sampling gets one token where the
+    # canvas contract needs ``_output_tokens_per_step``, so ``_get_output_tokens``
+    # raises. Two layers keep it away: the ``InputBatch`` is built with
+    # ``disable_logprobs`` for block models, and ``TTScheduler`` neutralizes
+    # ``config.BLOCK_HOST_SAMPLING_FORCERS`` on unvalidated requests -- extend
+    # that table when adding a request-driven branch here.
     def check_perform_device_sampling(
         self, is_decode: bool, has_structured_outputs: bool
     ) -> bool:
@@ -1867,6 +1874,8 @@ class TTModelRunner:
         # host sampling to compute full top-N from logits.
         max_lp = input_batch.max_num_logprobs
         if max_lp is not None:
+            # A *requested* count is enough, including the 0 that OpenAI's
+            # ``logprobs: true`` produces.
             if num_devices not in (8, 32):
                 return False
             if max_lp > 0 and not self.supports_topk_logprobs:

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1999,32 +1999,3 @@ class TTPlatform(Platform):
                 "This block-output model owns its Gumbel sampling and does not "
                 "support these request parameters: " + "; ".join(unsupported)
             )
-
-    @staticmethod
-    def compat_sampling_required(sampling_params, num_devices) -> bool:
-        # Device logprobs only supported on multi-device setups and only
-        # the sampled token's logprob is returned (not top-k alternatives).
-        # Single device: any logprobs require host sampling.
-        # Multi-device: logprobs > 1 requires host sampling because device
-        # can only return the sampled token's logprob.
-        # https://github.com/tenstorrent/tt-metal/issues/34077
-        if (
-            sampling_params.logprobs is not None
-            and sampling_params.logprobs > 0
-            and (num_devices == 1 or sampling_params.logprobs > 1)
-        ):
-            return True
-
-        # all of the following sampling params require compat sampling
-        return (
-            sampling_params.min_p != 0.0
-            or (
-                sampling_params.bad_words is not None
-                and len(sampling_params.bad_words) > 0
-            )
-            or sampling_params.prompt_logprobs is not None
-            or sampling_params.structured_outputs is not None
-            or sampling_params.logit_bias is not None
-            or sampling_params.allowed_token_ids is not None
-            or sampling_params.min_tokens != 0
-        )

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -12,6 +12,7 @@ from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request, RequestStatus
 
 from vllm_tt_plugin.config import (
+    BLOCK_UNVALIDATED_SAMPLING_NEUTRAL,
     get_tt_output_tokens_per_step,
     is_tt_block_output_model,
 )
@@ -102,26 +103,6 @@ class TTScheduler(AsyncScheduler):
 
     def set_forced_mode(self, mode: TTSchedulingMode) -> None:
         self._forced_mode = mode
-
-    # Host-only sampling controls and their neutral values: any of these
-    # forces the step onto host sampling (check_perform_device_sampling),
-    # which cannot construct a multi-token canvas and kills the engine.
-    # Penalties do not force host sampling, but a non-neutral value flips
-    # InputBatch.no_penalties and makes every block decode step build (and
-    # discard) penalty token tensors that grow with the committed session
-    # length; the frontend neutralizes them, so mirror that here for
-    # prebuilt requests that bypassed it.
-    _BLOCK_HOST_ONLY_SAMPLING_NEUTRAL = (
-        ("min_p", 0.0),
-        ("min_tokens", 0),
-        ("logit_bias", None),
-        ("allowed_token_ids", None),
-        ("bad_words", None),
-        ("_bad_words_token_ids", None),
-        ("presence_penalty", 0.0),
-        ("frequency_penalty", 0.0),
-        ("repetition_penalty", 1.0),
-    )
 
     def add_request(self, request: Request) -> None:
         if self._is_block_output_model:
@@ -281,15 +262,20 @@ class TTScheduler(AsyncScheduler):
 
     def _neutralize_block_output_host_sampling(self, request: Request) -> None:
         """Strip controls a block-output model cannot honor from a bypassed
-        request: host-sampling forcers, structured outputs, and resumable
-        streaming-input sessions.
+        request: structured outputs, resumable streaming-input sessions, and
+        the three sampling groups in
+        ``config.BLOCK_UNVALIDATED_SAMPLING_NEUTRAL`` -- host-sampling forcers,
+        penalties, and unsupported response controls. The consequence differs
+        per group; each config table says which.
 
-        Frontend validation rejects these; a prebuilt EngineCoreRequest skips
-        it, and any of them flips the step to host sampling mid-flight (which
-        cannot construct a multi-token canvas) or parks the request forever.
-        Raising here is no safer: an add_request exception also tears down
-        EngineCore, so neutralize instead, the way the sampling controls are
-        neutralized at the frontend.
+        A prebuilt EngineCoreRequest skips the frontend, which rejects the
+        response-contract controls outright and neutralizes the model-owned
+        sampling controls on the clone. Raising here is no safer than repairing:
+        an add_request exception also tears down EngineCore, so neutralize.
+
+        The field list lives in ``config.BLOCK_UNVALIDATED_SAMPLING_NEUTRAL``
+        so it can be pinned against the live predicate,
+        ``TTModelRunner.check_perform_device_sampling``.
         """
         params = request.sampling_params
         if params is None:
@@ -311,7 +297,7 @@ class TTScheduler(AsyncScheduler):
             # model-owned state slot. The frontend rejects it for block models.
             request.resumable = False
             stripped.append("resumable")
-        for field, neutral in self._BLOCK_HOST_ONLY_SAMPLING_NEUTRAL:
+        for field, neutral in BLOCK_UNVALIDATED_SAMPLING_NEUTRAL:
             if getattr(params, field, neutral) not in (neutral, [], {}):
                 setattr(params, field, neutral)
                 stripped.append(field.lstrip("_"))

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -226,9 +226,9 @@ def test_add_request_clamps_max_tokens_that_would_overshoot_max_model_len():
 
 
 def test_add_request_strips_host_sampling_controls_from_bypassed_request():
-    """A prebuilt EngineCoreRequest skips frontend validation; any of these
-    controls flips the step onto host sampling, which cannot construct a
-    multi-token canvas and would kill the engine."""
+    """A prebuilt EngineCoreRequest skips frontend validation. The consequence
+    differs by group -- see the three tables in ``config`` -- so this pins only
+    that every field is reset, not that each one is fatal."""
     scheduler = _scheduler()
     init_none_hash(sha256)
     params = SamplingParams(
@@ -242,6 +242,10 @@ def test_add_request_strips_host_sampling_controls_from_bypassed_request():
         presence_penalty=0.5,
         frequency_penalty=0.5,
         repetition_penalty=1.1,
+        # OpenAI ``logprobs: true`` arrives as logprobs=0, which is enough to
+        # force host sampling on every device count outside {8, 32}.
+        logprobs=0,
+        prompt_logprobs=1,
         structured_outputs=StructuredOutputsParams(json_object=True),
     )
     params.update_from_generation_config({}, eos_token_id=2)
@@ -270,8 +274,11 @@ def test_add_request_strips_host_sampling_controls_from_bypassed_request():
     assert params.allowed_token_ids is None
     assert params.bad_words is None
     assert params._bad_words_token_ids is None
-    # Non-neutral penalties make every block step build session-length
-    # penalty tensors it then discards.
+    assert params.logprobs is None
+    assert params.prompt_logprobs is None
+    # Non-neutral penalties do not change block output -- the model discards
+    # them -- but they flip no_penalties and make every step rebuild
+    # session-length token tensors. See config.BLOCK_PENALTY_NEUTRAL.
     assert params.presence_penalty == 0.0
     assert params.frequency_penalty == 0.0
     assert params.repetition_penalty == 1.0

--- a/tests/test_lane_input_batch.py
+++ b/tests/test_lane_input_batch.py
@@ -756,3 +756,139 @@ def test_runner_is_lane_mode_property():
     assert not _runner_with(data_parallel_size=1, tt_data_parallel_size=1)._is_lane_mode
     # Standard multi-process DP: each rank is its own engine -> plain InputBatch.
     assert not _runner_with(data_parallel_size=4, tt_data_parallel_size=4)._is_lane_mode
+
+
+# --------------------------------------------------------------------------
+# The device-sampling predicate, driven on a real batch
+# --------------------------------------------------------------------------
+
+
+def _predicate_holder(batch, *, num_devices: int, supports_topk_logprobs=False):
+    """A runner stand-in whose input_batch is a *real* one; the predicate is
+    called unbound, since everything else it reads is scalar config."""
+    return SimpleNamespace(
+        sample_on_device_mode="all",
+        num_devices=num_devices,
+        tt_data_parallel_size=1,
+        supports_topk_logprobs=supports_topk_logprobs,
+        model_config=SimpleNamespace(logits_processors=None),
+        input_batch=batch,
+    )
+
+
+@pytest.mark.parametrize("num_devices", [4, 8], ids=["p150x4", "logprobs-capable"])
+def test_requested_logprobs_force_host_sampling_off_capable_meshes(num_devices):
+    """Autoregressive path, for the record: a *requested* count is enough,
+    including the 0 that OpenAI ``logprobs: true`` produces, and four devices
+    is not one of the meshes that can sample logprobs on device.
+
+    Block-output models never reach this branch -- their batch is built with
+    ``disable_logprobs``, see the guard tests above -- which is why
+    neutralizing ``logprobs`` in TTScheduler is defence in depth rather than
+    the fix for a live crash.
+    """
+    from vllm_tt_plugin.model_runner import TTModelRunner
+
+    batch = _plain_batch_of_one(
+        _make_req("ar", [1], [], dict(temperature=0.0, logprobs=0)),
+        with_custom=False,
+        disable_logprobs=False,
+    )
+    runner = _predicate_holder(batch, num_devices=num_devices)
+
+    assert batch.max_num_logprobs == 0
+    performs_device_sampling = TTModelRunner.check_perform_device_sampling(
+        runner, is_decode=True, has_structured_outputs=False
+    )
+
+    assert performs_device_sampling is (num_devices == 8)
+
+
+def test_repaired_bypassed_request_satisfies_the_device_sampling_predicate():
+    """The behavioral pin for the neutralization table: a request carrying every
+    field in it must, once TTScheduler has repaired it, satisfy the real
+    predicate on a real block ``InputBatch`` -- and must not before.
+
+    Run against both batch shapes: the production one is built with
+    ``disable_logprobs=True``, whose sentinel hides ``logprobs`` from the
+    predicate, so the second pass drops that guard to exercise it.
+
+    Not pinned here: ``bad_words``, ``prompt_logprobs`` and the penalties. The
+    predicate reads none of them (for bad words it sees only the tokenized
+    ``_bad_words_token_ids``), so their reset is covered by
+    ``test_add_request_strips_host_sampling_controls_from_bypassed_request``
+    alone. Nor is a new predicate branch whose field is absent from the table --
+    see the note next to ``check_perform_device_sampling``.
+    """
+    from vllm_tt_plugin.config import BLOCK_UNVALIDATED_SAMPLING_NEUTRAL
+    from vllm_tt_plugin.model_runner import TTModelRunner
+    from vllm_tt_plugin.scheduler import TTScheduler
+
+    non_neutral = {
+        "min_p": 0.2,
+        "min_tokens": 1,
+        "logit_bias": {2: 1.0},
+        "allowed_token_ids": [1, 2],
+        "bad_words": ["bad"],
+        "logprobs": 0,
+        "prompt_logprobs": 1,
+        "presence_penalty": 0.5,
+        "frequency_penalty": 0.5,
+        "repetition_penalty": 1.1,
+    }
+    # The batch reads the tokenized form; seed it by hand.
+    private_non_neutral = {"_bad_words_token_ids": [[7]]}
+
+    # Every table field must be exercised.
+    covered = set(non_neutral) | set(private_non_neutral)
+    table_fields = {field for field, _ in BLOCK_UNVALIDATED_SAMPLING_NEUTRAL}
+    assert table_fields == covered, (
+        f"update this test's non-neutral values for {sorted(table_fields ^ covered)}"
+    )
+
+    # NOT temperature=0.0: SamplingParams squashes min_p for a greedy request,
+    # which would leave these assertions passing with min_p out of the table.
+    params = SamplingParams(temperature=1.0, **non_neutral)
+    for field, value in private_non_neutral.items():
+        setattr(params, field, value)
+    # Every value must survive construction, or the field stops being covered.
+    for field, value in non_neutral.items():
+        assert getattr(params, field) == value, (
+            f"SamplingParams neutralized {field} at construction; this test "
+            "would not exercise it"
+        )
+    request = SimpleNamespace(
+        request_id="bypassed",
+        sampling_params=params,
+        structured_output_request=None,
+        resumable=False,
+    )
+
+    def _predicate(disable_logprobs=True):
+        req = _make_req("bypassed", [1], [], dict(temperature=1.0))
+        req.sampling_params = params
+        batch = _plain_batch_of_one(
+            req,
+            # No custom logitsproc: _predicate_holder reports
+            # model_config.logits_processors=None, and a batch with one active
+            # is a state a real block-output runner cannot be in.
+            with_custom=False,
+            disable_logprobs=disable_logprobs,
+            output_tokens_per_step=16,
+        )
+        return TTModelRunner.check_perform_device_sampling(
+            _predicate_holder(batch, num_devices=4),
+            is_decode=True,
+            has_structured_outputs=False,
+        )
+
+    # The production block batch, and the same block batch with the
+    # disable_logprobs sentinel off so the logprobs branch is visible: both
+    # must reject before the repair and accept after.
+    assert _predicate(disable_logprobs=True) is False
+    assert _predicate(disable_logprobs=False) is False
+
+    TTScheduler._neutralize_block_output_host_sampling(SimpleNamespace(), request)
+
+    assert _predicate(disable_logprobs=True) is True
+    assert _predicate(disable_logprobs=False) is True


### PR DESCRIPTION
## TL;DR

`logprobs` was missing from the scheduler's neutralization table. It is **not** a live crash — the worker-side `disable_logprobs` guard already prevents it — so this is defence in depth. The substance is single-sourcing the table, deleting a dead and *differently wrong* fifth copy of the predicate, and replacing a list-versus-list drift test with a behavioral one that drives the real predicate.

> **Revised after review.** The first version claimed a fatal path and pinned it with a hand-built `SimpleNamespace` that bypassed the real code, plus a drift test that compared two hand-written lists. Both criticisms were correct; corrected below.

## Details

### What is actually true

`check_perform_device_sampling` falls back to host sampling whenever a logprob count is requested and the per-rank device count is outside `{8, 32}` — and the documented DiffusionGemma mesh is `MESH_DEVICE=P150x4`, four devices. A *requested* count is enough, including the `0` that OpenAI's `logprobs: true` produces, because the branch tests `max_lp is not None`.

### Why that is not a live crash

The worker-side guard runs first, and covers both `InputBatch` flavors unconditionally for block models:

```python
# model_runner.py:388, :400
disable_logprobs=self._is_block_output_model
# input_batch.py:421
if self.disable_logprobs:
    self.sampling.num_logprobs[req_index] = LOGPROBS_NONE_SENTINEL
```

so `max_num_logprobs` reports `None` and the predicate never sees a count. That is already covered by `test_worker_guard_neutralizes_logprobs_for_block_output` and `test_lane_batch_forwards_the_logprobs_guard`.

What the scheduler entry buys instead:

**Defence in depth**, and nothing more than that. This layer should not depend on the sentinel staying where it is, and the table should mirror the predicate so the two can be audited against each other — that is the whole justification.

> An earlier revision of this PR also claimed neutralizing here fixes a client-visible response shape (an empty logprobs array on a real completion). It does not, and review caught it: `LogprobsProcessor.from_new_request` snapshots `sampling_params.num_logprobs` into a plain int in the **frontend**, before `engine_core.add_request` (`v1/engine/llm_engine.py:274-276`, `async_llm.py:409-412`), and under multiprocess deployment the frontend holds a separately serialized `SamplingParams` anyway. A mutation inside EngineCore cannot reach it. Claim withdrawn from the code comments and from here.

### The dead fifth copy

The predicate was written out in four places across three modules in two vocabularies, plus `TTPlatform.compat_sampling_required` — **no callers anywhere** in the plugin or in vLLM 0.25.1, and a *different* logprobs rule:

```python
sampling_params.logprobs is not None and sampling_params.logprobs > 0
    and (num_devices == 1 or sampling_params.logprobs > 1)
```

It is the copy a maintainer extending the table would reach for, because it is the shape-compatible one, and copying it reproduces exactly this omission for `logprobs=0` and for four-device meshes. Deleted.

### Single source, split by consequence

The table moves to `config.py`, which every consumer already imports:

- `BLOCK_HOST_SAMPLING_FORCERS` — the mirror of the predicate. Every entry has a corresponding branch, so the two can be audited against each other.
- `BLOCK_PENALTY_NEUTRAL` — never fatal, and it does not change generation either. The cost is host waste that grows with the session: a non-neutral value flips `no_penalties`, and from then on every block decode step rebuilds the prompt and output token-history tensors in `_prepare_model_inputs` (`[rows, max_prompt_len]` and `[rows, max_output_len]`, only the second growing as generation does) — against a `max_model_len` of 262144 for the documented DiffusionGemma config — which are passed to the model and dropped there.

  > This rationale flipped twice, and the second flip was mine to own. In an earlier revision I replaced "built and discarded" with "they silently take effect", on the strength of `async_decode.py:521-524` passing `prompt_tokens`/`output_tokens` into `decode_forward`. I verified the call site and not the consumer. DiffusionGemma — the only model declaring `output_tokens_per_step > 1` — opens both `decode_forward` and `prefill_forward` with `del sampling_params` and never references `**kwargs` again, so the penalties cannot take effect. The original rationale was right, and it agreed with `platform.py:668-674` and `docs/diffusion-gemma.md:88-92`, which I had left contradicting my own new text. Restored.
- `BLOCK_UNSUPPORTED_RESPONSE_CONTROLS` — `prompt_logprobs`, which is neither. Review pointed out that an earlier revision put it in the forcers table under a comment saying it is *not* a forcer, which defeats the split: an entry there with no matching branch makes the next audit either delete it or distrust the header.
- `BLOCK_UNVALIDATED_SAMPLING_NEUTRAL` — the union, which is what the scheduler applies.

Conflating the fatal and the wasteful sets under one "host only" name is what let the fatal list read as complete when it was not.

### The drift pin is behavioral now

A list-versus-list assertion passes when a predicate branch is added and neither list is updated, which is fair criticism of the first version. Removed, along with the `HOST_SAMPLING_TRIGGER_FIELDS` frozenset it compared against — one hand-written list is better than two that agree with each other.

In its place, `test_repaired_bypassed_request_satisfies_the_device_sampling_predicate` builds a request carrying every field in the table, repairs it through the real `TTScheduler` method, adds it to a **real block `InputBatch`** (`disable_logprobs=True`, `output_tokens_per_step=16`), and asserts the **real** `check_perform_device_sampling` returns `False` before and `True` after. The request's fields are derived from the table, so a new entry extends the test; an entry with no value in the test fails a coverage assertion.

It runs against **both** batch shapes, which review showed is necessary. A block batch is the production one, but it is built with `disable_logprobs=True`, and that sentinel hides `logprobs` from the predicate entirely — so on that batch alone the two fields this table *gained* were invisible, and the assertions held with their neutralization removed. The second pass drops the guard so the logprobs branch is actually exercised. Verified by making the neutralization skip `logprobs` with the table intact: the test fails now, and did not before.

Also corrected in the code comments: the failure a host-sampling fallback produces is the explicit guard in `_get_output_tokens` ("Block-output step fell back to host sampling"), which raises before any sampling — not `_coerce_output_block`, which that guard means is never reached on this path.

`test_requested_logprobs_force_host_sampling_off_capable_meshes` is also rewritten to use a real non-block `InputBatch` — where the logprobs branch genuinely is the live path — instead of the stand-in that bypassed it.

## Related Artifacts

Resolves #81

## Validation

Host suite on a Blackhole quiet box (`bh_quietbox_2`), tt-metal `python_env` (Python 3.12, vLLM 0.25.1):

```text
$ ruff check src tests
All checks passed!

$ PYTHONPATH=ci/host-stubs:src python -m pytest tests/ --ignore=tests/tt -q
332 passed, 16 warnings in 6.34s
```

Both halves of the new pin confirmed to fail when broken:

```text
# A) neutralization skips min_p, table intact -> the behavioral half catches it
FAILED test_repaired_bypassed_request_satisfies_the_device_sampling_predicate

# B) add a table entry the test has no value for -> the coverage half catches it
AssertionError: update this test's non-neutral values for ['seed']
```

Experiment A is the one review made possible: the earlier revision built the request with `temperature=0.0`, and `SamplingParams` squashes `min_p` to 0.0 for a greedy request, so `min_p` was never actually exercised — removing its neutralization changed nothing, and the "drop min_p from the table" check I originally reported was really only tripping the coverage assertion. The test now builds with `temperature=1.0` and asserts every value survived construction.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.
