### PR TITLE
[doc] Correct the Gemma4 registration story and the stale constraint lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,18 @@ At startup the backend logs that it is running single-process lane-DP.
 ## Supported Model Families
 
 The plugin registers TT-prefixed model architectures backed by tt-metal model
-implementations. Current families:
+implementations. A checkpoint declares its own (bare) architecture name;
+`check_and_update_config` prepends `TT` before the registry lookup, which is
+why the names below are the registered ones rather than the ones in a
+`config.json`. The rewrite selects the class the model loader instantiates; it
+does not undo what `ModelConfig` already derived from the bare name upstream
+(architecture metadata, multimodal config, runner and convert types).
+
+DiffusionGemma is the exception in both directions: the plugin registers the
+bare `DiffusionGemmaForCausalLM`, and deliberately does *not* register the bare
+`DiffusionGemmaForBlockDiffusion`, because vLLM 0.25.1 owns that name and the
+plugin rewrites the architecture before registry lookup instead. Current
+families:
 
 - Llama 3.1 / 3.2 / 3.3 text models (`TTLlamaForCausalLM`)
 - Llama 3.2 vision models (`TTMllamaForConditionalGeneration`)
@@ -419,7 +430,10 @@ implementations. Current families:
   `TTGemma4ForConditionalGeneration`,
   `TTGemma4UnifiedForConditionalGeneration`)
 - DiffusionGemma block-output models (`TTDiffusionGemmaForBlockDiffusion`,
-  `TTDiffusionGemmaForCausalLM`)
+  `TTDiffusionGemmaForCausalLM`). A checkpoint's `config.json` declares the
+  bare `DiffusionGemmaForBlockDiffusion` or `DiffusionGemmaForCausalLM`; the
+  names here are what the rewrite above turns those into, so match your
+  checkpoint against the bare names.
 - DeepSeek V3 (`TTDeepseekV3ForCausalLM`)
 - GPT-OSS 20B / 120B (`TTGptOssForCausalLM`)
 
@@ -461,6 +475,9 @@ clear error before anything reaches the device:
 - Where chunked prefill is active, multimodal inputs are never split across a
   chunk boundary.
 - Prompt logprobs are rejected at request validation time.
+- `prompt_embeds` inputs are rejected at request validation time, for
+  every TT model. (Block-output models additionally reject
+  streaming-input sessions; see the DiffusionGemma document.)
 - Prefix caching is enabled only for models that declare TT support for it.
 - Async decode overlap is enabled only for models that declare the capability.
 - Multi-host MPI data parallelism is not supported.

--- a/docs/diffusion-gemma.md
+++ b/docs/diffusion-gemma.md
@@ -76,10 +76,20 @@ bucket has no servable execution shape and the failure is engine-fatal.
 
 Current support is synchronous, DP=1, one active sequence, on-device sampling
 for all model calls, and no scheduler chunked prefill; vLLM automatic prefix
-caching is disabled by the platform. Async scheduling, host sampling, custom
-logits processors, and non-uniproc executors are rejected at launch;
-`prompt_embeds` inputs and streaming-input (resumable) sessions are rejected
-per request; other unsupported per-request controls are listed below.
+caching is disabled by the platform.
+
+Rejected at launch: async scheduling, host sampling, custom logits processors,
+non-uniproc executors, an explicit `--diffusion-config` (the platform derives
+the canvas contract from the model's own capability declaration, so an operator
+copying a launch line from upstream DiffusionGemma documentation must drop that
+flag), and `VLLM_USE_RUST_FRONTEND=1` (that frontend runs HTTP outside Python
+and never calls TT request validation, so nothing would reject the requests
+listed below before they reach the engine).
+
+Rejected per request: streaming-input (resumable) sessions, for block-output
+models only. `prompt_embeds` inputs are rejected too, but that one is
+platform-wide -- every TT model refuses them, not just this one. Other
+unsupported per-request controls are listed below.
 
 HTTP sampling controls are accepted for OpenAI-client compatibility but ignored:
 

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1120,35 +1120,22 @@ def register_tt_models(register_test_models=False) -> None:
 
     # Gemma4 — text-only TT bridge.
     #
-    # Gemma4 isn't in vLLM's upstream registry, so without an entry here
-    # the upstream architecture resolver falls back to
-    # ``TransformersMultiModalForCausalLM`` (because ``hf_config !=
-    # hf_text_config`` for Gemma4's nested config — see
-    # ``ModelConfig._get_transformers_backend_cls``) and crashes on the
-    # ``_processor_factory`` assertion in the multimodal registry. The
-    # plugin's later ``TT``-prefix logic runs after that resolution, so
-    # it can't help.
+    # Only the ``TT``-prefixed aliases. Do not add the bare HF names: vLLM
+    # 0.25.1 registers all three itself and ``_register_model_if_missing``
+    # never overrides an existing entry, so those calls are no-ops.
     #
-    # We register the plain HF arch names directly so upstream resolution
-    # finds our class. Since ``Gemma4ForCausalLM`` (the TT class) does not
-    # use ``SupportsMultiModal``, vLLM's ``_model_info.supports_multimodal``
-    # is False, ``multimodal_config`` is not populated, and the request
-    # path stays text-only — which matches what the TT model implements.
-    # The ``TT``-prefixed aliases satisfy the plugin's later validation
-    # in ``check_and_update_config`` so no override is needed.
-    #
-    # The 12B checkpoint is the "unified" multimodal variant: its config
-    # declares ``architectures: ['Gemma4UnifiedForConditionalGeneration']``
-    # with ``model_type: gemma4_unified`` and nested text/vision/audio
-    # configs. Without the unified arch registered, the same nested-config
-    # fallback resolves it to ``TransformersMultiModalForCausalLM``. We map
-    # the unified arch (and its ``TT`` alias) to the same text-only TT class
-    # so text-only inference runs on the unified checkpoint.
+    # The prefix rewrite in ``check_and_update_config`` decides which class the
+    # loader instantiates, and nothing more. ``ModelConfig.__post_init__`` has
+    # already inspected the *bare* architecture by then, and for
+    # ``Gemma4ForConditionalGeneration`` and
+    # ``Gemma4UnifiedForConditionalGeneration`` that resolves to upstream's
+    # multimodal class -- so ``multimodal_config``, ``runner_type`` and
+    # ``convert_type`` are upstream's, and upstream's ``Gemma4Config`` hook has
+    # run against the TT config. Do not read the prefix as isolating Gemma4
+    # from upstream's Gemma4 handling; closing that would mean generalizing
+    # ``_install_diffusion_gemma_architecture_patch`` beyond one family.
     _gemma4_target = "models.demos.gemma4.tt.generator_vllm:Gemma4ForCausalLM"
     for arch in (
-        "Gemma4ForCausalLM",
-        "Gemma4ForConditionalGeneration",
-        "Gemma4UnifiedForConditionalGeneration",
         "TTGemma4ForCausalLM",
         "TTGemma4ForConditionalGeneration",
         "TTGemma4UnifiedForConditionalGeneration",

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -326,9 +326,17 @@ class TTWorker(WorkerBase):
         # to the architectures list. As a result the cached property still
         # holds the upstream (e.g. CUDA) name, and resolving it would find
         # upstream's vLLM model class — which doesn't have our
-        # ``get_kv_cache_spec`` hook. Prefer the prefixed entry from the
-        # ``architectures`` list (which the platform modifies in-place) and
-        # fall back to prepending ``"TT"`` when neither is available.
+        # ``get_kv_cache_spec`` hook.
+        #
+        # ``ModelConfig.architectures`` is a pydantic snapshot taken in
+        # ``__post_init__``, so it does not see ``check_and_update_config``
+        # rewriting ``hf_config.architectures`` in place afterwards. The
+        # ``next(...)`` therefore only matches a checkpoint that was already
+        # TT-prefixed when ``ModelConfig`` was built (DiffusionGemma via the
+        # ``get_config`` patch; the ``vllm_test_utils`` dummies and TT-named
+        # ``EXTRA_MODELS_DIR`` bundles natively). For a bare HF name the
+        # ``"TT" + architecture`` fallback is what resolves the class, so do not
+        # drop it as redundant.
         arch = next(
             (a for a in self.model_config.architectures if a.startswith("TT")),
             None,

--- a/tests/test_diffusion_gemma_registration.py
+++ b/tests/test_diffusion_gemma_registration.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -8,6 +9,11 @@ import vllm.config  # noqa: F401  # finish vLLM init before the plugin package,
 
 # whose bare import re-enters vllm.platforms mid-initialization
 import vllm_tt_plugin.platform as tt_platform
+
+# Captured at import, before any test can monkeypatch it away: worker.py runs
+# the real registration at module scope during collection, so this is the value
+# that actually decided what got registered.
+_EXTRA_MODELS_DIR_AT_IMPORT = os.environ.get("EXTRA_MODELS_DIR")
 
 
 def test_diffusion_gemma_uses_tt_architecture_before_upstream_config_hooks(
@@ -155,3 +161,110 @@ def test_gemma4_parsers_are_owned_by_upstream_vllm():
         ReasoningParserManager.get_reasoning_parser("diffusion_gemma")
     with pytest.raises(KeyError):
         ToolParserManager.get_tool_parser("diffusion_gemma")
+
+
+def test_gemma4_bare_architectures_are_owned_by_upstream_vllm(monkeypatch):
+    """vLLM 0.25.1 registers all three Gemma4 architectures itself, and
+    ``_register_model_if_missing`` never overrides an existing entry, so
+    registering the bare names was a no-op that read as the opposite. The TT
+    class is reached through the ``TT``-prefix rewrite instead.
+
+    Also pins the upstream ownership the comment now claims: if a future vLLM
+    drops these, the assertion below fails and the registration story has to be
+    revisited rather than silently regressing to a fallback resolution.
+    """
+    from vllm.model_executor.models.registry import ModelRegistry
+
+    # worker.py runs the real registration at module import, so it has already
+    # happened once under the shell's environment by collection time. Clear the
+    # gates and re-invoke, so anything not already registered is deterministic:
+    # TT_VLLM_BUILTIN_MODELS=0 returns before the Gemma4 aliases, and a
+    # TT_*_VER gate raises on a value it does not recognize.
+    for var in ["TT_VLLM_BUILTIN_MODELS"] + [
+        k for k in os.environ if k.startswith("TT_") and k.endswith("_VER")
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    # EXTRA_MODELS_DIR cannot be undone here: the first registration wins, so a
+    # bundle that claimed a TT Gemma4 name during collection already owns it.
+    if _EXTRA_MODELS_DIR_AT_IMPORT:
+        pytest.skip(
+            "EXTRA_MODELS_DIR was set at collection time, so the TT rows may be "
+            "bundle-owned and this test cannot attribute them"
+        )
+
+    tt_platform.register_tt_models()
+    registry = ModelRegistry.models
+    supported = ModelRegistry.get_supported_archs()
+
+    # Positive identity per arch, not "is not the TT bridge" -- a
+    # transformers-backend fallback would satisfy that too. Coupled to upstream
+    # layout on purpose: if these move, platform.py's comment needs rechecking.
+    for bare, module in (
+        ("Gemma4ForCausalLM", "gemma4"),
+        ("Gemma4ForConditionalGeneration", "gemma4_mm"),
+        ("Gemma4UnifiedForConditionalGeneration", "gemma4_unified"),
+    ):
+        assert bare in supported, (
+            f"{bare} is expected to be an upstream vLLM registration"
+        )
+        # Exact, not substring: "...models.gemma4" is a prefix of gemma4_mm,
+        # gemma4_unified and gemma4_mtp.
+        assert registry[bare].module_name == f"vllm.model_executor.models.{module}", (
+            f"{bare} no longer resolves to upstream's {module}: {registry[bare]!r}"
+        )
+
+    # The rewritten names are the ones the plugin owns.
+    for tt_arch in (
+        "TTGemma4ForCausalLM",
+        "TTGemma4ForConditionalGeneration",
+        "TTGemma4UnifiedForConditionalGeneration",
+    ):
+        assert tt_arch in supported, (
+            f"{tt_arch} was not registered; the builtin model map did not run"
+        )
+        # Exact, for the same reason as the upstream rows above.
+        assert registry[tt_arch].module_name == "models.demos.gemma4.tt.generator_vllm"
+        assert registry[tt_arch].class_name == "Gemma4ForCausalLM"
+
+
+def test_gemma4_conditional_archs_are_multimodal_upstream():
+    """Pins what the ``TT`` prefix does *not* buy, which the old comment got
+    wrong: ``ModelConfig`` inspects the bare architecture and caches its model
+    info before ``check_and_update_config`` -- the hook that does the rewrite --
+    so for two of the three names the cached info is upstream's multimodal class
+    and ``multimodal_config`` is already built. (The DiffusionGemma
+    ``get_config`` patch pre-empts this because it is installed earlier still,
+    on import of the ``vllm.general_plugins`` entry point, rather than from a
+    config hook.) The prefix only selects the class the loader instantiates.
+    """
+    from vllm.model_executor.models.registry import ModelRegistry
+
+    expected = {
+        "Gemma4ForCausalLM": False,
+        "Gemma4ForConditionalGeneration": True,
+        "Gemma4UnifiedForConditionalGeneration": True,
+    }
+    # Single-arch inspection: the public entry point wants a ModelConfig, and
+    # building one would load a checkpoint.
+    #
+    # It imports the class, so the multimodal archs need the full processor
+    # dependency set (torchvision). Registration is asserted either way -- that
+    # is import-free -- and the multimodal flag is skipped rather than failed
+    # where those deps are absent, as on the host-only CI job. The registration
+    # test above pins the same claim import-free, via module identity.
+    supported = ModelRegistry.get_supported_archs()
+    actual = {}
+    for arch in expected:
+        assert arch in supported, (
+            f"{arch} is expected to be an upstream vLLM registration"
+        )
+        info = ModelRegistry._try_inspect_model_cls(arch)
+        if info is None:
+            pytest.skip(
+                f"upstream inspection of {arch} could not import it; this "
+                "environment lacks the multimodal processor dependencies"
+            )
+        actual[arch] = info.supports_multimodal
+
+    assert actual == expected


### PR DESCRIPTION
## TL;DR

The Gemma4 registration block claimed those architectures are absent from vLLM's registry and registered them on that basis. In 0.25.1 all three are upstream, so the calls were no-ops and the comment argued the opposite of the (correct) DiffusionGemma block below it. Drop the dead calls, state accurately what the `TT` prefix does and does not decide, and fix three stale documentation claims.

## Details

### Registration

`_register_model_if_missing` never overrides an existing registration, and vLLM 0.25.1 registers `Gemma4ForCausalLM`, `Gemma4ForConditionalGeneration` and `Gemma4UnifiedForConditionalGeneration` itself — verified against the installed wheel with `VLLM_PLUGINS=""` so the plugin's own registrations cannot mask an upstream absence. The three bare-name calls were therefore silent no-ops; the TT class is reached through the `TT`-prefix rewrite in `check_and_update_config`.

The comment mattered more than the dead code: it sits directly above the DiffusionGemma block, which states the opposite reasoning and is right.

### What the `TT` prefix actually buys

Narrower than the old comment implied. The rewrite decides which class the model loader instantiates. It does not touch what `ModelConfig.__post_init__` already derived from the *bare* architecture, and two of the three names are multimodal upstream (`Gemma4ForConditionalGeneration` → `gemma4_mm`, `Gemma4UnifiedForConditionalGeneration` → `gemma4_unified`, which subclasses it):

```text
Gemma4ForCausalLM                       supports_multimodal=False
Gemma4ForConditionalGeneration          supports_multimodal=True
Gemma4UnifiedForConditionalGeneration   supports_multimodal=True
```

So for a Conditional or Unified checkpoint `multimodal_config` is already built before the rewrite happens, `runner_type` and `convert_type` are upstream's, and upstream's `Gemma4Config` hook has already run against the TT config — all three names are in `MODELS_CONFIG_MAP`, and `VllmConfig.__post_init__` dispatches through it well before `check_and_update_config`.

That early-config exposure stays open. It is the same problem `_install_diffusion_gemma_architecture_patch` solves for one family; closing it for Gemma4 means generalizing that patch off a table of claimed architecture names, which is its own change.

### Documentation

- `validate_request` rejects `prompt_embeds` for **every** TT model — the check precedes the block-output early return (`platform.py:1963` vs `:1968`). README's constraint list had only the sibling prompt-logprobs bullet, and the sole mention of `prompt_embeds` sat inside a DiffusionGemma paragraph, implying a block-only restriction.
- The DiffusionGemma launch-reject list omitted an explicit `--diffusion-config` (a real vLLM 0.25.1 flag, so an operator copying an upstream launch line gets a startup failure with no doc entry) and `VLLM_USE_RUST_FRONTEND=1`.
- README listed only the post-rewrite `TT`-prefixed DiffusionGemma names, so an operator matching a real checkpoint's `config.json` against the supported list found no match for either name it declares.

## Related Artifacts

Resolves #88

Related to #89 — the dead calls and the wrong comment are fixed here; the Gemma4 early-config exposure the corrected comment documents is not.

## Validation

Host suite on a Blackhole quiet box, tt-metal `python_env` (Python 3.12, vLLM 0.25.1):

```text
$ ruff check src tests && ruff format --check src tests    # pinned 0.14.0
All checks passed! / 54 files already formatted

$ PYTHONPATH=ci/host-stubs:src python -m pytest tests/ --ignore=tests/tt -q
331 passed
```

Two new tests. `test_gemma4_bare_architectures_are_owned_by_upstream_vllm` asserts positive per-arch module identity (exact `module_name`, not a substring — `…models.gemma4` is a prefix of `gemma4_mm`, `gemma4_unified` and `gemma4_mtp`) and clears `TT_VLLM_BUILTIN_MODELS` / `TT_*_VER` first, since `vllm_tt_plugin.worker` runs the real registration at module import. `test_gemma4_conditional_archs_are_multimodal_upstream` pins the table above; it asserts registration unconditionally and skips the multimodal flag where the environment cannot import the multimodal processors, as on the host-only CI job.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
