### PR TITLE
[deps] Update to vLLM 0.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ vLLM requires Python `>=3.10,<3.14`. Python 3.10.12 is the default `python3` on
 Ubuntu 22.04.
 
 The installation script builds vLLM `0.26.0` from source with
-`VLLM_TARGET_DEVICE=empty`. Other vLLM versions are not tested.
+`VLLM_TARGET_DEVICE=empty`.
 
-To install against vLLM `0.24.0` instead, check out the `compat/vllm-0.24.0`
-tag, the last plugin state that targets it, and follow the same steps. Nothing
-is maintained on top of that tag. Pair it with the tt-metal commit the LLMs
-table lists for it.
+To install against older supported vLLM versions `X.Y.Z` instead (e.g., `0.25.1`),
+check out the `compat/vllm-X.Y.Z` tag (e.g., `compat/vllm-0.25.1`), the last plugin state
+that targets it, and follow the same steps. Nothing is maintained on top of that tag for now.
+Pair it with the tt-metal commit the LLMs table lists for it.
 
 ## Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ here. Nothing TT-specific needs to touch vLLM core.
 |   +-- model_runner.py      # TT model execution bridge
 |   +-- scheduler.py         # TT scheduling policy
 |   +-- lane_scheduler.py    # Single-process multi-lane (lane-DP) coordinator
-|   +-- launcher.py          # retained tt-run / MPI launcher (not hooked by vLLM 0.25.1)
+|   +-- launcher.py          # retained tt-run / MPI launcher (not hooked by vLLM 0.26.0)
 |   +-- loader.py            # TT model loader
 |   +-- input_batch.py       # TT input-batch representation
 |   +-- async_decode.py      # Decode overlap helpers
@@ -44,7 +44,7 @@ for the appropriate tt-metal and vLLM commits.
 vLLM requires Python `>=3.10,<3.14`. Python 3.10.12 is the default `python3` on
 Ubuntu 22.04.
 
-The installation script builds vLLM `0.25.1` from source with
+The installation script builds vLLM `0.26.0` from source with
 `VLLM_TARGET_DEVICE=empty`. Other vLLM versions are not tested.
 
 To install against vLLM `0.24.0` instead, check out the `compat/vllm-0.24.0`

--- a/docs/diffusion-gemma.md
+++ b/docs/diffusion-gemma.md
@@ -16,7 +16,7 @@ canvases and trims the final canvas to the request's logical `max_tokens`.
 
 Follow [Environment Setup in the main README](../README.md#environment-setup):
 activate the tt-metal environment, then run `source docs/install-vllm-tt.sh`
-to install the pinned vLLM 0.25.1 build and this plugin.
+to install the pinned vLLM 0.26.0 build and this plugin.
 
 ## Launch
 
@@ -48,7 +48,7 @@ python -m vllm.entrypoints.openai.api_server \
 ```
 
 DiffusionGemma uses the `gemma4` reasoning and tool parsers shipped by vLLM
-0.25.1. The plugin does not override or alias upstream parser names. For tool
+0.26.0. The plugin does not override or alias upstream parser names. For tool
 calling add `--enable-auto-tool-choice --tool-call-parser gemma4`.
 
 `--max-num-batched-tokens` concerns scheduler prompt admission. It does not

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -13,7 +13,7 @@
 # not stay behind in the image layer.
 VLLM_COMMON_REQUIREMENTS=$(mktemp)
 curl -fsSL \
-    https://raw.githubusercontent.com/vllm-project/vllm/v0.25.1/requirements/common.txt \
+    https://raw.githubusercontent.com/vllm-project/vllm/v0.26.0/requirements/common.txt \
     -o "$VLLM_COMMON_REQUIREMENTS" ||
     # `return`, not `exit`: this script is sourced into the caller's shell.
     { echo "install-vllm-tt: cannot fetch vLLM common.txt"; return 1; }
@@ -23,5 +23,5 @@ rm -f "$VLLM_COMMON_REQUIREMENTS"
 # --no-binary vllm: the published wheel is the CUDA build, kernels included, so
 # vLLM has to come from source. vLLM ends up declaring no torch dependency, which
 # is intended; torch belongs to the tt-metal env this plugin runs inside.
-VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary vllm vllm==0.25.1
+VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary vllm vllm==0.26.0
 uv pip install -e .

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import torch
 from vllm.sampling_params import SamplingType
+from vllm.utils.math_utils import cdiv
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors
 from vllm.v1.sample.logits_processor import (
     BatchUpdateBuilder,
@@ -241,12 +242,14 @@ class InputBatch:
         # Block table.
         self.block_table = MultiGroupBlockTable(
             max_num_reqs=max_num_reqs,
-            max_model_len=max_model_len,
             max_num_batched_tokens=max_num_batched_tokens,
             pin_memory=False,
             device="cpu",
             block_sizes=block_sizes,
             kernel_block_sizes=kernel_block_sizes,
+            # Per-group max blocks per request; TT runs without context
+            # parallelism (cp_world_size == 1).
+            max_num_blocks=[cdiv(max_model_len, bs) for bs in block_sizes],
         )
 
         self.req_output_token_ids: list[list[int] | None] = []

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -657,7 +657,7 @@ def test_engine_level_reset_aborts_running_block_requests():
     )
     assert scheduler.running == []
     assert request.status == RequestStatus.FINISHED_ABORTED
-    assert sent == [[("req-0", 0)]]
+    assert sent == [[request]]
 
 
 def test_engine_reset_patch_requires_resolved_output_width():


### PR DESCRIPTION
## TL;DR

Builds the plugin against **vLLM 0.26.0** (from 0.25.1).

## Details

**Code**
- `src/vllm_tt_plugin/input_batch.py` — 0.26.0's `MultiGroupBlockTable.__init__` drops `max_model_len` and makes `max_num_blocks` required (adds optional `slot_mapping_modes`). Pass the per-group block budget explicitly (`max_num_blocks=[cdiv(max_model_len, bs) for bs in block_sizes]`, + `cdiv` import). TT runs `cp_world_size == 1` and 0.26.0 still applies the internal 128-alignment, so behavior is unchanged.
- `tests/test_block_scheduler.py` — 0.26.0 changes `finish_requests` to return `list[Request]` (was `list[tuple[str, int]]`). The engine-reset abort path forwards this list unchanged (upstream's `_send_abort_outputs` now also expects `list[Request]`); the stale assertion is updated to match.

**Version bump**
- `docs/install-vllm-tt.sh` — pinned source build + `requirements/common.txt` URL → `v0.26.0`.
- `README.md`, `docs/diffusion-gemma.md` — version references.

## Related Artifacts

Resolves #64 

## Validation

- Built `vllm 0.26.0+empty` from source; **329/329** host-only tests pass (`pytest tests/ --ignore=tests/tt`).
- Actions [passing](https://github.com/tenstorrent/tt-metal/actions/runs/32199971504).

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
