### PR TITLE
[ci,doc] Add tools to automate vLLM-version comparison & adaptation.

### DIFF
--- a/.github/prompts/vllm-upgrade-assessment.prompt.md
+++ b/.github/prompts/vllm-upgrade-assessment.prompt.md
@@ -1,0 +1,134 @@
+---
+name: "vLLM Upgrade Compatibility Assessment"
+description: "Assess (and optionally apply) the changes needed to move vllm-tt-plugin to a new upstream vLLM version. Diffs the plugin's vLLM coupling surface between the installed baseline and a target tag, classifies breakage by severity, and produces an issue-ready findings report plus a change plan. Use when a new vLLM release lands or when bumping the pinned version."
+argument-hint: "Target vLLM tag, e.g. v0.28.0 (optional; defaults to the latest upstream release)"
+agent: agent
+---
+
+# vLLM upgrade compatibility assessment
+
+## Usage
+
+Point an agent at this file with the target version — only TARGET is needed
+(BASELINE = the currently installed vLLM):
+
+```
+Follow .github/prompts/vllm-upgrade-assessment.prompt.md; assess this plugin against vLLM v0.28.0.
+```
+
+In Copilot for VS Code this file is also slash-invocable as `/vllm-upgrade-assessment`.
+
+Determine, and if asked apply, the plugin changes required to target a new upstream
+vLLM version. The plugin binds vLLM's **internal v1 APIs**, so every minor bump can
+break it — assess the actual source, never infer from release notes (those are a PR
+index, not truth). Investigate read-only first; edit only once the plan is clear.
+
+- **TARGET** — the vLLM tag to move to (e.g. `v0.28.0`); default = latest upstream release.
+- **BASELINE** — the vLLM version the plugin currently targets (the installed one).
+
+If tt-buddy skills are available, use `tt:learn`/`tt:note` and subagents as accelerants;
+otherwise the phases below stand alone.
+
+## Phase 0 — Pin the environment
+- Activate the tt-metal venv, then resolve the installed checkout (the only authority):
+  `python -c "import importlib.util as u; print(u.find_spec('vllm_tt_plugin').origin)"`.
+  Confirm it is the tree you intend to assess.
+- Record BASELINE: `python -c "import vllm; print(vllm.__version__)"` and the installed
+  source dir (`.../site-packages/vllm/`). Confirm `import ttnn` works.
+
+## Phase 1 — Map the coupling surface (the breakage surface)
+Re-derive from the plugin source every time — it evolves. Use the greps below and the
+**Known surface** snapshot as a starting checklist; durable, hard-to-re-derive nuances live
+in **Gotchas** at the end.
+- Imports: `grep -rhnE "^\s*(from|import)\s+vllm" src/`
+- vLLM subclasses: `grep -rnE "^class [A-Za-z_]+\(" src/` (note which extend vLLM bases).
+- Constructed vLLM dataclasses: grep for `ModelRunnerOutput(`, `SchedulerOutput(`,
+  `SamplingMetadata(`, `CachedRequestState(`, `LogprobsTensors(`, `EngineCoreOutputs(`,
+  `KVCacheConfig`, `MultiGroupBlockTable(`, etc.
+- Monkeypatch / override sites: read `platform.py` (patches live here), `entrypoints.py`,
+  `scheduler.py`, `lane_scheduler.py`, `worker.py`, `model_runner.py`, `input_batch.py`,
+  `launcher.py`.
+
+Known surface (verify against current source):
+- **Subclassed bases** — `TTPlatform(Platform)`, `TTModelLoader(BaseModelLoader)`,
+  `TTScheduler(AsyncScheduler)`, `TTLaneCoordinator(SchedulerInterface)`,
+  `TTWorker(WorkerBase)`, the plugin's own `InputBatch` + `TTLaneInputBatch`,
+  `Deferred/AsyncTTModelRunnerOutput(AsyncModelRunnerOutput)`, and
+  `TT*Launcher/Plan(CoreEngineLauncher/EngineLaunchPlan)`.
+- **Constructed dataclasses** — `ModelRunnerOutput`, `SchedulerOutput`, `SamplingMetadata`,
+  `CachedRequestState`, `LogprobsTensors`, `KVCacheConfig`/specs, `EngineCoreOutputs`,
+  `GrammarOutput`, `SchedulerStats`, and the `MultiGroupBlockTable(...)` call.
+- **Monkeypatch targets (in `platform.py`)** — `vllm.config.model.get_config`,
+  `vllm.tokenizers.registry.cached_tokenizer_from_config`,
+  `InputProcessor.process_inputs`, `AsyncLLM._add_streaming_input_request`,
+  `EngineCore.reset_prefix_cache`, `EngineCore`/`EngineCoreProc.pause_scheduler`.
+- **Helpers** — `vllm.utils.{torch_utils,system_utils,network_utils,math_utils,import_utils,argparse_utils}`
+  and `vllm.utils.length_from_prompt_token_ids_or_embeds`.
+
+The snapshot above is the surface *as last observed* — a concrete instance of a general
+pattern, not a current guarantee. Follow the general pattern regardless: re-derive the four
+categories (subclassed bases, constructed dataclasses, monkeypatch targets, imported
+helpers) from source and treat that as authoritative. If a coupling was added or removed,
+the greps catch it and this list will not — update the snapshot when they diverge.
+
+## Phase 2 — Diff the coupled files (BASELINE vs TARGET)
+- BASELINE side = installed source (exact, local): read `.../site-packages/vllm/<path>`.
+- TARGET side = upstream at the tag: fetch `vllm/<path>` at `refs/tags/<TARGET>` via your
+  GitHub file tool, or `https://raw.githubusercontent.com/vllm-project/vllm/<TARGET>/<path>`.
+  No shell `curl`/`gh`/`git` clone needed.
+- Also diff `requirements/common.txt` (BASELINE tag vs TARGET tag) for dependency changes
+  and any impact on `docs/vllm-overrides.txt`.
+- When subagents are available, parallelize by subsystem — worker/platform,
+  scheduler/lane, runner/outputs/sampling, config/loader/kv-cache,
+  entrypoints/monkeypatch/utils — handing each the exact symbols + plugin `file:line` anchors.
+
+## Phase 3 — Classify each delta
+For every coupled symbol: **CHANGE** (what differs) → **PLUGIN IMPACT** (`file:line`) → **SEVERITY**:
+- `BREAKING-IMPORT` — symbol moved / renamed / removed.
+- `BREAKING-CONSTRUCT` — dataclass gained a required field, or a field was removed/reordered.
+- `BREAKING-OVERRIDE` — a subclassed base's method signature changed, or a new abstract method appeared.
+- `BREAKING-PATCH (silent)` — a monkeypatch target moved / renamed / changed signature.
+- `BEHAVIORAL` — still runs, but semantics changed.
+- `NONE`.
+
+Prioritize: new required `__init__` params or abstract methods on subclassed bases;
+dataclass field changes; moved/renamed/removed imported symbols; monkeypatch target
+existence and signature. `MultiGroupBlockTable.__init__` and the scheduler's stale-token
+handling have churned across bumps — check them every time.
+
+## Phase 4 — Synthesize the change plan
+- Required code edits (each with `file:line` + the concrete change).
+- Version-pin bumps: `docs/install-vllm-tt.sh` (the `requirements/common.txt` URL and the
+  `vllm==<ver>` pin), `README.md`, `docs/diffusion-gemma.md`.
+- Low / conditional watch items (behavioral deltas, new optional fields, new default methods).
+
+## Phase 5 — Validate (only when applying)
+- Static: `uvx ruff@<pyproject pin> check` and `ruff format --check` on changed files;
+  pre-commit runs the same hooks on commit.
+- Build TARGET: bump `docs/install-vllm-tt.sh`, then (tt-metal venv active)
+  `source docs/install-vllm-tt.sh` — rebuilds vLLM's `empty` target and reinstalls the
+  plugin. Re-verify the import origin and `vllm.__version__`.
+- Host-only tests: `python -m pytest tests/ --ignore=tests/tt`. Add device/server tests
+  (`tests/tt`, needs a running server) only when the change touches device behavior.
+
+## Phase 6 — Record & ship
+- Findings → the tracking issue: a concise summary + concise per-version diffs, **no
+  proposed solutions**.
+- Change → a PR per `.github/pull_request_template.md`, title prefixed `[deps]`.
+- Branch / version model: `main` follows the latest supported vLLM; each still-supported
+  line lives on `release/vX.Y`; cherry-pick version-agnostic TT fixes across lines; tag
+  releases (e.g. `vX.Y.Z-tt.N`).
+
+## Gotchas (learned)
+- Release-notes highlights are GPU/model/kernel noise; only v1 internal API churn matters here.
+- Confirm which plugin form you are assessing — the checked-out working tree may not be the
+  branch that targets the version in question.
+- The plugin reimplements its own `InputBatch` (it does not subclass vLLM's), so vLLM's
+  `gpu_input_batch.InputBatch` churn is decoupled — but shared types it imports
+  (`CachedRequestState`) and the `MultiGroupBlockTable` call are not.
+- Monkeypatches live in `platform.py` (not `entrypoints.py`, which only wires the plugin
+  entry points) — grep there for the exact patched `module.attr` targets and the signatures
+  they assume.
+- The tt-run / MPI launcher is dormant: upstream `CoreEngineLauncher` / `EngineLaunchPlan`
+  are absent, so `launcher.py` runs its `ImportError` fallback and stays unhooked. Re-check
+  each bump whether they appeared upstream.

--- a/.github/prompts/vllm-upgrade-assessment.prompt.md
+++ b/.github/prompts/vllm-upgrade-assessment.prompt.md
@@ -35,8 +35,8 @@ otherwise the phases below stand alone.
   `python -c "import importlib.util as u; print(u.find_spec('vllm_tt_plugin').origin)"`.
   Confirm it is the tree you intend to assess.
 - Derive BASELINE from the repo, not the environment: the pin in `docs/install-vllm-tt.sh`
-  — `grep -oE 'vllm==[0-9]+\.[0-9]+\.[0-9]+' docs/install-vllm-tt.sh`. That is the version
-  the checkout targets.
+  — `sed -nE 's/.*vllm==([^[:space:]]+).*/\1/p' docs/install-vllm-tt.sh` (capture the full
+  version token, including any `.postN`/`rcN` suffix). That is the version the checkout targets.
 - Gate on installed == pin: `python -c "import vllm; print(vllm.__version__)"` (ignore any
   `+empty`/local suffix). On a **mismatch** the environment has drifted and the installed
   tree is the wrong baseline — never diff against it, and never auto-rebuild the venv (that

--- a/.github/prompts/vllm-upgrade-assessment.prompt.md
+++ b/.github/prompts/vllm-upgrade-assessment.prompt.md
@@ -24,7 +24,8 @@ break it — assess the actual source, never infer from release notes (those are
 index, not truth). Investigate read-only first; edit only once the plan is clear.
 
 - **TARGET** — the vLLM tag to move to (e.g. `v0.28.0`); default = latest upstream release.
-- **BASELINE** — the vLLM version the plugin currently targets (the installed one).
+- **BASELINE** — the vLLM version the checkout targets: the pin in
+  `docs/install-vllm-tt.sh`, not merely whatever happens to be installed.
 
 If tt-buddy skills are available, use `tt:learn`/`tt:note` and subagents as accelerants;
 otherwise the phases below stand alone.
@@ -33,14 +34,27 @@ otherwise the phases below stand alone.
 - Activate the tt-metal venv, then resolve the installed checkout (the only authority):
   `python -c "import importlib.util as u; print(u.find_spec('vllm_tt_plugin').origin)"`.
   Confirm it is the tree you intend to assess.
-- Record BASELINE: `python -c "import vllm; print(vllm.__version__)"` and the installed
-  source dir (`.../site-packages/vllm/`). Confirm `import ttnn` works.
+- Derive BASELINE from the repo, not the environment: the pin in `docs/install-vllm-tt.sh`
+  — `grep -oE 'vllm==[0-9]+\.[0-9]+\.[0-9]+' docs/install-vllm-tt.sh`. That is the version
+  the checkout targets.
+- Gate on installed == pin: `python -c "import vllm; print(vllm.__version__)"` (ignore any
+  `+empty`/local suffix). On a **mismatch** the environment has drifted and the installed
+  tree is the wrong baseline — never diff against it, and never auto-rebuild the venv (that
+  mutates the environment and belongs to Phase 5 / explicit consent). Instead:
+  - Report all three versions: installed, pin, TARGET.
+  - **Interactive:** ask the user which is the intended baseline — the repo pin (the usual
+    answer) or the installed version — and proceed only on their answer.
+  - **Unattended** (no one to answer, e.g. an agent picking up the tracking issue):
+    **hard-stop.** Do no assessment; post a blocking note stating the drift (installed vs
+    pin vs TARGET) and that a human must reconcile it (rebuild the pin, or confirm intent)
+    before the assessment can run.
+- Confirm `import ttnn` works; note the installed source dir (`.../site-packages/vllm/`).
 
 ## Phase 1 — Map the coupling surface (the breakage surface)
 Re-derive from the plugin source every time — it evolves. Use the greps below and the
 **Known surface** snapshot as a starting checklist; durable, hard-to-re-derive nuances live
 in **Gotchas** at the end.
-- Imports: `grep -rhnE "^\s*(from|import)\s+vllm" src/`
+- Imports: `grep -rnE "^\s*(from|import)\s+vllm" src/`
 - vLLM subclasses: `grep -rnE "^class [A-Za-z_]+\(" src/` (note which extend vLLM bases).
 - Constructed vLLM dataclasses: grep for `ModelRunnerOutput(`, `SchedulerOutput(`,
   `SamplingMetadata(`, `CachedRequestState(`, `LogprobsTensors(`, `EngineCoreOutputs(`,
@@ -72,7 +86,10 @@ helpers) from source and treat that as authoritative. If a coupling was added or
 the greps catch it and this list will not — update the snapshot when they diverge.
 
 ## Phase 2 — Diff the coupled files (BASELINE vs TARGET)
-- BASELINE side = installed source (exact, local): read `.../site-packages/vllm/<path>`.
+- BASELINE side = the pinned baseline source (per the Phase 0 gate). When installed == pin,
+  read the exact local tree `.../site-packages/vllm/<path>` — fastest and byte-exact.
+  Otherwise read the pinned tag `refs/tags/v<pin>` the same way as TARGET below; never diff
+  against a drifted installed version.
 - TARGET side = upstream at the tag: fetch `vllm/<path>` at `refs/tags/<TARGET>` via your
   GitHub file tool, or `https://raw.githubusercontent.com/vllm-project/vllm/<TARGET>/<path>`.
   No shell `curl`/`gh`/`git` clone needed.
@@ -103,8 +120,8 @@ handling have churned across bumps — check them every time.
 - Low / conditional watch items (behavioral deltas, new optional fields, new default methods).
 
 ## Phase 5 — Validate (only when applying)
-- Static: `uvx ruff@<pyproject pin> check` and `ruff format --check` on changed files;
-  pre-commit runs the same hooks on commit.
+- Static: `uvx ruff@<pyproject pin> check` and `uvx ruff@<pyproject pin> format --check`
+  on changed files (the commit/CI pre-commit job runs these plus the other hooks).
 - Build TARGET: bump `docs/install-vllm-tt.sh`, then (tt-metal venv active)
   `source docs/install-vllm-tt.sh` — rebuilds vLLM's `empty` target and reinstalls the
   plugin. Re-verify the import origin and `vllm.__version__`.

--- a/.github/workflows/vllm-release-watch.yml
+++ b/.github/workflows/vllm-release-watch.yml
@@ -1,0 +1,105 @@
+name: vLLM release watch
+
+# Opens a tracking issue when upstream vLLM publishes a release newer than the
+# version this plugin pins in docs/install-vllm-tt.sh, so the compatibility
+# assessment (.github/prompts/vllm-upgrade-assessment.prompt.md) can be run.
+#
+# It runs on the default branch, so the pin it compares against is whatever that
+# branch currently targets. Adjust the schedule to taste.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays, 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve pinned vs latest vLLM
+        id: ver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Source of truth for what the plugin currently targets.
+          pinned=$(grep -oE 'vllm==[0-9]+\.[0-9]+\.[0-9]+' docs/install-vllm-tt.sh | head -1 | cut -d '=' -f3)
+          # Latest stable upstream release (prereleases are excluded by the API).
+          latest=$(gh api repos/vllm-project/vllm/releases/latest --jq .tag_name | sed 's/^v//')
+          if [ -z "$pinned" ] || [ -z "$latest" ]; then
+            echo "could not resolve versions (pinned='$pinned' latest='$latest')" >&2
+            exit 1
+          fi
+          # newer := latest is strictly greater than pinned by version sort.
+          if [ "$pinned" != "$latest" ] && \
+             [ "$(printf '%s\n%s\n' "$pinned" "$latest" | sort -V | tail -1)" = "$latest" ]; then
+            newer=true
+          else
+            newer=false
+          fi
+          {
+            echo "pinned=$pinned"
+            echo "latest=$latest"
+            echo "newer=$newer"
+          } >> "$GITHUB_OUTPUT"
+          echo "pinned=$pinned latest=$latest newer=$newer"
+
+      - name: Open assessment issue
+        if: steps.ver.outputs.newer == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST: ${{ steps.ver.outputs.latest }}
+          PINNED: ${{ steps.ver.outputs.pinned }}
+        run: |
+          set -euo pipefail
+          title="vLLM v${LATEST} compatibility assessment"
+          # Dedup: skip when an open issue already names this version.
+          count=$(gh issue list --state open --search "vLLM v${LATEST} in:title" --json number --jq 'length')
+          if [ "${count:-0}" -gt 0 ]; then
+            echo "issue already open for v${LATEST}; nothing to do."
+            exit 0
+          fi
+          # Auto-fill the one section CI can compute without analysis: the
+          # requirements/common.txt delta between the two tags.
+          raw=https://raw.githubusercontent.com/vllm-project/vllm
+          base=$(mktemp); tgt=$(mktemp)
+          if curl -fsSL "$raw/v${PINNED}/requirements/common.txt" -o "$base" \
+             && curl -fsSL "$raw/v${LATEST}/requirements/common.txt" -o "$tgt"; then
+            deps_delta=$(diff "$base" "$tgt" | sed -n 's/^< /- /p; s/^> /+ /p') || true
+            [ -n "$deps_delta" ] || deps_delta="No changes to requirements/common.txt."
+          else
+            deps_delta="(could not fetch requirements/common.txt for one or both tags)"
+          fi
+          rm -f "$base" "$tgt"
+
+          # Seed the issue in the #64 shape; the assessing agent fills the
+          # placeholders per the playbook's Phase 6. printf format strings are
+          # single-quoted so backticks/`$` stay literal; only %s is substituted.
+          body=$(mktemp)
+          {
+            printf 'Upstream vLLM **v%s** is available; the plugin pins **%s** (`docs/install-vllm-tt.sh`).\n\n' "$LATEST" "$PINNED"
+            printf 'Run `.github/prompts/vllm-upgrade-assessment.prompt.md` (TARGET = `v%s`, BASELINE = `%s`) and edit this issue with the findings — a concise summary plus concise per-version diffs, no proposed solutions.\n\n' "$LATEST" "$PINNED"
+            printf '## Summary\n_(to be completed by the assessment)_\n\n'
+            printf '## Diffs relevant to the plugin (%s → %s)\n' "$PINNED" "$LATEST"
+            printf '**Breaking** — _(to be completed)_\n\n'
+            printf '**Behavioral** — _(to be completed)_\n\n'
+            printf '**Unchanged / byte-identical** — _(to be completed)_\n\n'
+            printf '## Dependencies (`requirements/common.txt`, %s → %s)\n' "$PINNED" "$LATEST"
+            printf '```diff\n%s\n```\n\n' "$deps_delta"
+            printf '## Method\nDiffed the installed baseline against the upstream tag, per coupled symbol.\n\n'
+            printf '_Opened automatically by `.github/workflows/vllm-release-watch.yml`._\n'
+          } > "$body"
+
+          gh issue create --title "$title" --body-file "$body" \
+            --label "type:compatibility" --label "type:dependencies"
+          rm -f "$body"
+          # To hand the assessment off automatically, assign the issue to the
+          # Copilot coding agent (requires the coding agent enabled for the repo):
+          # add `--assignee "@copilot"` above, or a follow-up `gh issue edit`.
+          # Left off by default so a human triages first.

--- a/.github/workflows/vllm-release-watch.yml
+++ b/.github/workflows/vllm-release-watch.yml
@@ -12,6 +12,12 @@ on:
     - cron: "0 6 * * 1"   # Mondays, 06:00 UTC
   workflow_dispatch: {}
 
+# Serialize runs so an overlapping schedule + manual dispatch can't both pass the
+# dedup check and double-create. cancel-in-progress: false queues rather than kills.
+concurrency:
+  group: vllm-release-watch
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -28,8 +34,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Source of truth for what the plugin currently targets.
-          pinned=$(grep -oE 'vllm==[0-9]+\.[0-9]+\.[0-9]+' docs/install-vllm-tt.sh | head -1 | cut -d '=' -f3)
+          # Source of truth for what the plugin currently targets. Capture the full
+          # version token (not just X.Y.Z) so a .postN / rcN suffix is preserved.
+          pinned=$(sed -nE 's/.*vllm==([^[:space:]]+).*/\1/p' docs/install-vllm-tt.sh | head -1)
           # Latest stable upstream release (prereleases are excluded by the API).
           latest=$(gh api repos/vllm-project/vllm/releases/latest --jq .tag_name | sed 's/^v//')
           if [ -z "$pinned" ] || [ -z "$latest" ]; then
@@ -59,10 +66,14 @@ jobs:
         run: |
           set -euo pipefail
           title="vLLM v${LATEST} compatibility assessment"
-          # Dedup: skip when an open issue already names this version.
-          count=$(gh issue list --state open --search "vLLM v${LATEST} in:title" --json number --jq 'length')
-          if [ "${count:-0}" -gt 0 ]; then
-            echo "issue already open for v${LATEST}; nothing to do."
+          # Dedup — mainly to stop the weekly schedule re-filing the same issue
+          # until the pin is bumped. Use the list endpoint (not --search, which is
+          # eventually consistent and can lag), scoped by our label; --state all so
+          # a version's issue is never re-created even after it is closed.
+          exists=$(gh issue list --state all --label type:compatibility --limit 200 \
+            --json title --jq "map(select(.title == \"$title\")) | length")
+          if [ "${exists:-0}" -gt 0 ]; then
+            echo "issue already exists for v${LATEST}; nothing to do."
             exit 0
           fi
           # Auto-fill the one section CI can compute without analysis: the


### PR DESCRIPTION
## TL;DR
Add a reusable, on-demand framework for assessing (and applying) vLLM version bumps: a phase-by-phase playbook plus a scheduled release watcher that files a tracking issue when upstream ships a newer release.

## Details
The plugin binds vLLM's internal v1 APIs, so every minor bump can break it and each one needs a compatibility pass. This PR captures that pass as repo-native tooling:

- **`.github/prompts/vllm-upgrade-assessment.prompt.md`** — an on-demand playbook (not auto-loaded, so zero cost to unrelated sessions). Phases:
  → pin env
  → map the coupling surface (grep re-derivation + a snapshot cross-check)
  → diff the coupled files (installed baseline vs `refs/tags/<TARGET>`)
  → classify by severity
  → synthesize the change plan
  → validate (ruff → build via `docs/install-vllm-tt.sh` → host-only pytest)
  → record & ship.

  Kickoff is a one-liner:
  > Follow .github/prompts/vllm-upgrade-assessment.prompt.md; assess this plugin against vLLM vX.Y.Z.

  It is also `/`-invocable in Copilot for VS Code. Works with Claude or Copilot; `tt-buddy` skills are an optional accelerant, not a dependency.

- **`.github/workflows/vllm-release-watch.yml`** (**in progress, needs an approval from reviewers**) — weekly (+ manual) job that compares the `vllm==` pin in `docs/install-vllm-tt.sh` to vLLM's latest stable release and, if newer, opens a **deduped** tracking issue pointing at the playbook with TARGET/BASELINE filled in. Uses `GITHUB_TOKEN` + `issues: write`; no secrets. The issue body is identical to the playbook's kickoff line, so manual and automated entry points converge.

## Related Artifacts
Relates to #64 (the framework's first target — vLLM 0.26.0). The 0.26.0 upgrade itself ships separately.

## Validation

The framework was exercised end-to-end two sessions: 0.25.1→0.26.0 #96 (1 fix; 329 host-only tests pass on a real 0.26.0 build) and 0.26.0→0.28.0 (2 scheduler breakages identified).

## Checklist

- [x] This PR is focused on a single logical change (the upgrade-assessment framework).
- [x] ~I added or updated tests where applicable~ — N/A (docs + CI workflow; YAML + shell logic validated above).
- [x] I ran the relevant checks and recorded them above.
- [x] I updated documentation where applicable (the playbook is the doc).