### PR TITLE
[bug] Return aborted `Requests` from `TTLaneCoordinator.finish_requests`

### DIFF
--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -686,13 +686,15 @@ class TTLaneCoordinator(SchedulerInterface):
 
     def finish_requests(
         self,
-        request_ids: str | Iterable[str],
+        request_ids: str | Iterable[str] | None,
         finished_status: RequestStatus,
-    ) -> None:
+    ) -> list[Request]:
         # Broadcast to every lane; a lane no-ops for IDs it does not hold, so no
         # request->lane map is needed.
+        aborted: list[Request] = []
         for sched in self.lanes:
-            sched.finish_requests(request_ids, finished_status)
+            aborted.extend(sched.finish_requests(request_ids, finished_status))
+        return aborted
 
     # ------------------------------------------------------------------
     # SchedulerInterface: queries / lifecycle

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -8,10 +8,13 @@ on a small surface of each lane (``waiting`` / ``skipped_waiting`` / ``running``
 length, forced-mode scheduling, and ``update_from_output``).
 """
 
+import collections
 from types import SimpleNamespace
 
+import pytest
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.request import RequestStatus
 
 from vllm_tt_plugin.lane_scheduler import (
     TTLaneCoordinator,
@@ -39,6 +42,7 @@ class FakeLane:
         skipped_waiting=0,
         partial_prefills=0,
         pending_finished=(),
+        owns=(),
     ):
         self.waiting = [object()] * waiting
         self.skipped_waiting = [object()] * skipped_waiting
@@ -51,6 +55,8 @@ class FakeLane:
         self.scheduled_modes: list[TTSchedulingMode] = []
         self.update_calls: list[SchedulerOutput] = []
         self._eco: dict[int, EngineCoreOutputs] = {}
+        self._owned = {r.request_id: r for r in owns}
+        self.finish_calls: list[tuple] = []
 
     def set_forced_mode(self, mode):
         self._mode = mode
@@ -70,6 +76,16 @@ class FakeLane:
     def update_from_output(self, scheduler_output, model_runner_output):
         self.update_calls.append(scheduler_output)
         return self._eco
+
+    def finish_requests(self, request_ids, finished_status):
+        self.finish_calls.append((request_ids, finished_status))
+        if request_ids is None:
+            ids = list(self._owned)
+        elif isinstance(request_ids, str):
+            ids = [request_ids]
+        else:
+            ids = list(request_ids)
+        return [self._owned.pop(rid) for rid in ids if rid in self._owned]
 
 
 def _make_coordinator(lanes, *, per_lane_max=32, log_stats=False):
@@ -519,3 +535,44 @@ def test_per_lane_vllm_config_uses_per_lane_max_num_seqs():
     # model sizing is left untouched (copied, not aliased/mutated).
     assert global_config.scheduler_config.max_num_seqs == 32
     assert per_lane_config.scheduler_config is not global_config.scheduler_config
+
+
+def _req(rid, client_index=0):
+    return SimpleNamespace(request_id=rid, client_index=client_index)
+
+
+@pytest.mark.parametrize(
+    "request_ids, expected_ids",
+    [
+        (None, ["a0", "a1", "b0"]),  # None -> every held request
+        (["a1", "b0", "gone"], ["a1", "b0"]),  # spans lanes; unheld id no-ops
+        ("a0", ["a0"]),  # single str id
+    ],
+)
+def test_finish_requests_returns_only_owned_no_duplicates(request_ids, expected_ids):
+    # Each lane returns only the requests it holds (a request lives in exactly one
+    # lane), so the coordinator's concatenation is the aborted set with no
+    # duplicates.
+    a0, a1, b0 = _req("a0", 0), _req("a1", 1), _req("b0", 0)
+    owned = {"a0": a0, "a1": a1, "b0": b0}
+    coordinator = _make_coordinator([FakeLane(owns=[a0, a1]), FakeLane(owns=[b0])])
+
+    aborted = coordinator.finish_requests(request_ids, RequestStatus.FINISHED_ABORTED)
+
+    assert aborted == [owned[i] for i in expected_ids]  # exact objects, in lane order
+    assert len({id(r) for r in aborted}) == len(aborted)  # no request returned twice
+
+
+def test_finish_requests_result_is_routable_per_client():
+    # The returned Requests must carry client_index so engine-core's
+    # _send_abort_outputs can notify each client. True end-to-end notification is
+    # covered device-side in tests/tt.
+    lanes = [FakeLane(owns=[_req("a", 0), _req("b", 1)]), FakeLane(owns=[_req("c", 0)])]
+    coordinator = _make_coordinator(lanes)
+
+    aborted = coordinator.finish_requests(None, RequestStatus.FINISHED_ABORTED)
+
+    by_client = collections.defaultdict(set)
+    for r in aborted:
+        by_client[r.client_index].add(r.request_id)
+    assert by_client == {0: {"a", "c"}, 1: {"b"}}


### PR DESCRIPTION
## TL;DR

Under lane-DP, `TTLaneCoordinator.finish_requests` returned `None` while 0.26.0's `SchedulerInterface` returns `list[Request]`, so engine-core abort/shutdown dropped client notifications for already-finished requests and hung those clients. Return the concatenated per-lane requests.

## Details

`TTLaneCoordinator` is the plugin's only direct `SchedulerInterface` implementor. 0.26.0's `finish_requests` returns `list[Request]`; `TTScheduler` inherits the correct `Scheduler.finish_requests`, but the coordinator overrode it to broadcast to lanes and return `None`.

Two 0.26.0 proc paths — `EngineCoreProc.pause_scheduler(mode="abort")` (core.py:1789) and the shutdown/drain path (core.py:1445) — do `aborted_reqs = scheduler.finish_requests(None, …)` then `_send_abort_outputs(aborted_reqs)`, which is `if aborted_reqs:` and groups by `request.client_index`. A `None` return is falsy, so the requests are finished in the lanes but no client is notified. The plugin's own `pause_scheduler` wrapper falls through to the stock original, so this is reachable in lane-DP. It also latently broke the plugin's `reset_prefix_cache` abort patch, which does `len(aborted)` / `send_abort_outputs(aborted)`.

Fix: match the interface — `request_ids: str | Iterable[str] | None`, return `list[Request]`, concatenating each lane's finished requests (a request lives in exactly one lane, so the result has no duplicates). `TTScheduler` (single-lane) was already correct via inheritance, so only the coordinator subtype needed adapting.

## Related Artifacts

Follow-up to a review finding on #96

## Validation

```text
$ python -m pytest tests/ --ignore=tests/tt -q
333 passed
```

Actions are [passing](https://github.com/tenstorrent/tt-metal/actions/runs/33162147497)

Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] ~I updated documentation where applicable.~ — N/A