### PR TITLE
[deps] Update to vLLM 0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ here. Nothing TT-specific needs to touch vLLM core.
 |   +-- model_runner.py      # TT model execution bridge
 |   +-- scheduler.py         # TT scheduling policy
 |   +-- lane_scheduler.py    # Single-process multi-lane (lane-DP) coordinator
-|   +-- launcher.py          # retained tt-run / MPI launcher (not hooked by vLLM 0.26.0)
+|   +-- launcher.py          # retained tt-run / MPI launcher (not hooked by vLLM 0.28.0)
 |   +-- loader.py            # TT model loader
 |   +-- input_batch.py       # TT input-batch representation
 |   +-- async_decode.py      # Decode overlap helpers
@@ -44,7 +44,7 @@ for the appropriate tt-metal and vLLM commits.
 vLLM requires Python `>=3.10,<3.14`. Python 3.10.12 is the default `python3` on
 Ubuntu 22.04.
 
-The installation script builds vLLM `0.26.0` from source with
+The installation script builds vLLM `0.28.0` from source with
 `VLLM_TARGET_DEVICE=empty`.
 
 To install against older supported vLLM versions `X.Y.Z` instead (e.g., `0.25.1`),

--- a/docs/diffusion-gemma.md
+++ b/docs/diffusion-gemma.md
@@ -16,7 +16,7 @@ canvases and trims the final canvas to the request's logical `max_tokens`.
 
 Follow [Environment Setup in the main README](../README.md#environment-setup):
 activate the tt-metal environment, then run `source docs/install-vllm-tt.sh`
-to install the pinned vLLM 0.26.0 build and this plugin.
+to install the pinned vLLM 0.28.0 build and this plugin.
 
 ## Launch
 
@@ -48,7 +48,7 @@ python -m vllm.entrypoints.openai.api_server \
 ```
 
 DiffusionGemma uses the `gemma4` reasoning and tool parsers shipped by vLLM
-0.26.0. The plugin does not override or alias upstream parser names. For tool
+0.28.0. The plugin does not override or alias upstream parser names. For tool
 calling add `--enable-auto-tool-choice --tool-call-parser gemma4`.
 
 `--max-num-batched-tokens` concerns scheduler prompt admission. It does not

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -13,7 +13,7 @@
 # not stay behind in the image layer.
 VLLM_COMMON_REQUIREMENTS=$(mktemp)
 curl -fsSL \
-    https://raw.githubusercontent.com/vllm-project/vllm/v0.26.0/requirements/common.txt \
+    https://raw.githubusercontent.com/vllm-project/vllm/v0.28.0/requirements/common.txt \
     -o "$VLLM_COMMON_REQUIREMENTS" ||
     # `return`, not `exit`: this script is sourced into the caller's shell.
     { echo "install-vllm-tt: cannot fetch vLLM common.txt"; return 1; }
@@ -23,5 +23,5 @@ rm -f "$VLLM_COMMON_REQUIREMENTS"
 # --no-binary vllm: the published wheel is the CUDA build, kernels included, so
 # vLLM has to come from source. vLLM ends up declaring no torch dependency, which
 # is intended; torch belongs to the tt-metal env this plugin runs inside.
-VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary vllm vllm==0.26.0
+VLLM_TARGET_DEVICE=empty uv pip install --no-deps --no-binary vllm vllm==0.28.0
 uv pip install -e .

--- a/src/vllm_tt_plugin/lane_scheduler.py
+++ b/src/vllm_tt_plugin/lane_scheduler.py
@@ -267,6 +267,8 @@ class TTLaneCoordinator(SchedulerInterface):
         ]
         # No KV connector on TT; surfaced for engine-core attribute access.
         self.connector: KVConnectorBase_V1 | None = None
+        # No encoder-cache connector on TT; required by vLLM EngineCore.
+        self.ec_connector = None
 
         # Each lane scheduler must cap its running set at the *per-lane*
         # capacity, not the global ``max_num_seqs`` the coordinator sees. The

--- a/src/vllm_tt_plugin/scheduler.py
+++ b/src/vllm_tt_plugin/scheduler.py
@@ -66,8 +66,9 @@ class TTScheduler(AsyncScheduler):
       strict queue, and every async op is forced to complete before the next
       prefill, so no later write can reach the KV they were computed against.
       The base class appends them on arrival and the resumed prefill replays
-      them. ``Request.async_tokens_to_discard`` serves the wholesale
-      ``reset_prefix_cache`` teardown only; wiring ordinary preemption into it
+      them. Only the wholesale ``reset_prefix_cache`` teardown discards them
+      (upstream marks the request with ``drop_stale_output`` /
+      ``num_stale_output_tokens``); wiring ordinary preemption into that path
       drops valid tokens and silently truncates the response.
 
     Supports ``set_forced_mode`` for lane coordination:
@@ -490,12 +491,14 @@ class TTScheduler(AsyncScheduler):
                 request.num_output_placeholders += extra_placeholders
 
     def _update_request_with_output(
-        self, request: Request, new_token_ids: list[int]
+        self, request: Request, new_token_ids: list[int], is_stale: bool = False
     ) -> tuple[list[int], bool]:
         """Commit one block and reconcile its full physical reservation."""
         if not self._is_block_output_model:
-            return super()._update_request_with_output(request, new_token_ids)
-        if request.async_tokens_to_discard:
+            return super()._update_request_with_output(
+                request, new_token_ids, is_stale=is_stale
+            )
+        if is_stale:
             raise RuntimeError(
                 "A stale async output reached synchronous block serving; "
                 "block-output async scheduling and running prefix resets are "

--- a/tests/test_block_scheduler.py
+++ b/tests/test_block_scheduler.py
@@ -772,7 +772,7 @@ def test_deferred_keep_reset_returns_false_without_preempting_block_request():
     )
     assert scheduler.running == [request]
     assert request.status == RequestStatus.RUNNING
-    assert request.async_tokens_to_discard == 0
+    assert request.num_stale_output_tokens == 0
 
 
 def test_ar_prefix_cache_reset_delegates_to_upstream_preemption():
@@ -784,7 +784,7 @@ def test_ar_prefix_cache_reset_delegates_to_upstream_preemption():
     )
     assert scheduler.running == []
     assert request.status == RequestStatus.PREEMPTED
-    assert request.async_tokens_to_discard == 1
+    assert request.drop_stale_output is True
     assert request.num_output_placeholders == 0
 
 
@@ -792,7 +792,7 @@ def test_ar_prefix_cache_reset_delegates_to_upstream_preemption():
     ("mutate", "width", "exc", "match"),
     [
         pytest.param(
-            lambda r: setattr(r, "async_tokens_to_discard", 1),
+            lambda r: setattr(r, "num_stale_output_tokens", r.num_in_flight_tokens),
             CANVAS,
             RuntimeError,
             "stale async output",

--- a/tests/test_lane_scheduler.py
+++ b/tests/test_lane_scheduler.py
@@ -80,6 +80,7 @@ def _make_coordinator(lanes, *, per_lane_max=32, log_stats=False):
     coordinator.log_stats = log_stats
     coordinator.structured_output_manager = None
     coordinator.connector = None
+    coordinator.ec_connector = None
     coordinator._req_to_lane = {}
     coordinator._req_to_row = {}
     coordinator._free_slots_by_lane = [


### PR DESCRIPTION
## TL;DR

Build the plugin against vLLM 0.28.0 (from 0.26.0): adapt `TTScheduler`'s block-output override to 0.28's stale-output model and bump the pinned build. One code change, in one method.

## Details

Two 0.28 changes hit `TTScheduler._update_request_with_output`, and both collapse into a single coherent edit:
- `Scheduler`/`AsyncScheduler._update_request_with_output` gained `is_stale: bool = False`,
  now dispatched as a kwarg — the override omitted it (`TypeError` on the first generated
  token).
- `Request.async_tokens_to_discard` was removed; its stale-output role moved to
  `num_stale_output_tokens` / `drop_stale_output`, and the update loop now signals staleness
  via `is_stale`. The block-output guard read the deleted attribute (`AttributeError`).

**Fix**: accept `is_stale`, forward it to `super()` on the non-block path (AsyncScheduler guards its placeholder decrement with `if not is_stale`, so dropping it would underflow), and reject stale frames with `if is_stale:` on the block path. Docstring updated to the new model.

Everything else in the plugin's coupling surface is signature/field-stable (worker/platform, config/loader/kv-cache, outputs/sampling/logits, `MultiGroupBlockTable` byte-identical, all `platform.py` monkeypatch targets, `vllm.utils.*`). `common.txt` delta is benign (`+huggingface_hub`, `mistral_common` bump).

Three `tests/test_block_scheduler.py` sites were ported to the 0.28 model using probed runtime values: `num_stale_output_tokens == 0`; `drop_stale_output is True` (the old count didn't map — reset sets `num_stale = num_in_flight`); and driving `is_stale=True` via `setattr(num_stale_output_tokens, r.num_in_flight_tokens)`.

Deferred (optional, non-blocking): `get_kv_cache_usage()` / `check_runner_kv_caches_multi_layer()` overrides and a `session_id` passthrough test.

## Related Artifacts

Resolves #47 

## Validation

```text
$ source docs/install-vllm-tt.sh                 # builds vllm 0.28.0+empty from source
$ python -m pytest tests/ --ignore=tests/tt -q   # full host-only suite
329 passed
$ uvx ruff@0.14.0 check ... && ruff format --check ...
All checks passed!  /  files already formatted
```

Running [Actions](https://github.com/tenstorrent/tt-metal/actions/runs/34219119749): looks like the following error was caused by this branch:
```bash
RuntimeError: Insufficient space in /dev/shm: 160 MiB required, 63 MiB free. Increase /dev/shm (e.g. --shm-size or --ipc=host).
```
Others might be unrelated.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [ ] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.