### PR TITLE
fix: null the stale tail of reused block-table rows (cross-user KV clobber under chunked prefill)

### DIFF
--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -687,6 +687,19 @@ class InputBatch:
         out: list[torch.Tensor] = []
         for bt in self.block_table.block_tables:
             bt_cpu = bt.get_cpu_tensor()[rows, :width].clone()
+            # Zero every column past the row's valid block count. vLLM's
+            # move_row/condense copies only num_blocks entries, so a reused row
+            # keeps the previous occupant's block ids in its tail. Upstream GPU
+            # consumers mask by num_blocks_per_row; the TT path materializes the
+            # full width into device page tables (gemma4 chunked-prefill
+            # continuation slices to full-prompt width), so a stale tail routes
+            # KV writes into another live request's blocks (cross-user KV
+            # clobber, corrupt from decode step 2). Block 0 is the reserved
+            # null block, the same convention as decode row padding (#92).
+            for i, r in enumerate(rows):
+                nb = int(bt.num_blocks_per_row[int(r)])
+                if nb < bt_cpu.shape[1]:
+                    bt_cpu[i, nb:] = 0
             if bt_cpu.shape[1] < width:
                 pad = torch.zeros(
                     bt_cpu.shape[0], width - bt_cpu.shape[1], dtype=bt_cpu.dtype


### PR DESCRIPTION
## Problem

vLLM's `BlockTable.move_row` (used by `InputBatch.condense`) copies only `num_blocks` entries into the target row, leaving the previous occupant's block ids in the remaining columns. Upstream GPU consumers always mask by `num_blocks_per_row`, so the stale tail is unobservable there. The TT path materializes the sliced row into a full-width device page table, and gemma4's chunked-prefill continuation slices to full-prompt width — so a request condensed into a reused row mid-prefill consumes columns that still name **another live request's physical blocks**. Its continuation KV writes land in that request's cache: cross-user KV clobber, corrupt from decode step 2 onward (first token comes from prefill activations and is always correct).

## Evidence (KV fingerprint, WH T3K, gemma-4-12B, 2 identical greedy prompts, isl 4k, chunk 2048)

Per-block abs-sums of the first full-attention layer's K cache:

```
prefill A            row 0 -> blocks [1..54]
prefill B chunk 1    row 1 -> blocks [55..86]
A finishes prefill; condense() moves B to row 0 (copies 43 entries)
B chunk 2 consumed:  [55..97, 44,45,...,54]     <- tail = A's live blocks
vLLM at that moment: num_blocks_per_row[0]=43, consumed width=54
```

The clobbered request answers correctly for exactly one token, then degrades (`"It appears you have provided a repetitive text"`, digit loops).

## Fix

Zero every column past the row's valid block count in `block_tables_for_rows`. Block 0 is the reserved null block — the same convention decode-row padding already uses. Restores the per-row masking invariant upstream assumes.

## Measured (serving path, 32 identical greedy prompts, 3 consecutive batches, WH T3K 12B)

| | before | after |
|---|---|---|
| correct | 11/32 | **32/32 × 3** |
| distinct outputs | 13–14 | **1** |
| degenerate | ~12/batch | **0** |

## Why this presented as WH-only

BH specs run a 64Ki prefill budget → 4k prompts are single-chunk → the reused-row continuation path never executes. WH's 2048 budget makes 4k prompts multi-chunk. BH remains latently exposed for concurrent >64Ki prompts; this change removes the exposure for all models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)