### PR TITLE
fix: opt-in nulling of stale block-table row tails (rework of #103)

### DIFF
--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1116,15 +1116,23 @@ class TTLaneInputBatch(InputBatch):
     # ------------------------------------------------------------------
 
     def slot_block_tables(
-        self, rows: list[int], zero_gaps: bool, total: int, width: int
+        self,
+        rows: list[int],
+        zero_gaps: bool,
+        total: int,
+        width: int,
+        null_stale_tail: bool = False,
     ) -> list[torch.Tensor]:
         """Per-group block tables for ``rows`` (one row per slot), each padded
         to ``width`` (``max_num_blocks_per_req``). When ``zero_gaps`` is set,
         rows of ``range(total)`` not in ``rows`` are zeroed (empty decode slots
-        carry no blocks)."""
+        carry no blocks). ``null_stale_tail`` forwards to
+        ``block_tables_for_rows`` (lane mode builds both prefill and decode
+        tables through here, so the opt-in must ride along or lane-mode
+        deployments never execute the fix)."""
         occupied = set(rows)
         sel = list(range(total)) if zero_gaps else rows
-        out = self.block_tables_for_rows(sel, width)
+        out = self.block_tables_for_rows(sel, width, null_stale_tail=null_stale_tail)
         if zero_gaps and len(occupied) < total:
             gap = torch.ones(total, dtype=torch.bool)
             gap[list(occupied)] = False
@@ -1206,7 +1214,15 @@ class TTLaneInputBatch(InputBatch):
         input_tokens = torch.from_numpy(tokens_np)
 
         block_tables_per_group = lane_batch.slot_block_tables(
-            occupied, zero_gaps=True, total=total, width=runner.max_num_blocks_per_req
+            occupied,
+            zero_gaps=True,
+            total=total,
+            width=runner.max_num_blocks_per_req,
+            null_stale_tail=bool(
+                getattr(
+                    getattr(runner, "model", None), "tt_null_stale_block_table_tail", False
+                )
+            ),
         )
         rows_all = list(range(total))
         tt_sampling_params = lane_batch.slot_sampling_params(rows_all)
@@ -1296,7 +1312,15 @@ class TTLaneInputBatch(InputBatch):
         input_tokens = lane_batch.token_ids_cpu_tensor[rows_np, :max_prefill]
 
         block_tables_per_group = lane_batch.slot_block_tables(
-            rows, zero_gaps=False, total=0, width=runner.max_num_blocks_per_req
+            rows,
+            zero_gaps=False,
+            total=0,
+            width=runner.max_num_blocks_per_req,
+            null_stale_tail=bool(
+                getattr(
+                    getattr(runner, "model", None), "tt_null_stale_block_table_tail", False
+                )
+            ),
         )
         tt_sampling_params = lane_batch.slot_sampling_params(rows)
         batch_size_per_dp = list(plan.batch_size_per_dp)

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1220,7 +1220,9 @@ class TTLaneInputBatch(InputBatch):
             width=runner.max_num_blocks_per_req,
             null_stale_tail=bool(
                 getattr(
-                    getattr(runner, "model", None), "tt_null_stale_block_table_tail", False
+                    getattr(runner, "model", None),
+                    "tt_null_stale_block_table_tail",
+                    False,
                 )
             ),
         )
@@ -1318,7 +1320,9 @@ class TTLaneInputBatch(InputBatch):
             width=runner.max_num_blocks_per_req,
             null_stale_tail=bool(
                 getattr(
-                    getattr(runner, "model", None), "tt_null_stale_block_table_tail", False
+                    getattr(runner, "model", None),
+                    "tt_null_stale_block_table_tail",
+                    False,
                 )
             ),
         )

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -678,7 +678,7 @@ class InputBatch:
         return output_token_ids_tensor
 
     def block_tables_for_rows(
-        self, rows: torch.Tensor | list[int], width: int
+        self, rows: torch.Tensor | list[int], width: int, null_stale_tail: bool = False
     ) -> list[torch.Tensor]:
         """Per-group block tables sliced to ``rows`` and right-padded on the
         block dimension to ``width``.
@@ -686,10 +686,25 @@ class InputBatch:
         Constant ``width`` (``max_num_blocks_per_req``) is required for ttnn
         tracing: runtime block tables must match the traced width even when
         their underlying group is narrower.
+
+        ``null_stale_tail`` additionally zeroes every column past each row's
+        valid block count. vLLM's move_row/condense copies only ``num_blocks``
+        entries, so a reused row keeps the previous occupant's block ids in
+        its tail; upstream GPU consumers mask by ``num_blocks_per_row``, but a
+        model that materializes the full width into device page tables (e.g.
+        gemma4's chunked-prefill continuation) would route KV writes into
+        another live request's blocks. Opt-in via the model attribute
+        ``tt_null_stale_block_table_tail`` so models that never consume past
+        the valid count keep today's behavior byte-for-byte.
         """
         out: list[torch.Tensor] = []
         for bt in self.block_table.block_tables:
             bt_cpu = bt.get_cpu_tensor()[rows, :width].clone()
+            if null_stale_tail:
+                for i, r in enumerate(rows):
+                    nb = int(bt.num_blocks_per_row[int(r)])
+                    if nb < bt_cpu.shape[1]:
+                        bt_cpu[i, nb:] = 0
             if bt_cpu.shape[1] < width:
                 pad = torch.zeros(
                     bt_cpu.shape[0], width - bt_cpu.shape[1], dtype=bt_cpu.dtype

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1115,7 +1115,9 @@ class TTModelRunner:
             target_width,
             null_stale_tail=bool(
                 getattr(
-                    getattr(self, "model", None), "tt_null_stale_block_table_tail", False
+                    getattr(self, "model", None),
+                    "tt_null_stale_block_table_tail",
+                    False,
                 )
             ),
         )

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -1111,7 +1111,13 @@ class TTModelRunner:
         # block-table widths differ after upstream page-size unification.
         target_width = self.max_num_blocks_per_req
         block_tables_per_group = input_batch.block_tables_for_rows(
-            req_indices, target_width
+            req_indices,
+            target_width,
+            null_stale_tail=bool(
+                getattr(
+                    getattr(self, "model", None), "tt_null_stale_block_table_tail", False
+                )
+            ),
         )
 
         # Group-0 view kept on TTModelInput.block_tables for back-compat with


### PR DESCRIPTION
Rework of #103 per its closure rationale (unconditional 0-padding affected all models). The zeroing runs only for models declaring `tt_null_stale_block_table_tail = True`; all other models' tables are byte-for-byte unchanged **on every path**.

## Two commits

1. `9f1aec8` — opt-in nulling in `block_tables_for_rows`, gated at the model runner's per-group call on the model attribute. Root cause, fingerprint evidence, and before/after in the commit message; gemma4 declares the attribute in tt-metal `arg/gemma4_coherence_fix @ a570e36dfab`. Model-side masking was tried first and measured insufficient (21/32 — hybrid per-layer tables bypass the single-tensor kwarg). This is the only plugin change in the whole effort: `num_blocks_per_row` — the ground truth for a row's valid width — exists only in the plugin, so the masking cannot live anywhere else.
2. `b379451` — routes the same gate through **lane mode**: `slot_block_tables` forwards `null_stale_tail`, and both lane call sites (`_build_decode_input`, `_build_prefill_input`) gate on the same attribute. As first pushed, lane-mode deployments never executed the fix.

## Root cause (fingerprinted, WH T3K gemma-4-12B, 2 identical greedy prompts, isl 4k, chunk 2048)

vLLM's `move_row`/`condense` copies only `num_blocks` entries into a reused row; upstream GPU consumers mask by `num_blocks_per_row`, but the TT path materializes full width into device page tables, and gemma4's chunked-prefill continuation slices to full-prompt width — so a request condensed into a reused row consumes columns naming **another live request's blocks**, and its continuation KV writes clobber that request's cache (corrupt from decode step 2, concurrency >= 2, wherever the prefill budget makes prompts multi-chunk):

```
prefill A          row 0 -> [1..54]
prefill B chunk 1  row 1 -> [55..86]
condense() moves B to row 0 (copies 43 entries)
B chunk 2 consumed [55..97, 44,...,54]   <- tail = A's live blocks
vLLM at that step: num_blocks_per_row[0] = 43, consumed width = 54
```

## Evidence

**WH T3K (non-lane), serving path, 32 identical greedy prompts, 3 consecutive batches:**

| | before | after |
|---|---|---|
| correct | 11/32 | **32/32 x 3** |
| distinct outputs | 13-14 | **1** |
| degenerate | ~12/batch | **0** |

Also verified on 31B/T3K: 32/32 x 3 identical.

**BH LoudBox (lane mode), 12B, bounded prod shape, staggered >64Ki prompts:** with the lane amendment active, the gate fired on every call and nulled **9 genuinely nonzero stale tails** — the hazard is real on lane-mode Blackhole (latent above its 64Ki prefill budget) and the gated fix neutralizes it on both paths.

Why this presented as WH-only: BH specs run a 64Ki prefill budget so 4k prompts are single-chunk and the reused-row continuation path never executes there; WH's 2048 budget makes 4k prompts multi-chunk.

Host-only suite: **329 passed** at both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

