### PR TITLE
fix google/gemma-4-E2B-it AmbiguousGlobalPerLayerAttributeError

### DIFF
--- a/docs/vllm-overrides.txt
+++ b/docs/vllm-overrides.txt
@@ -16,3 +16,6 @@
 # (https://github.com/tenstorrent/tt-metal/issues/30193).
 opencv-python-headless==4.11.0.86
 numpy>=1.24.4,<2
+
+# cf. https://github.com/vllm-project/vllm/pull/49797 (vllm v0.28.0 has this)
+transformers>=5.5.3,<5.15.0

--- a/docs/vllm-overrides.txt
+++ b/docs/vllm-overrides.txt
@@ -17,5 +17,17 @@
 opencv-python-headless==4.11.0.86
 numpy>=1.24.4,<2
 
-# cf. https://github.com/vllm-project/vllm/pull/49797 (vllm v0.28.0 has this)
+# vLLM 0.26.0 reads Gemma 4's head_dim off the global HF config
+# (transformers_utils/model_arch_config_convertor.py get_head_size, and
+# model_executor/models/gemma4.py). transformers 5.15.0 made head_dim a per-layer
+# attribute on heterogeneous configs and raises AmbiguousGlobalPerLayerAttributeError
+# on that read, so google/gemma-4-* fails during ModelConfig construction, before any
+# TT code runs. vLLM 0.28.0 carries the fix (vllm-project/vllm#49797).
+#
+# Retarget this ceiling when the pinned vLLM moves; do not just delete it. common.txt
+# declares no upper bound, so an uncapped install resolves the newest transformers
+# release, which is validated against neither the pinned vLLM nor the tt-metal env
+# (tt_metal/python_env/requirements-dev.txt pins transformers 5.12.1). The floor
+# restates vLLM's own: --override replaces a requirement instead of intersecting it.
+transformers>=5.5.3,<5.15.0
 transformers>=5.5.3,<5.15.0


### PR DESCRIPTION
transformers 5.15.0 raises AmbiguousGlobalPerLayerAttributeError on head_dim access for heterogeneous configs like gemma-4.

> transformers.integrations.heterogeneity.configuration_utils.
> AmbiguousGlobalPerLayerAttributeError: 'head_dim' is a per-layer
> attribute and may vary across layers. Access it via the individual
> layer configs instead (e.g. config.per_layer_config[i].head_dim).
> To read the global config value from config.head_dim anyway, set
> `allow_global_per_layer_attribute_access` to `True` on the config.
> Warning: only do this if the caller can safely handle heterogeneous
> configs; code that assumes a homogeneous model may use the global
> value incorrectly.

<!--
Thank you for contributing to vllm-tt-plugin.
Use one title prefix: [bug], [feat], [perf], [ref], [test], [ci], [doc], [deps], ...
For example: [bug] Reject invalid device IDs for standard TT DP.
Please complete the relevant sections so reviewers can understand and validate the change.
-->

## TL;DR

<!-- Summarize the change and its impact in one or two sentences. -->

## Details

<!-- Explain the problem, motivation, and implementation approach. -->

## Related Artifacts

<!-- Link an issue using "Resolves #<issue>" when this PR closes it. Otherwise, write N/A. Also mark related labels and provide important attachements or links. -->

## Validation

<!-- List the commands run and their results. Include relevant hardware, model, and mesh configuration for TT device tests. -->

```text
<command and result>
```

## Checklist

- [x] This PR is focused on a single logical change.
- [ ] I added or updated tests where applicable.
- [ ] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.
