### PR TITLE
install: install torchvision, which vLLM's common.txt omits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,10 @@ jobs:
 
       - name: Install torch
         # Stands in for the tt-metal env, which owns torch in a real install.
-        run: uv pip install torch
+        # Pinned to the version that env pins (tt-metal
+        # tt_metal/python_env/requirements-dev.txt), so the torchvision pin in
+        # install-vllm-tt.sh resolves against the torch it is paired with.
+        run: uv pip install torch==2.11.0
 
       - name: Install vLLM and the plugin
         # The same script the README hands operators, so this job also fails

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ access to `raw.githubusercontent.com` beyond the package index. When installing
 inside a container, also set `UV_NO_CACHE=1` to keep the uv cache out of the
 image layer.
 
+`common.txt` omits `torchvision`, which vLLM imports unconditionally from
+several model and processor modules, so the script installs it separately: the
+CPU build, with `--no-deps`, at the version the tt-metal env pins alongside its
+`torch`. Environments built from tt-metal's `requirements-dev.txt` already
+carry it; the `ttnn` wheel does not declare it.
+
 To install or refresh only the plugin package:
 
 ```bash

--- a/docs/install-vllm-tt.sh
+++ b/docs/install-vllm-tt.sh
@@ -20,6 +20,16 @@ curl -fsSL \
 uv pip install --override docs/vllm-overrides.txt \
     -r "$VLLM_COMMON_REQUIREMENTS"   # see that file for why. Must read when bumping vllm version!
 rm -f "$VLLM_COMMON_REQUIREMENTS"
+# torchvision is absent from common.txt (requirements/cuda.txt carries it for
+# the CUDA target), yet several vLLM model and processor modules import it
+# unconditionally. Registry inspection imports the module for the resolved
+# architecture, so without torchvision a serve command dies before any TT code
+# runs; transformers' Gemma4 processor reaches it for google/gemma-4-*.
+# --no-deps and the CPU index leave torch alone: this is the torchvision half
+# of the torch pair the tt-metal env fixes, and the default PyPI wheel is the
+# CUDA build.
+uv pip install --no-deps --index-url https://download.pytorch.org/whl/cpu \
+    torchvision==0.26.0   # keep in sync with tt-metal requirements-dev.txt
 # --no-binary vllm: the published wheel is the CUDA build, kernels included, so
 # vLLM has to come from source. vLLM ends up declaring no torch dependency, which
 # is intended; torch belongs to the tt-metal env this plugin runs inside.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,11 @@ license = "Apache-2.0"
 dependencies = ["tblib>=3.1.0"]
 
 [project.optional-dependencies]
-# The plugin runs only inside a tt-metal python_env, which already owns torch,
-# transformers, numpy, and torchvision; restating them here only risks conflicts.
+# The plugin runs only inside a tt-metal env, which already owns torch,
+# transformers, and numpy; restating them here only risks conflicts. torchvision
+# is not among them: the ttnn wheel declares neither torch nor torchvision, so
+# only environments built from tt-metal's requirements-dev.txt happen to carry
+# it, and docs/install-vllm-tt.sh installs it explicitly.
 # qwen-vl-utils is used solely by the offline Qwen-VL example
 # (examples/offline_inference_tt.py), not by the serving path, and the tt-metal
 # env does not provide it.


### PR DESCRIPTION
Fixes #107.

## Background

`docs/install-vllm-tt.sh` is the only install path the README hands operators. It fetches vLLM's `requirements/common.txt` at the pinned tag, installs that list, then builds vLLM with `--no-deps` so vLLM's own (CUDA) metadata is never resolved. The script therefore owns the dependency set, which its own header comment states: "This script owns the dependency set as a result".

`torchvision` is in `requirements/cuda.txt` (line 10 at v0.26.0, `torchvision==0.26.0`) and is absent from `requirements/common.txt`. Before the switch to the `common.txt` list, it arrived incidentally through the CUDA resolution. Since that switch it is installed by nothing.

## Why this breaks serving

vLLM imports `torchvision` unconditionally from several model and processor modules (`vllm/model_executor/models/openpangu_vl.py`, and the processors `step3_vl.py`, `internvl.py`, `deepseek_ocr.py`, `nemotron_vl.py`, `hunyuan_vl_image.py`, `deepseek_vl2.py`). It is also reached indirectly: `vllm/model_executor/models/gemma4_mm.py:26` imports `Gemma4Processor` at module scope, `transformers/models/gemma4/processing_gemma4.py` imports `image_processing_gemma4.py`, and that module does an unguarded `from torchvision.transforms.v2 import functional as tvF`. All of it runs inside `ModelRegistry.inspect_model_cls` during `ModelConfig` construction, so `vllm serve google/gemma-4-E2B-it` dies before any TT code is consulted.

This is a vLLM-side dependency, not a tt-metal one. `models/demos/gemma4/` in tt-metal contains no reference to `torchvision`, `Gemma4Processor`, `AutoProcessor`, or `image_processing`; its transformers usage is `modeling_gemma4`, `AutoConfig`, and `AutoTokenizer`. The reporter's traceback has no tt-metal frames. Adding the dependency to `models/demos/gemma4/requirements.txt` would also only reach the one place that installs it (tt-metal's `vllm-model-tests-impl.yaml`), never an operator following this README.

The claim in `pyproject.toml` that the tt-metal environment always supplies `torchvision` holds only for environments built from `tt_metal/python_env/requirements-dev.txt` (lines 112-113 pin `torch==2.11.0` and `torchvision==0.26.0`). The `ttnn` wheel declares neither `torch` nor `torchvision`, which is the environment the reporter has.

## Changes

- `docs/install-vllm-tt.sh`: install `torchvision==0.26.0` with `--no-deps` from `https://download.pytorch.org/whl/cpu`. `--no-deps` and the explicit CPU index are deliberate: `torch` belongs to the tt-metal environment and must not be mutated, and the default PyPI wheel on linux x86_64 is the CUDA build. The pin is the `torchvision` half of the `torch==2.11.0` / `torchvision==0.26.0` pair tt-metal fixes.
- `.github/workflows/ci.yaml`: pin the torch stand-in to `torch==2.11.0`. Unpinned it resolves to `torch==2.14.0+cpu` today, three minor versions ahead of what tt-metal pins, which both defeats the job's stated purpose ("Stands in for the tt-metal env") and leaves the `torchvision` pin paired with the wrong torch.
- `pyproject.toml`, `README.md`: correct the dependency-ownership statements.

## Why the existing CI missed this

Two CI systems, two different reasons, and only the first is fixed here.

- Plugin host CI has the right environment (it installs `torch` alone, no `torchvision`) but runs no test that reaches the import. Every host test either monkeypatches `ModelRegistry.get_supported_archs` (`test_block_scheduler.py:63`, `test_block_request_validation.py:312`, `test_dp_modes.py:51`, `test_dp_modes.py:343`, `test_visible_devices.py:284`) or touches only the parser managers (`test_diffusion_gemma_registration.py:141`). **This PR does not close that gap**: no test here would fail if `torchvision` were dropped from the install script again.
- tt-metal hardware CI does run `google/gemma-4-*` and does source this script (`vllm-model-tests-impl.yaml:248,254`), but the job runs inside a container whose `dockerfile/Dockerfile.python:157` installs `requirements-dev.txt`, so `torchvision` is already present. That masking is not fixable from this repo: as long as the dev image pre-installs `requirements-dev.txt`, that CI cannot validate the plugin's declared dependency set.

## Not a duplicate

`gh issue list --repo tenstorrent/vllm-tt-plugin --state all --search torchvision` returns only #107. `gh pr list --repo tenstorrent/vllm-tt-plugin --state open --search torchvision` returns nothing.

## Tests run

`uv` resolution of the new install command, dry-run, `--python-platform x86_64-unknown-linux-gnu`, Python 3.10 / 3.12 / 3.13: all resolve `torchvision==0.26.0+cpu`. Also checked `aarch64-apple-darwin` / 3.12, which resolves `torchvision==0.26.0`, and `torch==2.11.0` for 3.10 / 3.12, which resolves `torch==2.11.0+cpu`. No `--torch-backend` conflict with the `UV_TORCH_BACKEND=cpu` the CI job sets (uv 0.12.6).

The reported failure was reproduced directly in a throwaway venv with `torch==2.11.0`, `transformers==5.16.1` and no `torchvision`: `import transformers.models.gemma4.image_processing_gemma4` raises `ModuleNotFoundError: No module named 'torchvision'` at `image_processing_gemma4.py:17`, the same line as the report, on current transformers. Installing `torchvision==0.26.0` in that venv makes the import succeed.

`pre-commit run`: all hooks pass. `shellcheck -s bash docs/install-vllm-tt.sh` and `bash -n docs/install-vllm-tt.sh`: clean.

Not run locally: the full `source docs/install-vllm-tt.sh` path and the host suite, both of which need a vLLM build. CI covers them; the install step there resolves `torchvision==0.26.0+cpu`.

## Follow-up, not in this PR

No host test covers this dependency. Adding one means adding the first host test that loads a model class or an image processor, which is a change worth making on its own rather than inside a dependency fix.

The comment at `src/vllm_tt_plugin/platform.py:1140` says "Gemma4 isn't in vLLM's upstream registry". That is stale at v0.26.0: `registry.py` has `Gemma4ForCausalLM` (line 110), `Gemma4ForConditionalGeneration` (line 405), and `Gemma4UnifiedForConditionalGeneration` (line 406), so all three bare-name calls to `_register_model_if_missing` in the loop at `platform.py:1164-1173` are now no-ops. That is why inspection lands in upstream `gemma4_mm` at all. Installing `torchvision` clears the crash; the registration mismatch is a separate change.

## AI assistance

AI assistance (Claude Code) was used for the investigation and to draft this change. I reviewed every changed line and ran the commands reported above.
