### PR TITLE
[bug] Reject non-greedy requests for greedy-only TT samplers

### DIFF
--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1243,6 +1243,7 @@ class TTPlatform(Platform):
     _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
     _standard_dp_mesh_grids: ClassVar[dict[str, tuple[int, int]]] = {}
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
+    non_greedy_decoding_on_device: ClassVar[bool] = True
     # Stored as a weakref in production so a torn-down engine's config stops
     # tripping the one-engine-per-process guard once nothing else holds it;
     # tests may seed a direct config object.
@@ -1787,6 +1788,21 @@ class TTPlatform(Platform):
             if model_capabilities
             else False
         )
+        # Existing device-sampling models predate this narrower capability and
+        # support non-greedy requests, so absence preserves that contract. A
+        # greedy-only implementation must declare the restriction explicitly.
+        supports_non_greedy_sampling_on_device = (
+            model_capabilities.get("supports_non_greedy_sampling_on_device", True)
+            if model_capabilities
+            else True
+        )
+        if not isinstance(supports_non_greedy_sampling_on_device, bool):
+            raise ValueError(
+                "model_capabilities['supports_non_greedy_sampling_on_device'] "
+                "must be a bool, got "
+                f"{supports_non_greedy_sampling_on_device!r}"
+            )
+        cls.non_greedy_decoding_on_device = supports_non_greedy_sampling_on_device
         if sample_on_device_mode is not None and not supports_sample_on_device:
             raise ValueError(
                 f"sample_on_device_mode={sample_on_device_mode!r} was requested, "
@@ -1968,7 +1984,7 @@ class TTPlatform(Platform):
         params: "SamplingParams | PoolingParams",
     ) -> None:
         """Raises if this request is unsupported on this platform"""
-        from vllm.sampling_params import SamplingParams
+        from vllm.sampling_params import SamplingParams, SamplingType
 
         dev = cls.device_name
 
@@ -1977,6 +1993,18 @@ class TTPlatform(Platform):
 
         if isinstance(params, SamplingParams) and params.prompt_logprobs is not None:
             raise ValueError(f"Not yet supporting prompt_logprobs on {dev}")
+
+        if (
+            isinstance(params, SamplingParams)
+            and cls.sample_on_device_mode in ("all", "decode_only")
+            and not cls.non_greedy_decoding_on_device
+            and params.sampling_type is not SamplingType.GREEDY
+        ):
+            raise ValueError(
+                "This TT model supports greedy device sampling only; got "
+                f"temperature={params.temperature}, top_p={params.top_p}, "
+                f"top_k={params.top_k}"
+            )
 
         block_contract = cls._get_block_output_contract()
         if not isinstance(params, SamplingParams) or block_contract is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ _TT_PLATFORM_CONFIG_ATTRS = (
     "_standard_dp_visible_device_groups",
     "_standard_dp_mesh_grids",
     "sample_on_device_mode",
+    "non_greedy_decoding_on_device",
     "always_compat_sampling",
     "_tt_vllm_config",
 )

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -288,6 +288,20 @@ class ARModel:
     }
 
 
+class GreedyOnlyARModel:
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_non_greedy_sampling_on_device": False,
+    }
+
+
+class InvalidSamplingCapabilityARModel:
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_non_greedy_sampling_on_device": "no",
+    }
+
+
 class _WeakrefableConfig(SimpleNamespace):
     """SimpleNamespace itself cannot be weak-referenced; VllmConfig can."""
 
@@ -347,6 +361,38 @@ def _ar_config():
     config = _weakrefable_config()
     config.model_config.hf_config.canvas_length = None
     return config
+
+
+def test_greedy_only_device_sampling_rejects_non_greedy_at_request_boundary(
+    monkeypatch,
+):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, GreedyOnlyARModel)
+
+    TTPlatform.check_and_update_config(config)
+
+    with pytest.raises(ValueError, match="greedy device sampling only"):
+        _validate(SamplingParams(max_tokens=16, temperature=1.0, top_p=0.9))
+    _validate(SamplingParams(max_tokens=16, temperature=0.0))
+
+
+def test_existing_device_sampling_capability_keeps_non_greedy_behavior(monkeypatch):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, ARModel)
+
+    TTPlatform.check_and_update_config(config)
+
+    _validate(SamplingParams(max_tokens=16, temperature=1.0, top_p=0.9))
+
+
+def test_non_greedy_device_sampling_capability_must_be_boolean(monkeypatch):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, InvalidSamplingCapabilityARModel)
+
+    with pytest.raises(
+        ValueError, match="supports_non_greedy_sampling_on_device.*bool"
+    ):
+        TTPlatform.check_and_update_config(config)
 
 
 def test_admission_handle_releases_with_the_dead_engine(monkeypatch):


### PR DESCRIPTION
## TL;DR

Reject non-greedy requests at the API validation boundary when a TT model explicitly declares its on-device sampler greedy-only. Existing model behavior is unchanged when the new capability is absent.

## Details

Generated Quetzal performs device-side argmax and fails closed if temperature, top-p, or bounded top-k sampling reaches the model runner. Today that exception occurs in EngineCore and tears down the server. This change consumes the semantic `supports_non_greedy_sampling_on_device` model capability, stores the resolved value on TTPlatform, and raises before engine dispatch. The capability defaults to true only to preserve the established contract of already-enrolled device samplers; restricted models must opt out explicitly. Invalid non-boolean declarations fail startup.

AI assistance was used. The submitter must review and defend every changed line before merge.

## Related Artifacts

Paired Quetzal capability declaration: `tenstorrent/tt-quetzalcoatlus:nkapre/declare-greedy-only-device-sampling` (PR link will be added once created).

Observed incident: GPT-OSS-120B generated Quetzal returned HTTP 500 and EngineCore exited after a canonical AIME request used temperature=1.0.

## Validation

```text
PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest -q tests/test_block_request_validation.py
72 passed

PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest -q tests/ --ignore=tests/tt
371 passed, 14 warnings

.venv/bin/pre-commit run
PASS (all hooks)
```

Device/API validation will be attached after the paired Quetzal capability is staged on GPT-OSS-120B, P300X2.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks and recorded them above.
- [x] Documentation is not required; this is an internal model capability consumed at startup.