### PR TITLE
[bug] Fall back to host sampling for greedy-only device samplers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,7 @@ Keys currently consumed by `src/vllm_tt_plugin/platform.py`:
 | `supports_prefix_caching` | `False` | Whether the vLLM prefix cache may be used |
 | `output_tokens_per_step` | `1` | Committed output width per step. `1` is token-at-a-time; `>1` is block-output width |
 | `supports_sample_on_device` | `False` | Opt-in for on-device sampling. A requested `sample_on_device_mode` is rejected when `False` |
+| `supports_non_greedy_sampling_on_device` | `True` | Whether an enrolled device sampler can execute temperature/top_p/top_k, not only greedy. `check_perform_device_sampling` routes a non-greedy step to host sampling when `False` |
 | `supports_async_decode` | `False` | Whether async scheduling may stay on. When `False`, the platform warns and clears `async_scheduling` |
 
 Absent keys default via `.get`. That is the live contract. Do not add
@@ -335,7 +336,8 @@ lifetime of the value:
   `check_and_update_config` configures every later test. Current names in
   `tests/conftest.py` `_TT_PLATFORM_CONFIG_ATTRS`:
   `_standard_dp_visible_device_groups`, `_standard_dp_mesh_grids`,
-  `sample_on_device_mode`, `always_compat_sampling`, `_tt_vllm_config`.
+  `sample_on_device_mode`, `supports_non_greedy_sampling_on_device`,
+  `always_compat_sampling`, `_tt_vllm_config`.
   `always_compat_sampling` is assigned at runtime inside
   `_apply_check_and_update_config`, not declared as a `ClassVar` on the class
   body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ Keys currently consumed by `src/vllm_tt_plugin/platform.py`:
 | `supports_prefix_caching` | `False` | Whether the vLLM prefix cache may be used |
 | `output_tokens_per_step` | `1` | Committed output width per step. `1` is token-at-a-time; `>1` is block-output width |
 | `supports_sample_on_device` | `False` | Opt-in for on-device sampling. A requested `sample_on_device_mode` is rejected when `False` |
-| `supports_non_greedy_sampling_on_device` | `True` | Whether an enrolled device sampler can execute temperature/top_p/top_k, not only greedy. `check_perform_device_sampling` routes a non-greedy step to host sampling when `False` |
+| `supports_random_sampling_on_device` | `True` | Whether an enrolled device sampler can execute random sampling (temperature/top_p/top_k), not only greedy. `check_perform_device_sampling` routes a random-sampling step to host sampling when `False` |
 | `supports_async_decode` | `False` | Whether async scheduling may stay on. When `False`, the platform warns and clears `async_scheduling` |
 
 Absent keys default via `.get`. That is the live contract. Do not add
@@ -336,7 +336,7 @@ lifetime of the value:
   `check_and_update_config` configures every later test. Current names in
   `tests/conftest.py` `_TT_PLATFORM_CONFIG_ATTRS`:
   `_standard_dp_visible_device_groups`, `_standard_dp_mesh_grids`,
-  `sample_on_device_mode`, `supports_non_greedy_sampling_on_device`,
+  `sample_on_device_mode`, `supports_random_sampling_on_device`,
   `always_compat_sampling`, `_tt_vllm_config`.
   `always_compat_sampling` is assigned at runtime inside
   `_apply_check_and_update_config`, not declared as a `ClassVar` on the class

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ curl http://localhost:8000/v1/completions \
   }'
 ```
 
-Requests that cannot use TT on-device sampling automatically fall back to vLLM’s host-side sampling path. This fallback is selected per batch and requires no user configuration. One case: a model whose on-device sampler only implements greedy decoding (`model_capabilities['supports_non_greedy_sampling_on_device'] = False`) falls back to host sampling for the whole batch on any step that contains a non-greedy request.
+Requests that cannot use TT on-device sampling automatically fall back to vLLM’s host-side sampling path. This fallback is selected per batch and requires no user configuration. One case: a model whose on-device sampler only implements greedy decoding (`model_capabilities['supports_random_sampling_on_device'] = False`) falls back to host sampling for the whole batch on any step that contains a random-sampling request (temperature > 0).
 
 For vision models, start the server with the correct `--model`, then send a chat
 completion request with image content. Qwen 2.5-VL models can use either a

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ curl http://localhost:8000/v1/completions \
   }'
 ```
 
-Requests that cannot use TT on-device sampling automatically fall back to vLLM’s host-side sampling path. This fallback is selected per batch and requires no user configuration.
+Requests that cannot use TT on-device sampling automatically fall back to vLLM’s host-side sampling path. This fallback is selected per batch and requires no user configuration. One case: a model whose on-device sampler only implements greedy decoding (`model_capabilities['supports_non_greedy_sampling_on_device'] = False`) falls back to host sampling for the whole batch on any step that contains a non-greedy request.
 
 For vision models, start the server with the correct `--model`, then send a chat
 completion request with image content. Qwen 2.5-VL models can use either a

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -182,11 +182,11 @@ class TTModelRunner:
         # Whether to sample on device
         self.sample_on_device_mode = getattr(TTPlatform, "sample_on_device_mode", None)
         assert self.sample_on_device_mode in (None, "all", "decode_only")
-        # Whether the device sampler can execute a non-greedy request;
-        # check_perform_device_sampling falls back to host sampling when it
-        # can't.
-        self.supports_non_greedy_sampling_on_device = getattr(
-            TTPlatform, "supports_non_greedy_sampling_on_device", True
+        # Whether the device sampler supports random sampling (temperature
+        # != 0), not only greedy; check_perform_device_sampling falls back
+        # to host sampling when it can't.
+        self.supports_random_sampling_on_device = getattr(
+            TTPlatform, "supports_random_sampling_on_device", True
         )
         # Whether the model supports top-K logprobs on device.
         # Detected from model_type (available to all DP ranks without
@@ -1948,12 +1948,10 @@ class TTModelRunner:
         if has_always_host_only_sampling_params:
             return False
 
-        # An argmax-only device sampler can't execute a non-greedy request;
-        # one non-greedy row sends the whole step's batch to host sampling.
-        if (
-            not self.supports_non_greedy_sampling_on_device
-            and not input_batch.all_greedy
-        ):
+        # An argmax-only device sampler can't execute a random request; one
+        # such row (input_batch.all_greedy False) sends the whole step's
+        # batch to host sampling.
+        if not self.supports_random_sampling_on_device and not input_batch.all_greedy:
             return False
 
         # Structured outputs are not supported on device yet

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -182,6 +182,12 @@ class TTModelRunner:
         # Whether to sample on device
         self.sample_on_device_mode = getattr(TTPlatform, "sample_on_device_mode", None)
         assert self.sample_on_device_mode in (None, "all", "decode_only")
+        # Whether the device sampler can execute a non-greedy request;
+        # check_perform_device_sampling falls back to host sampling when it
+        # can't.
+        self.supports_non_greedy_sampling_on_device = getattr(
+            TTPlatform, "supports_non_greedy_sampling_on_device", True
+        )
         # Whether the model supports top-K logprobs on device.
         # Detected from model_type (available to all DP ranks without
         # requiring the model to be loaded). Models like gpt-oss-120b
@@ -1940,6 +1946,14 @@ class TTModelRunner:
             or bool(self.model_config.logits_processors)  # custom logitsprocs
         )
         if has_always_host_only_sampling_params:
+            return False
+
+        # An argmax-only device sampler can't execute a non-greedy request;
+        # one non-greedy row sends the whole step's batch to host sampling.
+        if (
+            not self.supports_non_greedy_sampling_on_device
+            and not input_batch.all_greedy
+        ):
             return False
 
         # Structured outputs are not supported on device yet

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1243,6 +1243,7 @@ class TTPlatform(Platform):
     _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
     _standard_dp_mesh_grids: ClassVar[dict[str, tuple[int, int]]] = {}
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
+    supports_non_greedy_sampling_on_device: ClassVar[bool] = True
     # Stored as a weakref in production so a torn-down engine's config stops
     # tripping the one-engine-per-process guard once nothing else holds it;
     # tests may seed a direct config object.
@@ -1779,9 +1780,9 @@ class TTPlatform(Platform):
             _install_block_output_reset_abort_patch()
             _install_block_output_pause_guard_patch()
 
-        # A model either supports the full on-device sampling pipeline or it
-        # doesn't — there is no greedy-only mode. Models opt in by setting
-        # `supports_sample_on_device` in their `model_capabilities` dict.
+        # `supports_sample_on_device` opts a model into the on-device sampling
+        # pipeline. Models opt in by setting it in their `model_capabilities`
+        # dict.
         supports_sample_on_device = (
             model_capabilities.get("supports_sample_on_device", False)
             if model_capabilities
@@ -1794,6 +1795,40 @@ class TTPlatform(Platform):
                 f"({model_class.__module__}) does not support on-device sampling. "
                 "Unset sample_on_device_mode or use a model that supports it."
             )
+
+        # Independently narrows an enrolled device sampler to greedy-only,
+        # for a device kernel that only implements argmax. Absence defaults
+        # to True so existing device-sampling models keep supporting
+        # non-greedy requests; check_perform_device_sampling reads the
+        # resolved value to fall back to host sampling otherwise.
+        supports_non_greedy_sampling_on_device = (
+            model_capabilities.get("supports_non_greedy_sampling_on_device", True)
+            if model_capabilities
+            else True
+        )
+        if not isinstance(supports_non_greedy_sampling_on_device, bool):
+            raise ValueError(
+                "model_capabilities['supports_non_greedy_sampling_on_device'] "
+                "must be a bool, got "
+                f"{supports_non_greedy_sampling_on_device!r}"
+            )
+        if is_block_output_model and not supports_non_greedy_sampling_on_device:
+            # _neutralize_model_owned_sampling fixes the cloned per-request
+            # temperature to 1.0, never 0.0, so input_batch.all_greedy is
+            # always False here. Combined with this capability set to
+            # False, every step would fall back to host sampling, which
+            # cannot build a block-output canvas.
+            raise ValueError(
+                "Block-output models commit output from a model-owned "
+                "sampler and cannot declare "
+                "supports_non_greedy_sampling_on_device=False: it would "
+                "force every step to host sampling, which cannot build a "
+                "block-output canvas. Remove the capability declaration for "
+                f"model {model_class.__name__} ({model_class.__module__})."
+            )
+        cls.supports_non_greedy_sampling_on_device = (
+            supports_non_greedy_sampling_on_device
+        )
         if is_block_output_model and sample_on_device_mode != "all":
             raise ValueError(
                 "Block-output models emit complete multi-token outputs from "

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1243,7 +1243,7 @@ class TTPlatform(Platform):
     _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
     _standard_dp_mesh_grids: ClassVar[dict[str, tuple[int, int]]] = {}
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
-    supports_non_greedy_sampling_on_device: ClassVar[bool] = True
+    supports_random_sampling_on_device: ClassVar[bool] = True
     # Stored as a weakref in production so a torn-down engine's config stops
     # tripping the one-engine-per-process guard once nothing else holds it;
     # tests may seed a direct config object.
@@ -1798,21 +1798,21 @@ class TTPlatform(Platform):
 
         # Independently narrows an enrolled device sampler to greedy-only,
         # for a device kernel that only implements argmax. Absence defaults
-        # to True so existing device-sampling models keep supporting
-        # non-greedy requests; check_perform_device_sampling reads the
-        # resolved value to fall back to host sampling otherwise.
-        supports_non_greedy_sampling_on_device = (
-            model_capabilities.get("supports_non_greedy_sampling_on_device", True)
+        # to True so existing device-sampling models keep supporting random
+        # requests (temperature != 0); check_perform_device_sampling reads
+        # the resolved value to fall back to host sampling otherwise.
+        supports_random_sampling_on_device = (
+            model_capabilities.get("supports_random_sampling_on_device", True)
             if model_capabilities
             else True
         )
-        if not isinstance(supports_non_greedy_sampling_on_device, bool):
+        if not isinstance(supports_random_sampling_on_device, bool):
             raise ValueError(
-                "model_capabilities['supports_non_greedy_sampling_on_device'] "
+                "model_capabilities['supports_random_sampling_on_device'] "
                 "must be a bool, got "
-                f"{supports_non_greedy_sampling_on_device!r}"
+                f"{supports_random_sampling_on_device!r}"
             )
-        if is_block_output_model and not supports_non_greedy_sampling_on_device:
+        if is_block_output_model and not supports_random_sampling_on_device:
             # _neutralize_model_owned_sampling fixes the cloned per-request
             # temperature to 1.0, never 0.0, so input_batch.all_greedy is
             # always False here. Combined with this capability set to
@@ -1821,14 +1821,12 @@ class TTPlatform(Platform):
             raise ValueError(
                 "Block-output models commit output from a model-owned "
                 "sampler and cannot declare "
-                "supports_non_greedy_sampling_on_device=False: it would "
+                "supports_random_sampling_on_device=False: it would "
                 "force every step to host sampling, which cannot build a "
                 "block-output canvas. Remove the capability declaration for "
                 f"model {model_class.__name__} ({model_class.__module__})."
             )
-        cls.supports_non_greedy_sampling_on_device = (
-            supports_non_greedy_sampling_on_device
-        )
+        cls.supports_random_sampling_on_device = supports_random_sampling_on_device
         if is_block_output_model and sample_on_device_mode != "all":
             raise ValueError(
                 "Block-output models emit complete multi-token outputs from "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ _TT_PLATFORM_CONFIG_ATTRS = (
     "_standard_dp_visible_device_groups",
     "_standard_dp_mesh_grids",
     "sample_on_device_mode",
+    "supports_non_greedy_sampling_on_device",
     "always_compat_sampling",
     "_tt_vllm_config",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ _TT_PLATFORM_CONFIG_ATTRS = (
     "_standard_dp_visible_device_groups",
     "_standard_dp_mesh_grids",
     "sample_on_device_mode",
-    "supports_non_greedy_sampling_on_device",
+    "supports_random_sampling_on_device",
     "always_compat_sampling",
     "_tt_vllm_config",
 )

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -291,14 +291,14 @@ class ARModel:
 class GreedyOnlyARModel:
     model_capabilities = {
         **ARModel.model_capabilities,
-        "supports_non_greedy_sampling_on_device": False,
+        "supports_random_sampling_on_device": False,
     }
 
 
 class InvalidSamplingCapabilityARModel:
     model_capabilities = {
         **ARModel.model_capabilities,
-        "supports_non_greedy_sampling_on_device": "no",
+        "supports_random_sampling_on_device": "no",
     }
 
 
@@ -338,8 +338,8 @@ def _patch_model_resolution(monkeypatch, model_class=BlockModel):
     )
 
 
-def test_startup_defaults_non_greedy_sampling_capability_to_supported(monkeypatch):
-    """A model that predates supports_non_greedy_sampling_on_device keeps
+def test_startup_defaults_random_sampling_capability_to_supported(monkeypatch):
+    """A model that predates supports_random_sampling_on_device keeps
     the established contract: its device sampler is assumed to support the
     full sampling pipeline, unrestricted."""
     config = _ar_config()
@@ -347,11 +347,11 @@ def test_startup_defaults_non_greedy_sampling_capability_to_supported(monkeypatc
 
     TTPlatform.check_and_update_config(config)
 
-    assert TTPlatform.supports_non_greedy_sampling_on_device is True
+    assert TTPlatform.supports_random_sampling_on_device is True
 
 
 def test_startup_resolves_greedy_only_sampling_capability(monkeypatch):
-    """A model that declares supports_non_greedy_sampling_on_device=False
+    """A model that declares supports_random_sampling_on_device=False
     gets that restriction recorded on TTPlatform, for
     check_perform_device_sampling to read per step."""
     config = _ar_config()
@@ -359,16 +359,14 @@ def test_startup_resolves_greedy_only_sampling_capability(monkeypatch):
 
     TTPlatform.check_and_update_config(config)
 
-    assert TTPlatform.supports_non_greedy_sampling_on_device is False
+    assert TTPlatform.supports_random_sampling_on_device is False
 
 
-def test_startup_rejects_non_boolean_non_greedy_sampling_capability(monkeypatch):
+def test_startup_rejects_non_boolean_random_sampling_capability(monkeypatch):
     config = _ar_config()
     _patch_model_resolution(monkeypatch, InvalidSamplingCapabilityARModel)
 
-    with pytest.raises(
-        ValueError, match="supports_non_greedy_sampling_on_device.*bool"
-    ):
+    with pytest.raises(ValueError, match="supports_random_sampling_on_device.*bool"):
         TTPlatform.check_and_update_config(config)
 
 
@@ -787,7 +785,7 @@ def test_startup_rejects_block_model_declaring_greedy_only_sampling(monkeypatch)
     class BlockModelClaimingGreedyOnly(BlockModel):
         model_capabilities = {
             **BlockModel.model_capabilities,
-            "supports_non_greedy_sampling_on_device": False,
+            "supports_random_sampling_on_device": False,
         }
 
     config = _config()
@@ -795,7 +793,7 @@ def test_startup_rejects_block_model_declaring_greedy_only_sampling(monkeypatch)
 
     with pytest.raises(
         ValueError,
-        match=r"supports_non_greedy_sampling_on_device.*capability declaration",
+        match=r"supports_random_sampling_on_device.*capability declaration",
     ):
         TTPlatform.check_and_update_config(config)
 

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -288,12 +288,32 @@ class ARModel:
     }
 
 
+class GreedyOnlyARModel:
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_non_greedy_sampling_on_device": False,
+    }
+
+
+class InvalidSamplingCapabilityARModel:
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_non_greedy_sampling_on_device": "no",
+    }
+
+
 class _WeakrefableConfig(SimpleNamespace):
     """SimpleNamespace itself cannot be weak-referenced; VllmConfig can."""
 
 
 def _weakrefable_config():
     return _WeakrefableConfig(**vars(_config()))
+
+
+def _ar_config():
+    config = _weakrefable_config()
+    config.model_config.hf_config.canvas_length = None
+    return config
 
 
 def _patch_model_resolution(monkeypatch, model_class=BlockModel):
@@ -316,6 +336,40 @@ def _patch_model_resolution(monkeypatch, model_class=BlockModel):
         "vllm.model_executor.model_loader.utils.get_model_architecture",
         lambda _model_config: (model_class, None),
     )
+
+
+def test_startup_defaults_non_greedy_sampling_capability_to_supported(monkeypatch):
+    """A model that predates supports_non_greedy_sampling_on_device keeps
+    the established contract: its device sampler is assumed to support the
+    full sampling pipeline, unrestricted."""
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, ARModel)
+
+    TTPlatform.check_and_update_config(config)
+
+    assert TTPlatform.supports_non_greedy_sampling_on_device is True
+
+
+def test_startup_resolves_greedy_only_sampling_capability(monkeypatch):
+    """A model that declares supports_non_greedy_sampling_on_device=False
+    gets that restriction recorded on TTPlatform, for
+    check_perform_device_sampling to read per step."""
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, GreedyOnlyARModel)
+
+    TTPlatform.check_and_update_config(config)
+
+    assert TTPlatform.supports_non_greedy_sampling_on_device is False
+
+
+def test_startup_rejects_non_boolean_non_greedy_sampling_capability(monkeypatch):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, InvalidSamplingCapabilityARModel)
+
+    with pytest.raises(
+        ValueError, match="supports_non_greedy_sampling_on_device.*bool"
+    ):
+        TTPlatform.check_and_update_config(config)
 
 
 def test_startup_stores_block_capability_and_enforces_contract(monkeypatch):
@@ -721,6 +775,27 @@ def test_startup_rejects_block_model_declaring_prefix_caching(monkeypatch):
     with pytest.raises(
         ValueError,
         match=r"supports_prefix_caching.*capability declaration",
+    ):
+        TTPlatform.check_and_update_config(config)
+
+
+def test_startup_rejects_block_model_declaring_greedy_only_sampling(monkeypatch):
+    """A block-output request's cloned SamplingParams is always neutralized
+    to a non-greedy temperature, so declaring this capability False would
+    force every step to host sampling, which cannot build a canvas."""
+
+    class BlockModelClaimingGreedyOnly(BlockModel):
+        model_capabilities = {
+            **BlockModel.model_capabilities,
+            "supports_non_greedy_sampling_on_device": False,
+        }
+
+    config = _config()
+    _patch_model_resolution(monkeypatch, BlockModelClaimingGreedyOnly)
+
+    with pytest.raises(
+        ValueError,
+        match=r"supports_non_greedy_sampling_on_device.*capability declaration",
     ):
         TTPlatform.check_and_update_config(config)
 

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -319,8 +319,48 @@ def test_apply_sampled_token_updates_request_state():
 # region Device sampling eligibility
 
 
+def _runner_for_device_sampling(
+    batch: InputBatch, supports_random: bool
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_batch=batch,
+        sample_on_device_mode="all",
+        num_devices=1,
+        tt_data_parallel_size=1,
+        model_config=SimpleNamespace(logits_processors=None),
+        supports_topk_logprobs=False,
+        supports_random_sampling_on_device=supports_random,
+    )
+
+
+def _batch_with_requests(*sampling_params: SamplingParams) -> InputBatch:
+    """Creates a batch with one request per given SamplingParams."""
+    batch = InputBatch(
+        max_num_reqs=MAX_NUM_REQS,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_batched_tokens=MAX_MODEL_LEN,
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[BLOCK_SIZE],
+        kernel_block_sizes=[BLOCK_SIZE],
+    )
+    for i, params in enumerate(sampling_params):
+        batch.add_request(
+            CachedRequestState(
+                req_id=f"r{i}",
+                prompt_token_ids=list(range(4)),
+                mm_features=None,
+                sampling_params=params,
+                generator=None,
+                block_ids=([0],),
+                num_computed_tokens=4,
+                output_token_ids=[],
+            )
+        )
+    return batch
+
+
 @pytest.mark.parametrize(
-    "temperature, supports_non_greedy, expect_device_sampling",
+    "temperature, supports_random, expect_device_sampling",
     [
         (0.0, True, True),
         (0.0, False, True),
@@ -330,17 +370,17 @@ def test_apply_sampled_token_updates_request_state():
     ids=[
         "greedy-full",
         "greedy-restricted",
-        "non-greedy-full",
-        "non-greedy-restricted",
+        "random-full",
+        "random-restricted",
     ],
 )
-def test_check_perform_device_sampling_routes_non_greedy_to_host_when_restricted(
+def test_check_perform_device_sampling_routes_random_to_host_when_restricted(
     temperature: float,
-    supports_non_greedy: bool,
+    supports_random: bool,
     expect_device_sampling: bool,
 ):
     """A device sampler that only implements argmax must not receive a
-    non-greedy step. check_perform_device_sampling routes that step to host
+    random step. check_perform_device_sampling routes that step to host
     sampling instead, the same way it already does for bad_words, min_p, and
     every other always-host-only sampling control."""
     batch, _ = _batch_with_one_request(
@@ -349,21 +389,43 @@ def test_check_perform_device_sampling_routes_non_greedy_to_host_when_restricted
         num_computed_tokens=4,
         sampling_params=SamplingParams(temperature=temperature),
     )
-    runner = SimpleNamespace(
-        input_batch=batch,
-        sample_on_device_mode="all",
-        num_devices=1,
-        tt_data_parallel_size=1,
-        model_config=SimpleNamespace(logits_processors=None),
-        supports_topk_logprobs=False,
-        supports_non_greedy_sampling_on_device=supports_non_greedy,
-    )
 
     result = TTModelRunner.check_perform_device_sampling(
-        runner, is_decode=True, has_structured_outputs=False
+        _runner_for_device_sampling(batch, supports_random),
+        is_decode=True,
+        has_structured_outputs=False,
     )
 
     assert result is expect_device_sampling
+
+
+def test_check_perform_device_sampling_routes_mixed_batch_to_host_when_restricted():
+    """One random row in an otherwise-greedy batch sends the whole step's
+    batch to host sampling for a greedy-only device sampler; an all-greedy
+    batch of the same size still uses the device."""
+    mixed_batch = _batch_with_requests(
+        SamplingParams(temperature=0.0), SamplingParams(temperature=1.0)
+    )
+    all_greedy_batch = _batch_with_requests(
+        SamplingParams(temperature=0.0), SamplingParams(temperature=0.0)
+    )
+
+    assert (
+        TTModelRunner.check_perform_device_sampling(
+            _runner_for_device_sampling(mixed_batch, supports_random=False),
+            is_decode=True,
+            has_structured_outputs=False,
+        )
+        is False
+    )
+    assert (
+        TTModelRunner.check_perform_device_sampling(
+            _runner_for_device_sampling(all_greedy_batch, supports_random=False),
+            is_decode=True,
+            has_structured_outputs=False,
+        )
+        is True
+    )
 
 
 # endregion Device sampling eligibility

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -29,6 +29,7 @@ def _batch_with_one_request(
     prompt_len: int,
     output_len: int,
     num_computed_tokens: int,
+    sampling_params: SamplingParams | None = None,
 ) -> tuple[InputBatch, CachedRequestState]:
     """Creates a batch with a single request, for testing purposes."""
     batch = InputBatch(
@@ -43,7 +44,7 @@ def _batch_with_one_request(
         req_id="r",
         prompt_token_ids=list(range(prompt_len)),
         mm_features=None,
-        sampling_params=SamplingParams(temperature=0.0),
+        sampling_params=sampling_params or SamplingParams(temperature=0.0),
         generator=None,
         block_ids=([0],),
         num_computed_tokens=num_computed_tokens,
@@ -314,3 +315,55 @@ def test_apply_sampled_token_updates_request_state():
 
 
 # endregion Output state
+
+# region Device sampling eligibility
+
+
+@pytest.mark.parametrize(
+    "temperature, supports_non_greedy, expect_device_sampling",
+    [
+        (0.0, True, True),
+        (0.0, False, True),
+        (1.0, True, True),
+        (1.0, False, False),
+    ],
+    ids=[
+        "greedy-full",
+        "greedy-restricted",
+        "non-greedy-full",
+        "non-greedy-restricted",
+    ],
+)
+def test_check_perform_device_sampling_routes_non_greedy_to_host_when_restricted(
+    temperature: float,
+    supports_non_greedy: bool,
+    expect_device_sampling: bool,
+):
+    """A device sampler that only implements argmax must not receive a
+    non-greedy step. check_perform_device_sampling routes that step to host
+    sampling instead, the same way it already does for bad_words, min_p, and
+    every other always-host-only sampling control."""
+    batch, _ = _batch_with_one_request(
+        prompt_len=4,
+        output_len=0,
+        num_computed_tokens=4,
+        sampling_params=SamplingParams(temperature=temperature),
+    )
+    runner = SimpleNamespace(
+        input_batch=batch,
+        sample_on_device_mode="all",
+        num_devices=1,
+        tt_data_parallel_size=1,
+        model_config=SimpleNamespace(logits_processors=None),
+        supports_topk_logprobs=False,
+        supports_non_greedy_sampling_on_device=supports_non_greedy,
+    )
+
+    result = TTModelRunner.check_perform_device_sampling(
+        runner, is_decode=True, has_structured_outputs=False
+    )
+
+    assert result is expect_device_sampling
+
+
+# endregion Device sampling eligibility


### PR DESCRIPTION
## TL;DR

Route a non-greedy request against a greedy-only on-device sampler to vLLM's existing per-step host-sampling fallback, instead of rejecting the request at the API boundary. Alternative to #111, same underlying capability, different enforcement point; see Details for why.

## Details

**Problem.** Some TT models perform sampling on the Tenstorrent device rather than the host. A device sampler that only implements greedy decoding (argmax) cannot execute a `temperature`/`top_p`/`top_k` request. Before either this PR or #111, such a request reached the device unchecked and crashed `EngineCore` (observed incident, per #111: GPT-OSS-120B generated Quetzal, HTTP 500, engine exit, on a `temperature=1.0` request).

**Why not #111's approach.** #111 fixes the same incident by adding a `model_capabilities` key, `supports_non_greedy_sampling_on_device`, and rejecting the offending request in `TTPlatform.validate_request`. Reviewing that approach surfaced two defects specific to enforcing it there:

- `TTPlatform.validate_request` only runs through vLLM's Python HTTP frontend. An existing comment in `platform.py` states this: "The Rust frontend handles HTTP outside Python, so nothing runs `TTPlatform.validate_request`." For a non-block-output model (the shape of the model in the reported incident) with `VLLM_USE_RUST_FRONTEND=1`, the new check in #111 never runs at all, and the original crash can still happen.
- The resolved capability is read live off a process-global `TTPlatform` class attribute on every request. Two AR engines sharing one process (this plugin's own comment: "AR engines may share a process freely") can stomp on each other's declared capability.

**This PR's approach.** Same `model_capabilities` key (`supports_non_greedy_sampling_on_device`, default `True` for backward compatibility), same resolution in `TTPlatform._apply_check_and_update_config`. The difference is where it's enforced: `TTModelRunner.check_perform_device_sampling` (`model_runner.py`) already decides, per step, whether a batch can use on-device sampling or must fall back to host sampling, for several other unsupported features (`bad_words`, `min_p`, `logit_bias`, `allowed_token_ids`, `min_tokens`, custom logits processors, structured outputs, unsupported logprobs shapes). This PR adds one more condition there: if the model is greedy-only and any active row in the batch is non-greedy (`InputBatch.all_greedy`, already defined, previously unused), fall back to host sampling for that step, exactly like every other case already handled by that method.

Side effects of moving the check there, both verified by reading the code, not asserted:

- `check_perform_device_sampling` runs in the model runner's per-step execution path unconditionally, so this works under the Rust frontend too, not just the Python frontend.
- `TTModelRunner.__init__` snapshots the capability once, into an instance attribute, at worker construction (`self.supports_non_greedy_sampling_on_device = getattr(TTPlatform, ..., True)`), the same pattern already used for `sample_on_device_mode`. A later-starting sibling engine's class-attribute mutation does not retroactively change an already-constructed instance's snapshot.

**Trade-off, stated plainly.** `check_perform_device_sampling` returns one bool per step's batch, not per request, matching its existing contract for every other host-only condition. If one row in a step's batch is non-greedy against a greedy-only model, the whole batch (including greedy rows sharing that step) samples on host for that step. That costs the greedy rows a step's worth of device-sampling speed; it does not cost correctness. #111's rejection design avoids this entirely, at the cost of rejecting requests that this design instead admits.

**Guard added that #111 does not need.** A block-output model's per-request `SamplingParams` clone is always neutralized to a fixed, non-greedy `temperature=1.0` (`_neutralize_model_owned_sampling`), so `InputBatch.all_greedy` is always `False` for one. Combined with `supports_non_greedy_sampling_on_device=False`, every step would silently fall back to host sampling, and host sampling cannot build a block-output canvas (existing test: `test_startup_requires_device_sampling_for_block_models`). Added a startup-time `ValueError` for that combination, matching this repo's existing convention of raising when a declared capability contradicts block-output status.

**Documentation.** Updated `AGENTS.md`'s `model_capabilities` table and `_TT_PLATFORM_CONFIG_ATTRS` list, and added one sentence to `README.md`'s existing host-sampling-fallback paragraph naming this case.

AI assistance was used to review #111 and to design and implement this alternative. Posting for reviewer scrutiny, not asserting it is merge-ready as-is.

## Related Artifacts

Alternative to #111 (same incident, same new `model_capabilities` key, different enforcement point; see Details). No tracked issue number; the motivating incident is documented in #111's own description.

## Validation

Host-only; no Tenstorrent hardware in this environment. Device-side validation (does host sampling actually run correctly for a real greedy-only device-sampling model under this fallback) is outstanding and should happen before merge, same caveat #111 itself carries.

```text
PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/test_block_request_validation.py tests/test_model_runner.py -v
91 passed, 14 warnings

PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/ --ignore=tests/tt
376 passed, 14 warnings

pre-commit run --files AGENTS.md README.md src/vllm_tt_plugin/platform.py src/vllm_tt_plugin/model_runner.py tests/conftest.py tests/test_block_request_validation.py tests/test_model_runner.py
trim trailing whitespace.....Passed
fix end of files.............Passed
check for merge conflicts....Passed
ruff check....................Passed
ruff format...................Passed
```

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.