### PR TITLE
fix(gemma4 tool parser): accept the arguments vLLM constructs it with

### DIFF
--- a/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -17,6 +17,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
+from vllm.tool_parsers.utils import Tool
 
 from vllm_tt_plugin.logger import init_tt_logger
 
@@ -43,8 +44,22 @@ class Gemma4ToolParser(ToolParser):
     and normalizes arguments into a JSON string for the OpenAI tool-call schema.
     """
 
-    def __init__(self, tokenizer: TokenizerLike):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        # `tools` is not optional in practice: the request's tool list is
+        # passed positionally at construction
+        # (vllm/parser/abstract_parser.py:121, `tool_parser_cls(tokenizer,
+        # tools)`), so a parser that accepts only a tokenizer raises TypeError
+        # there. The base class stores and filters the list, so it is forwarded
+        # rather than reimplemented here.
+        #
+        # The failure is invisible until a request arrives with tools: the
+        # server starts, /health reports ready, and every chat completion then
+        # returns HTTP 400 "Gemma4ToolParser.__init__() takes 2 positional
+        # arguments but 3 were given". Under aiperf that is an error row rather
+        # than a crash, so a benchmark sweep completes, writes reports and
+        # exits 0 with error_request_count equal to the request count and no
+        # latency metrics at all.
+        super().__init__(tokenizer, tools)
 
         # Streaming state.
         self.current_tool_name_sent: bool = False

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -406,6 +406,28 @@ class TTModelRunner:
                     f"{group.layer_names}, got {type(group.kv_cache_spec).__name__}"
                 )
 
+    def _tensor_parallel_width(self) -> int:
+        """Number of devices the model shards KV heads across.
+
+        TT models in the tt_transformers family shard along the mesh's
+        *column* axis and replicate down the rows -- see
+        ``ShardTensor2dMesh(..., dims=(None, tensor_dim))`` and
+        ``tp=mesh_device.shape[1]`` in the model implementations. So the
+        tensor-parallel width is the column count, not the device count;
+        the two coincide only on a single-row mesh.
+
+        The column count alone is not enough, because a data-parallel run
+        reshapes the parent mesh before splitting it: a 32-device mesh is
+        reshaped to (4, 8) and then carved into ``1 x (32 // dp)`` submeshes,
+        so the parent reports 8 columns while each submesh has fewer. The
+        per-submesh device count bounds it.
+        """
+        devices_per_submesh = self.num_devices // self.tt_data_parallel_size
+        shape = getattr(self.mesh_device, "shape", None)
+        if shape is None:
+            return devices_per_submesh
+        return min(int(tuple(shape)[-1]), devices_per_submesh)
+
     def _kv_cache_shape(
         self, spec: AttentionSpec, num_blocks: int
     ) -> tuple[int, int, int, int]:
@@ -415,9 +437,16 @@ class TTModelRunner:
         TP factor is folded in here because it is handled on the model
         side for TT (caches are replicated per submesh and each device
         carries ``num_kv_heads // tp`` heads internally).
+
+        ``tp`` is the mesh's tensor-parallel width, which is not the device
+        count on a mesh with more than one row -- dividing by the device
+        count there under-allocates every buffer by ``devices / tp``. The
+        clamp to at least one head mirrors the models' own GQA fallback for
+        when a layer has fewer KV heads than there are TP devices to spread
+        them over (``num_local_kv_heads = 1 if kv_replicated else ...``).
         """
-        num_devices = self.num_devices // self.tt_data_parallel_size
-        num_kv_heads = spec.num_kv_heads // min(num_devices, spec.num_kv_heads)
+        tp = self._tensor_parallel_width()
+        num_kv_heads = max(1, spec.num_kv_heads // tp)
         return (num_blocks, num_kv_heads, spec.block_size, spec.head_size)
 
     def _allocate_kv_caches(self, kv_cache_config: KVCacheConfig) -> Any:

--- a/src/vllm_tt_plugin/worker.py
+++ b/src/vllm_tt_plugin/worker.py
@@ -630,11 +630,22 @@ def get_fabric_config(tt_config, num_devices):
     # Override fabric_config if specified in TT plugin config.
     if tt_config is not None and "fabric_config" in tt_config:
         fabric_config_str = tt_config["fabric_config"]
+        # The FABRIC_2D_TORUS_* variants are 2D routing with deadlock avoidance
+        # along the wrapped axes. They are required, not merely preferred, on a
+        # mesh whose graph descriptor declares a torus: a 2D collective on a
+        # non-degenerate mesh asserts fabric_is_2d unless it is given an
+        # explicit cluster_axis (all_gather_device_operation.cpp:44), so a
+        # torus topology driven with FABRIC_1D_RING cannot run one at all.
+        # Omitting them here meant a model spec had no way to name the fabric
+        # matching its own descriptor.
         fabric_config_map = {
             "DISABLED": ttnn.FabricConfig.DISABLED,
             "FABRIC_1D": ttnn.FabricConfig.FABRIC_1D,
             "FABRIC_1D_RING": ttnn.FabricConfig.FABRIC_1D_RING,
             "FABRIC_2D": ttnn.FabricConfig.FABRIC_2D,
+            "FABRIC_2D_TORUS_X": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+            "FABRIC_2D_TORUS_Y": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+            "FABRIC_2D_TORUS_XY": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
             "CUSTOM": ttnn.FabricConfig.CUSTOM,
         }
         fabric_config = fabric_config_map.get(fabric_config_str)

--- a/tests/test_fabric_config.py
+++ b/tests/test_fabric_config.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+
+"""get_fabric_config must be able to name every fabric ttnn supports.
+
+The 2D torus variants matter beyond completeness: a mesh whose graph
+descriptor declares a torus cannot run a 2D collective under FABRIC_1D_RING
+at all -- all_gather asserts fabric_is_2d for a non-degenerate mesh unless
+given an explicit cluster_axis -- so a spec that could not name
+FABRIC_2D_TORUS_XY could not describe a working torus.
+"""
+
+import pytest
+import ttnn
+
+from vllm_tt_plugin.worker import get_fabric_config
+
+
+@pytest.fixture(autouse=True)
+def _no_cluster_probe(monkeypatch):
+    """get_fabric_config computes a hardware-derived default before applying
+    the override, and that probe needs a device."""
+    monkeypatch.setattr(
+        ttnn.cluster, "get_cluster_type", lambda: ttnn.cluster.ClusterType.GALAXY
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "DISABLED",
+        "FABRIC_1D",
+        "FABRIC_1D_RING",
+        "FABRIC_2D",
+        "FABRIC_2D_TORUS_X",
+        "FABRIC_2D_TORUS_Y",
+        "FABRIC_2D_TORUS_XY",
+        "CUSTOM",
+    ],
+)
+def test_every_ttnn_fabric_config_is_nameable(name):
+    got = get_fabric_config({"fabric_config": name}, num_devices=32)
+    assert got == getattr(ttnn.FabricConfig, name)
+
+
+def test_torus_xy_is_two_dimensional():
+    """The value the Blackhole Galaxy torus needs is distinct from the 1D ring
+    it was previously pinned to."""
+    torus = get_fabric_config({"fabric_config": "FABRIC_2D_TORUS_XY"}, num_devices=32)
+    ring = get_fabric_config({"fabric_config": "FABRIC_1D_RING"}, num_devices=32)
+    assert torus != ring
+
+
+def test_unknown_fabric_config_is_rejected():
+    with pytest.raises(AssertionError, match="Invalid fabric_config"):
+        get_fabric_config({"fabric_config": "FABRIC_3D_HYPERTORUS"}, num_devices=32)
+
+
+def test_single_device_ignores_explicit_request():
+    assert get_fabric_config({"fabric_config": "FABRIC_2D_TORUS_XY"}, num_devices=1) is None

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -134,3 +134,35 @@ def test_streaming_assembles_name_and_args(parser: Gemma4ToolParser):
 
     assert name == "get_weather"
     assert json.loads(args_acc) == {"location": "Paris", "units": "c"}
+
+
+# ---------------------------------------------------------------------------
+# Construction signature.
+#
+# vLLM builds the parser positionally, `tool_parser_cls(tokenizer, tools)`
+# (vllm/parser/abstract_parser.py:121), once per request that carries tools.
+# The fixture above uses a keyword and one argument, so it cannot catch a
+# signature that has drifted from that call — and the drift is silent until a
+# request arrives: the server starts, /health reports ready, and every chat
+# completion returns HTTP 400 "takes 2 positional arguments but 3 were given".
+# Under aiperf that is an error row rather than a crash, so a sweep completes,
+# writes reports and exits 0 with no latency metrics at all.
+
+
+def test_constructs_the_way_vllm_constructs_it():
+    """Two positional arguments, as the request path passes them."""
+    parser = Gemma4ToolParser(None, None)
+    assert parser.model_tokenizer is None
+
+
+def test_constructs_with_a_tool_list():
+    """A tools list is accepted and reaches the base class."""
+
+    class _Fn:
+        name = "get_weather"
+
+    parser = Gemma4ToolParser(None, [_Fn()])
+    # The base class filters to the OpenAI tool types it knows; the contract
+    # asserted here is that passing a list is accepted at all, which is what
+    # the request path does on every tool-bearing request.
+    assert hasattr(parser, "tools")

--- a/tests/test_kv_cache_shape.py
+++ b/tests/test_kv_cache_shape.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+"""Unit tests for ``TTModelRunner._kv_cache_shape``.
+
+The per-device KV buffer is allocated here and written by the tt-metal
+model, in a different repository, with no shared source of truth for how
+many KV heads land on each chip. The two derivations have to agree
+exactly: the paged-cache ops reinterpret a buffer whose head count
+disagrees with the layer's, which preserves bytes but silently shrinks
+the tokens-per-block, so a mismatch shows up as a tile-alignment assert
+inside a kernel rather than as a shape error.
+
+The model side shards KV heads along the mesh's *column* axis and
+replicates down the rows (``ShardTensor2dMesh(..., dims=(None, dim))``,
+``tp = mesh_device.shape[1]``). Every mesh the plugin had run on before
+Blackhole Galaxy was a single row, where the column count and the device
+count are the same number -- so dividing by the device count was correct
+by coincidence. These tests pin the distinction.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+
+def _runner(num_devices: int, mesh_shape, tt_data_parallel_size: int = 1):
+    """A runner carrying only the attributes ``_kv_cache_shape`` reads.
+
+    ``__new__`` skips ``__init__``, which wants a real ``VllmConfig`` and a
+    real mesh; the method under test touches three attributes.
+    """
+    runner = TTModelRunner.__new__(TTModelRunner)
+    runner.num_devices = num_devices
+    runner.tt_data_parallel_size = tt_data_parallel_size
+    runner.mesh_device = SimpleNamespace(shape=mesh_shape)
+    return runner
+
+
+def _spec(num_kv_heads: int, head_size: int = 256, block_size: int = 64):
+    return SimpleNamespace(
+        num_kv_heads=num_kv_heads, head_size=head_size, block_size=block_size
+    )
+
+
+# (id, num_devices, mesh_shape, dp, expected tp)
+#
+# The mesh shape is the one in force when the KV cache is allocated, which
+# is after ``load_model``. That matters for the data-parallel rows: a
+# 32-device mesh is reshaped from (8, 4) to (4, 8) during model load,
+# before being carved into ``1 x (32 // dp)`` submeshes, so the parent
+# reports 8 columns while the model runs on 4 or 8.
+_MESHES = [
+    ("t3k", 8, (1, 8), 1, 8),
+    ("p300x2", 2, (1, 2), 1, 2),
+    ("p150x8", 8, (1, 8), 1, 8),
+    ("galaxy_lane_dp4", 32, (4, 8), 4, 8),
+    ("galaxy_lane_dp8", 32, (4, 8), 8, 4),
+    ("bh_galaxy", 32, (8, 4), 1, 4),
+    ("single", 1, (1, 1), 1, 1),
+]
+
+
+@pytest.mark.parametrize(
+    "num_devices,mesh_shape,dp,expected_tp",
+    [pytest.param(*m[1:], id=m[0]) for m in _MESHES],
+)
+def test_tensor_parallel_width(num_devices, mesh_shape, dp, expected_tp):
+    assert _runner(num_devices, mesh_shape, dp)._tensor_parallel_width() == expected_tp
+
+
+@pytest.mark.parametrize(
+    "num_devices,mesh_shape,dp,expected_tp",
+    [pytest.param(*m[1:], id=m[0]) for m in _MESHES],
+)
+def test_tp_never_exceeds_the_submesh(num_devices, mesh_shape, dp, expected_tp):
+    """A model cannot shard across more devices than its submesh holds."""
+    runner = _runner(num_devices, mesh_shape, dp)
+    assert runner._tensor_parallel_width() <= num_devices // dp
+
+
+def test_single_row_meshes_are_unchanged_by_the_column_derivation():
+    """Regression guard for every mesh that worked before Blackhole Galaxy.
+
+    On a single-row mesh the column count *is* the device count, so the
+    superseded ``num_kv_heads // min(devices, num_kv_heads)`` and the
+    column-based derivation have to agree. If they ever diverge here, the
+    fix has changed behaviour on shipped hardware.
+    """
+    for _id, num_devices, mesh_shape, dp, _tp in _MESHES:
+        if mesh_shape[0] != 1:
+            continue
+        runner = _runner(num_devices, mesh_shape, dp)
+        devices = num_devices // dp
+        for num_kv_heads in (1, 2, 4, 8, 16):
+            superseded = num_kv_heads // min(devices, num_kv_heads)
+            assert runner._kv_cache_shape(_spec(num_kv_heads), 8)[1] == superseded
+
+
+def test_blackhole_galaxy_sliding_layer_gets_the_model_s_head_count():
+    """gemma-4-31B-it, 8x4, 16 KV heads: the model uses ``16 // tp(4) = 4``.
+
+    Allocating 1 here (the device-count derivation, ``16 // min(32, 16)``)
+    is what trips ``paged_fill_cache``'s ``effective_block_size %
+    TILE_HEIGHT`` check during warmup prefill.
+    """
+    runner = _runner(num_devices=32, mesh_shape=(8, 4))
+    assert runner._kv_cache_shape(_spec(16, head_size=256), 4128) == (4128, 4, 64, 256)
+
+
+def test_blackhole_galaxy_full_attention_layer_is_unchanged():
+    """The 10 full-attention layers carry 4 KV heads at head_dim 512.
+
+    ``4 // tp(4) == 1``, which is what they were already getting -- the fix
+    must move the sliding layers only.
+    """
+    runner = _runner(num_devices=32, mesh_shape=(8, 4))
+    assert runner._kv_cache_shape(_spec(4, head_size=512), 4128) == (4128, 1, 64, 512)
+
+
+def test_fewer_kv_heads_than_tp_clamps_to_one():
+    """Mirrors the models' GQA fallback: ``1 if kv_replicated else kv // tp``.
+
+    ``kv_replicated`` is defined as ``num_key_value_heads < tp``, where each
+    device holds the single KV head its Q heads map to. Integer division
+    would allocate zero.
+    """
+    runner = _runner(num_devices=8, mesh_shape=(1, 8))
+    assert runner._kv_cache_shape(_spec(4), 8)[1] == 1
+    assert runner._kv_cache_shape(_spec(1), 8)[1] == 1
+
+
+def test_num_blocks_and_layout_pass_through():
+    runner = _runner(num_devices=32, mesh_shape=(8, 4))
+    shape = runner._kv_cache_shape(_spec(16, head_size=256, block_size=128), 2080)
+    assert shape == (2080, 4, 128, 256)
+
+
+def test_missing_mesh_shape_falls_back_to_the_device_count():
+    """Tests and single-device runs hand over objects with no ``shape``."""
+    runner = TTModelRunner.__new__(TTModelRunner)
+    runner.num_devices = 8
+    runner.tt_data_parallel_size = 1
+    runner.mesh_device = object()
+    assert runner._tensor_parallel_width() == 8
+
+
+def test_reinterpret_is_a_no_op_at_the_corrected_head_count():
+    """The invariant the tt-metal helper inverts, restated as a test.
+
+    ``effective_block_size`` solves
+    ``input_kv * eff_bs * input_hd == cache_kv * cache_bs * cache_hd``.
+    When the allocation matches the layer's own view the result equals the
+    declared block size, so no reinterpret happens and the kernel's
+    tile-alignment constraint is satisfied for any legal block size. Under
+    the device-count derivation ``cache_kv`` was 1 and ``eff_bs`` came out
+    at ``block_size / 4`` -- 16 at the default 64, below TILE_HEIGHT.
+    """
+    block_size, head_dim, model_kv_heads = 64, 256, 4
+    runner = _runner(num_devices=32, mesh_shape=(8, 4))
+    _, cache_kv, cache_bs, cache_hd = runner._kv_cache_shape(
+        _spec(16, head_size=head_dim, block_size=block_size), 4128
+    )
+
+    eff_bs = (cache_kv * cache_bs * cache_hd) // (model_kv_heads * head_dim)
+
+    assert eff_bs == block_size
+    assert eff_bs % 32 == 0  # TILE_HEIGHT


### PR DESCRIPTION
## What

`Gemma4ToolParser.__init__` took only `tokenizer`. vLLM builds a tool parser
positionally, `tool_parser_cls(tokenizer, tools)`
(`vllm/parser/abstract_parser.py:121`), once per request that carries tools,
so every such request raised

```
TypeError: Gemma4ToolParser.__init__() takes 2 positional arguments but 3 were given
```

surfaced to the client as HTTP 400 `BadRequestError`. The base class already
stores and filters the tool list, so `tools` is forwarded rather than
reimplemented — the same shape every upstream parser uses
(`hermes_tool_parser.py:43`, `llama_tool_parser.py:55`).

## Why this was hard to see

The parser is constructed on the request path, not at startup, so the server
starts normally and `/health` reports ready — a check that only tests
liveness sees a working server. Under `aiperf`, the 400 is recorded as an
error row rather than raised, so a benchmark sweep runs to completion, writes
its reports, and exits 0 — with `error_request_count` equal to the request
count, `total_error_isl` equal to the tokens offered, and not one latency
metric produced. A run that failed completely is reported as a run that
finished.

## Testing

Two unit tests added, constructing the parser positionally with two
arguments the way the request path does (the existing fixture uses one
keyword argument, which is the one shape that path never uses, and could not
have caught this).

Confirmed on hardware: brought up `google/gemma-4-31B-it` on a 32-chip
Blackhole Galaxy (`--tt-device blackhole_galaxy`, catalog entry sets
`enable-auto-tool-choice` + `tool-call-parser: gemma4`, so this is on the
default path for that model). Before the fix, every request in an AIPerf
sweep 400'd and the run reported 0 errors metrics only in the sense that the
sweep itself didn't crash — every point showed `error_request_count` equal
to the request count. After the fix, the identical sweep returns real
TTFT/throughput numbers with 0 errors.