### PR TITLE
[feat] Speculative decoding: contract types and a conformant host stand-in model

### DIFF
--- a/src/vllm_tt_plugin/spec_decode.py
+++ b/src/vllm_tt_plugin/spec_decode.py
@@ -3,16 +3,22 @@
 """Contract types for speculative decoding between the runner and a TT model.
 
 The contract these types encode is specified in
-https://github.com/tenstorrent/vllm-tt-plugin/issues/110. Nothing here reads a
-`model_capabilities` key or admits a configuration; this module is the wire
-surface only, so a model class and the runner can agree on shapes and modes
-before either side implements a step of the loop.
+https://github.com/tenstorrent/vllm-tt-plugin/issues/110. This module holds the
+wire surface and the validation of the values that cross it, so a model class
+and the runner can agree on shapes and modes before either side implements a
+step of the loop. It reads no ``model_capabilities`` key and admits no
+configuration: ``normalize_declared_values`` validates a declaration a caller
+has already read, and lives here next to the constant sets it validates.
 
-Two properties of the contract are enforced here rather than left to each
-caller, because both were ambiguous enough in earlier revisions to produce
-off-by-one and shape errors: the inclusive range a valid ``accepted_counts``
-entry lies in, and the pairing between a ``spec_mode`` and the fields a verify
-return must carry for it.
+Per the contract, one step is verify then propose: the runner calls
+``decode_forward`` over the ``[B, 1+K]`` candidate block, walks acceptance, and
+calls ``propose_draft_tokens`` with that same step's hidden state.
+
+Two properties are enforced by these types rather than left to each caller,
+because leaving either to a caller invites an off-by-one or a shape error that
+only surfaces inside an accept walk: the inclusive range a valid
+``accepted_counts`` entry lies in, and the pairing between a ``spec_mode`` and
+the fields a verify return must carry for it.
 """
 
 from collections.abc import Sequence
@@ -22,10 +28,25 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import torch
 
-# Accept modes, named by what the verify call returns rather than by which side
-# performs acceptance. Naming the performer cannot describe a device argmax
-# followed by a host walk, which is what both existing tt-metal
+# Accept modes. The first two are named for what the verify call returns, which
+# is what the runner branches on; naming the performer instead cannot describe a
+# device argmax followed by a host walk, which is what both existing tt-metal
 # implementations do.
+#
+#   "logits"       returns logits [B, 1+K, V]. The host walks acceptance, so
+#                  this is the only mode that can serve a request needing host
+#                  arbitration: structured output, host logits processors,
+#                  min_p, logit_bias, bad_words, allowed_token_ids, min_tokens
+#                  or logprobs. It pays a [B, 1+K, V] readback.
+#   "argmax_ids"   returns the verify argmax ids [B, 1+K]. The host walks
+#                  acceptance greedily, comparing ids, so no logits cross. This
+#                  mode is greedy only.
+#   "fused_sample" returns accepted ids and counts. The device accepts and
+#                  samples: rejection sampling, the residual correction and the
+#                  bonus token all happen there, which is the fusion the name
+#                  describes. It is the only mode that may be followed by a
+#                  verify with accepted_counts=None, because it is the only one
+#                  that leaves an authoritative count on the device.
 ACCEPT_MODE_LOGITS = "logits"
 ACCEPT_MODE_ARGMAX_IDS = "argmax_ids"
 ACCEPT_MODE_FUSED_SAMPLE = "fused_sample"
@@ -64,8 +85,15 @@ HIDDEN_HANDOFF_ON_DEVICE = "on_device"
 HIDDEN_HANDOFF_ROUNDTRIP = "roundtrip"
 HIDDEN_HANDOFFS = frozenset({HIDDEN_HANDOFF_ON_DEVICE, HIDDEN_HANDOFF_ROUNDTRIP})
 
-# Which verify-return fields each mode must carry.
-_MODE_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+# The contract's name for the target hidden state a device drafter consumes.
+# Deliberately unconstrained: the runner holds it and hands it back without
+# interpreting its dtype, layout or tensor-parallel fracturing. Named so the
+# term is greppable on both sides of the boundary.
+HiddenHandle = Any
+
+# Which verify-return fields each mode must carry. Contract information, so a
+# caller can check a return it did not build.
+MODE_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
     ACCEPT_MODE_LOGITS: ("logits",),
     ACCEPT_MODE_ARGMAX_IDS: ("argmax_ids",),
     ACCEPT_MODE_FUSED_SAMPLE: ("accepted_token_ids", "accepted_counts"),
@@ -86,11 +114,26 @@ class SpecPlan:
     """
 
     effective_k: int
+    # Decode rows one speculating request occupies while verifying its
+    # [B, 1+K] block. Unrelated to a lane-DP lane: this counts rows of the
+    # model's decode batch, not TT lanes in an engine. The runner checks it
+    # against its own row budget and never asks how the rows are arranged.
     lanes_per_request: int
+    # Fixed device bytes per speculating request, independent of sequence
+    # length: candidate state slots, a conv stash, retained hidden rows.
     extra_bytes_per_seq: int
+    # Device bytes per KV token beyond the target KV, which is what a drafter
+    # with its own paged KV pair costs, since that cache grows with the
+    # sequence. A model reporting only the fixed part under-reserves by the
+    # whole drafter cache.
     extra_bytes_per_token: int
     accept_modes: tuple[str, ...]
     drafter_state: str
+    # Whether the model also serves a narrow [B, 1] decode alongside the wide
+    # [B, 1+K] one. Speculative decode calls are uniformly 1+K wide even on a
+    # step where no request carries drafts, so that a model needs one verify
+    # shape rather than two; a model that sets this offers a second, narrower
+    # shape and the runner prefers it on those steps.
     supports_narrow_decode: bool = False
 
     def __post_init__(self) -> None:
@@ -109,18 +152,12 @@ class SpecPlan:
             if value < 0:
                 raise ValueError(f"SpecPlan.{name} must not be negative, got {value}")
 
-        modes = tuple(self.accept_modes)
+        modes = normalize_declared_values(
+            self.accept_modes, ACCEPT_MODES, "SpecPlan.accept_modes"
+        )
         object.__setattr__(self, "accept_modes", modes)
         if not modes:
             raise ValueError("SpecPlan.accept_modes must name at least one mode")
-        unknown = [mode for mode in modes if mode not in ACCEPT_MODES]
-        if unknown:
-            raise ValueError(
-                f"SpecPlan.accept_modes has unknown modes {unknown}; "
-                f"known modes are {sorted(ACCEPT_MODES)}"
-            )
-        if len(set(modes)) != len(modes):
-            raise ValueError(f"SpecPlan.accept_modes repeats a mode: {list(modes)}")
         if self.drafter_state not in DRAFTER_STATES:
             raise ValueError(
                 f"SpecPlan.drafter_state {self.drafter_state!r} is not one of "
@@ -182,10 +219,13 @@ class SpecReject:
 class DraftOutput:
     """What a device drafter returns for one step.
 
-    ``draft_token_ids`` is ``[B, K]`` and padded: row ``i`` carries its real
-    draft count in the runner's own per-row bookkeeping, not in this tensor.
-    ``draft_scores`` is ``[B, K, q]`` for a drafter that produces them, and
-    ``None`` otherwise; a runner that does not need scores must not require it.
+    ``draft_token_ids`` is ``[B, K]`` and padded. How many of row ``i``'s
+    drafts are real is the runner's own bookkeeping, carried into the verify
+    call as ``num_valid_drafts``, not encoded in this tensor.
+    ``draft_scores`` is ``[B, K, q]``, the drafter's top ``q`` scores per
+    drafted position, for a drafter that produces them and ``None`` otherwise.
+    An accept rule that needs the drafter distribution reads them; a runner
+    that does not must not require them.
     """
 
     draft_token_ids: "torch.Tensor"
@@ -202,17 +242,22 @@ class VerifyOutput:
     """
 
     spec_mode: str
+    # [B, 1+K] verify argmax ids, for spec_mode "argmax_ids".
     argmax_ids: "torch.Tensor | None" = None
+    # [B, 1+K, V] over the whole vocabulary, for spec_mode "logits".
     logits: "torch.Tensor | None" = None
+    # [B, 1+K] committed prefix plus correction or bonus, for "fused_sample".
     accepted_token_ids: "torch.Tensor | None" = None
+    # [B] committed token count per row, for "fused_sample". Same domain as the
+    # accepted_counts a verify takes as input: see SpecPlan.
     accepted_counts: "torch.Tensor | None" = None
-    # Opaque to the runner, which holds it and passes it back to the drafter
-    # without interpreting its dtype, layout or tensor-parallel fracturing.
-    # Empty when the model retains the hidden state on device.
-    hidden: Any = None
+    # The target hidden state a device drafter consumes, held by the runner and
+    # handed back to propose_draft_tokens uninterpreted. None when the model
+    # retains it on device.
+    hidden: HiddenHandle = None
 
     def __post_init__(self) -> None:
-        required = _MODE_REQUIRED_FIELDS.get(self.spec_mode)
+        required = MODE_REQUIRED_FIELDS.get(self.spec_mode)
         if required is None:
             raise ValueError(
                 f"VerifyOutput.spec_mode {self.spec_mode!r} is not one of "
@@ -265,6 +310,8 @@ __all__ = [
     "SPEC_REQUIREMENT_HIDDEN_FEED",
     "SPEC_REQUIREMENT_PAGED_DRAFTER_CACHE",
     "DraftOutput",
+    "MODE_REQUIRED_FIELDS",
+    "HiddenHandle",
     "SpecPlan",
     "SpecReject",
     "VerifyOutput",

--- a/src/vllm_tt_plugin/spec_decode.py
+++ b/src/vllm_tt_plugin/spec_decode.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+"""Contract types for speculative decoding between the runner and a TT model.
+
+The contract these types encode is specified in
+https://github.com/tenstorrent/vllm-tt-plugin/issues/110. Nothing here reads a
+`model_capabilities` key or admits a configuration; this module is the wire
+surface only, so a model class and the runner can agree on shapes and modes
+before either side implements a step of the loop.
+
+Two properties of the contract are enforced here rather than left to each
+caller, because both were ambiguous enough in earlier revisions to produce
+off-by-one and shape errors: the inclusive range a valid ``accepted_counts``
+entry lies in, and the pairing between a ``spec_mode`` and the fields a verify
+return must carry for it.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+# Accept modes, named by what the verify call returns rather than by which side
+# performs acceptance. Naming the performer cannot describe a device argmax
+# followed by a host walk, which is what both existing tt-metal
+# implementations do.
+ACCEPT_MODE_LOGITS = "logits"
+ACCEPT_MODE_ARGMAX_IDS = "argmax_ids"
+ACCEPT_MODE_FUSED_SAMPLE = "fused_sample"
+ACCEPT_MODES = frozenset(
+    {ACCEPT_MODE_LOGITS, ACCEPT_MODE_ARGMAX_IDS, ACCEPT_MODE_FUSED_SAMPLE}
+)
+
+# Where a drafter's own state lives. "internal" means the model allocates it
+# and reports its size through the two byte fields of SpecPlan. "paged" means
+# the drafter needs a scheduler-owned growing cache, declared through the model
+# class's get_kv_cache_spec hook.
+DRAFTER_STATE_INTERNAL = "internal"
+DRAFTER_STATE_PAGED = "paged"
+DRAFTER_STATES = frozenset({DRAFTER_STATE_INTERNAL, DRAFTER_STATE_PAGED})
+
+# What a drafting method needs from the model. The runner maps a vLLM
+# SpeculativeConfig method name onto these; a model never enumerates method
+# names, so a new upstream method does not require a model change.
+SPEC_REQUIREMENT_DEVICE_PROPOSE = "device_propose"
+SPEC_REQUIREMENT_HIDDEN_FEED = "hidden_feed"
+SPEC_REQUIREMENT_DRAFTER_SCORES = "drafter_scores"
+SPEC_REQUIREMENT_PAGED_DRAFTER_CACHE = "paged_drafter_cache"
+SPEC_REQUIREMENTS = frozenset(
+    {
+        SPEC_REQUIREMENT_DEVICE_PROPOSE,
+        SPEC_REQUIREMENT_HIDDEN_FEED,
+        SPEC_REQUIREMENT_DRAFTER_SCORES,
+        SPEC_REQUIREMENT_PAGED_DRAFTER_CACHE,
+    }
+)
+
+# How the target hidden state reaches a device drafter. Both are live modes: a
+# drafter on another mesh, or one that is a separate model instance, needs the
+# host round trip even though the first TT implementation retains it on device.
+HIDDEN_HANDOFF_ON_DEVICE = "on_device"
+HIDDEN_HANDOFF_ROUNDTRIP = "roundtrip"
+HIDDEN_HANDOFFS = frozenset({HIDDEN_HANDOFF_ON_DEVICE, HIDDEN_HANDOFF_ROUNDTRIP})
+
+# Which verify-return fields each mode must carry.
+_MODE_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    ACCEPT_MODE_LOGITS: ("logits",),
+    ACCEPT_MODE_ARGMAX_IDS: ("argmax_ids",),
+    ACCEPT_MODE_FUSED_SAMPLE: ("accepted_token_ids", "accepted_counts"),
+}
+
+
+@dataclass(frozen=True)
+class SpecPlan:
+    """What one model can serve at one ``(max_num_seqs, requested_k)`` point.
+
+    Returned by a model class's ``spec_plan`` classmethod at config time. The
+    runner budgets with these numbers and never inspects the physical verify
+    layout: a model's lane arithmetic, L1 fit and state budget stay private,
+    and only their consequences cross.
+
+    ``accept_modes`` is stored as a tuple because the instance is frozen and a
+    list field would be shared mutable state on a value object.
+    """
+
+    effective_k: int
+    lanes_per_request: int
+    extra_bytes_per_seq: int
+    extra_bytes_per_token: int
+    accept_modes: tuple[str, ...]
+    drafter_state: str
+    supports_narrow_decode: bool = False
+
+    def __post_init__(self) -> None:
+        if self.effective_k < 1:
+            raise ValueError(
+                "SpecPlan.effective_k must be at least 1; a model that cannot "
+                f"speculate returns SpecReject instead, got {self.effective_k}"
+            )
+        if self.lanes_per_request < 1:
+            raise ValueError(
+                "SpecPlan.lanes_per_request must be at least 1, got "
+                f"{self.lanes_per_request}"
+            )
+        for name in ("extra_bytes_per_seq", "extra_bytes_per_token"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"SpecPlan.{name} must not be negative, got {value}")
+
+        modes = tuple(self.accept_modes)
+        object.__setattr__(self, "accept_modes", modes)
+        if not modes:
+            raise ValueError("SpecPlan.accept_modes must name at least one mode")
+        unknown = [mode for mode in modes if mode not in ACCEPT_MODES]
+        if unknown:
+            raise ValueError(
+                f"SpecPlan.accept_modes has unknown modes {unknown}; "
+                f"known modes are {sorted(ACCEPT_MODES)}"
+            )
+        if len(set(modes)) != len(modes):
+            raise ValueError(f"SpecPlan.accept_modes repeats a mode: {list(modes)}")
+        if self.drafter_state not in DRAFTER_STATES:
+            raise ValueError(
+                f"SpecPlan.drafter_state {self.drafter_state!r} is not one of "
+                f"{sorted(DRAFTER_STATES)}"
+            )
+
+    @property
+    def accepted_counts_range(self) -> tuple[int, int]:
+        """Inclusive range a valid ``accepted_counts`` entry lies in.
+
+        A count, not an index: 1 means only the input token stood and every
+        draft was rejected. It is never 0, and it is 1 after a prefill and
+        after a non-speculating step, so the runner never special-cases the
+        first speculative step. A model selecting a per-candidate state slot
+        selects slot ``accepted_counts - 1``.
+        """
+        return (1, 1 + self.effective_k)
+
+    @property
+    def block_width(self) -> int:
+        """Row width of every speculative decode call, ``1 + effective_k``.
+
+        Uniform once speculation is on, including on a step where no request
+        carries drafts, so a model needs one verify shape and not two.
+        """
+        return 1 + self.effective_k
+
+
+@dataclass(frozen=True)
+class SpecReject:
+    """Why a model cannot serve a ``(max_num_seqs, requested_k)`` point.
+
+    ``supported_k`` carries what the same ``max_num_seqs`` would accept, so the
+    config-time error can tell an operator what to ask for instead. It is empty
+    when the model can serve no draft length at that concurrency.
+    """
+
+    reason: str
+    supported_k: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError("SpecReject.reason must explain the refusal")
+        supported = tuple(self.supported_k)
+        object.__setattr__(self, "supported_k", supported)
+        bad = [k for k in supported if k < 1]
+        if bad:
+            raise ValueError(
+                "SpecReject.supported_k must hold draft lengths of 1 or more, "
+                f"got {bad}"
+            )
+        if len(set(supported)) != len(supported):
+            raise ValueError(
+                f"SpecReject.supported_k repeats a value: {list(supported)}"
+            )
+
+
+@dataclass(frozen=True)
+class DraftOutput:
+    """What a device drafter returns for one step.
+
+    ``draft_token_ids`` is ``[B, K]`` and padded: row ``i`` carries its real
+    draft count in the runner's own per-row bookkeeping, not in this tensor.
+    ``draft_scores`` is ``[B, K, q]`` for a drafter that produces them, and
+    ``None`` otherwise; a runner that does not need scores must not require it.
+    """
+
+    draft_token_ids: "torch.Tensor"
+    draft_scores: "torch.Tensor | None" = None
+
+
+@dataclass(frozen=True)
+class VerifyOutput:
+    """What one verify call returns, and the mode that says which fields apply.
+
+    The mode-to-field pairing is enforced rather than documented because a
+    return that carries the wrong field for its mode fails later, inside the
+    accept walk, where the cause is no longer visible.
+    """
+
+    spec_mode: str
+    argmax_ids: "torch.Tensor | None" = None
+    logits: "torch.Tensor | None" = None
+    accepted_token_ids: "torch.Tensor | None" = None
+    accepted_counts: "torch.Tensor | None" = None
+    # Opaque to the runner, which holds it and passes it back to the drafter
+    # without interpreting its dtype, layout or tensor-parallel fracturing.
+    # Empty when the model retains the hidden state on device.
+    hidden: Any = None
+
+    def __post_init__(self) -> None:
+        required = _MODE_REQUIRED_FIELDS.get(self.spec_mode)
+        if required is None:
+            raise ValueError(
+                f"VerifyOutput.spec_mode {self.spec_mode!r} is not one of "
+                f"{sorted(ACCEPT_MODES)}"
+            )
+        missing = [name for name in required if getattr(self, name) is None]
+        if missing:
+            raise ValueError(
+                f"VerifyOutput for spec_mode {self.spec_mode!r} must carry "
+                f"{list(required)}, missing {missing}"
+            )
+
+
+def normalize_declared_values(
+    values: Sequence[str] | None, known: frozenset[str], label: str
+) -> tuple[str, ...]:
+    """Validate a declared capability list against its known value set.
+
+    An absent declaration is empty, per the default-if-absent capability
+    convention. A present value that is not known raises, because a typo in a
+    capability list would otherwise silently disable the feature it names.
+    """
+    if values is None:
+        return ()
+    declared = tuple(values)
+    unknown = [value for value in declared if value not in known]
+    if unknown:
+        raise ValueError(
+            f"{label} has unknown values {unknown}; known values are {sorted(known)}"
+        )
+    if len(set(declared)) != len(declared):
+        raise ValueError(f"{label} repeats a value: {list(declared)}")
+    return declared
+
+
+__all__ = [
+    "ACCEPT_MODES",
+    "ACCEPT_MODE_ARGMAX_IDS",
+    "ACCEPT_MODE_FUSED_SAMPLE",
+    "ACCEPT_MODE_LOGITS",
+    "DRAFTER_STATES",
+    "DRAFTER_STATE_INTERNAL",
+    "DRAFTER_STATE_PAGED",
+    "HIDDEN_HANDOFFS",
+    "HIDDEN_HANDOFF_ON_DEVICE",
+    "HIDDEN_HANDOFF_ROUNDTRIP",
+    "SPEC_REQUIREMENTS",
+    "SPEC_REQUIREMENT_DEVICE_PROPOSE",
+    "SPEC_REQUIREMENT_DRAFTER_SCORES",
+    "SPEC_REQUIREMENT_HIDDEN_FEED",
+    "SPEC_REQUIREMENT_PAGED_DRAFTER_CACHE",
+    "DraftOutput",
+    "SpecPlan",
+    "SpecReject",
+    "VerifyOutput",
+    "normalize_declared_values",
+]

--- a/tests/spec/__init__.py
+++ b/tests/spec/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.

--- a/tests/spec/fake_spec_model.py
+++ b/tests/spec/fake_spec_model.py
@@ -2,19 +2,29 @@
 # SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 """A host model class that implements the speculative-decoding contract.
 
-No tt-metal model implements the runner-model contract yet, so the runner side
-has nothing to be driven against. This stand-in implements it in host torch
-with deterministic arithmetic, which makes it two things at once: a driver for
-the runner-side work, and a check on the contract itself, because it raises on
-every input the contract forbids rather than tolerating it.
+The contract is specified in
+https://github.com/tenstorrent/vllm-tt-plugin/issues/110. No tt-metal model
+implements it yet, so the runner side has nothing to be driven against. This
+stand-in implements it in host torch with deterministic arithmetic, which makes
+it two things at once: a driver for the runner-side work, and a check on the
+contract itself, because it raises on every input the contract forbids rather
+than tolerating it.
 
-Two deliberate departures from what the first tt-metal model will ship. Both
-accept modes are served, not just the one that lands first, because the mode
-dispatch is the part of the runner most likely to be wrong and a second mode
-costs nothing here. And ``fused_sample`` is refused, because no hardware can
-run it: a stand-in that served it would produce a passing test for a path that
-cannot execute.
+One step, per the contract, is verify then propose: ``decode_forward`` runs the
+``[B, 1+K]`` candidate block, the caller walks acceptance, and
+``propose_draft_tokens`` then drafts from that same step's hidden state.
+
+``argmax_ids`` and ``logits`` are both served because the mode dispatch is the
+runner code most likely to be wrong, and a second mode costs nothing here. A
+test pins that the two return the same ids, so a test of one is evidence about
+the other.
+
+``fused_sample`` is refused because no implementation serves it today, on
+either side. The contract keeps the mode for a model that will; a stand-in that
+served it would give a passing test for a path nothing can run.
 """
+
+import types
 
 import torch
 
@@ -54,6 +64,11 @@ class FakeSpecModel:
         "spec_hidden_handoff": [HIDDEN_HANDOFF_ON_DEVICE],
     }
 
+    # Defaults mirror the Qwen3.6 calibration the contract records, so a test
+    # that exercises a realistic refusal does not have to invent numbers: a
+    # discrete supported set, single-user concurrency, and a state cost of the
+    # right order. The byte costs are flat rather than the calibration's
+    # K x 36 MiB, because nothing here budgets against them.
     supported_k: tuple[int, ...] = (3, 7, 11)
     max_supported_num_seqs: int = 1
     accept_modes: tuple[str, ...] = (ACCEPT_MODE_ARGMAX_IDS, ACCEPT_MODE_LOGITS)
@@ -112,9 +127,8 @@ class FakeSpecModel:
         accepted_counts,
         hidden=None,
     ) -> DraftOutput:
-        block_width = 1 + num_drafts
-        rows = self._check_block(
-            "propose", committed_tokens, committed_positions, block_width
+        rows, _ = self._check_block(
+            "propose", committed_tokens, committed_positions, 1 + num_drafts
         )
         self._check_accepted_counts(accepted_counts, rows, num_drafts)
         self.propose_calls.append(
@@ -138,19 +152,23 @@ class FakeSpecModel:
         positions,
         num_valid_drafts,
         accepted_counts,
+        spec_mode: str,
         page_table=None,
         slot_mapping=None,
         sampling_params=None,
-        spec_mode: str = ACCEPT_MODE_ARGMAX_IDS,
     ) -> VerifyOutput:
+        """The verify primitive: one forward over the [B, 1+K] candidate block.
+
+        ``spec_mode`` has no default, so a caller that forgets it fails rather
+        than silently receiving greedy ids.
+        """
         del page_table, slot_mapping, sampling_params
         if spec_mode not in self.accept_modes:
             raise ValueError(
                 f"FakeSpecModel serves {list(self.accept_modes)}, "
                 f"asked for {spec_mode!r}"
             )
-        rows, block_width = tokens.shape
-        self._check_block("verify", tokens, positions, block_width)
+        rows, block_width = self._check_block("verify", tokens, positions)
         num_drafts = block_width - 1
         self._check_accepted_counts(accepted_counts, rows, num_drafts)
         if num_valid_drafts.shape != (rows,):
@@ -187,7 +205,15 @@ class FakeSpecModel:
 
     # ---- contract checks -------------------------------------------------
 
-    def _check_block(self, call: str, tokens, positions, block_width: int) -> int:
+    def _check_block(
+        self, call: str, tokens, positions, block_width: int | None = None
+    ) -> tuple[int, int]:
+        """Validate a candidate block and return its ``(rows, width)``.
+
+        The width is derived here rather than unpacked by the caller, so a
+        mis-ranked tensor produces the shape error naming the offender instead
+        of a bare unpacking failure.
+        """
         if tokens.dim() != 2 or positions.dim() != 2:
             raise ValueError(
                 f"{call} tokens and positions must both be 2-D [B, 1+K], got "
@@ -198,12 +224,17 @@ class FakeSpecModel:
                 f"{call} tokens {tuple(tokens.shape)} and positions "
                 f"{tuple(positions.shape)} must have the same shape"
             )
-        if tokens.shape[1] != block_width:
+        rows, width = int(tokens.shape[0]), int(tokens.shape[1])
+        if rows < 1:
             raise ValueError(
-                f"{call} expects the uniform width 1+K = {block_width}, got "
-                f"{tokens.shape[1]}"
+                f"{call} needs at least one row: the runner does not issue a "
+                f"step with no requests, got {tuple(tokens.shape)}"
             )
-        return int(tokens.shape[0])
+        if block_width is not None and width != block_width:
+            raise ValueError(
+                f"{call} expects the uniform width 1+K = {block_width}, got {width}"
+            )
+        return rows, width
 
     def _check_accepted_counts(self, accepted_counts, rows: int, num_drafts: int):
         if accepted_counts is None:
@@ -237,23 +268,27 @@ class FakeSpecModel:
         return committed_tokens.to(torch.int64).gather(1, index).squeeze(1)
 
     def _verified_ids(self, tokens, num_valid_drafts):
-        """Ids the verify claims, agreeing with the drafts up to accept_depth.
+        """Ids the verify claims, per row, agreeing up to that row's cap.
 
         Column 0 always repeats the input token, which is already committed.
-        Column ``1+j`` agrees with drafted column ``1+j`` while ``j`` is below
-        the depth this stand-in accepts, and otherwise returns an id no drafter
-        of this stand-in can produce, so the accept walk stops there.
+        Row ``i`` agrees with its drafted column ``1+j`` while ``j`` is below
+        ``min(accept_depth, num_valid_drafts[i])``, and otherwise returns an id
+        that differs from the draft at that column, so the accept walk for that
+        row stops there.
+
+        The cap is per row and never reduced across the batch. A batch-wide cap
+        would let one grammar-truncated request destroy every other request's
+        speculation, which the contract forbids, and no runner driven by this
+        stand-in would ever exercise the mixed case.
         """
-        rows, block_width = tokens.shape
-        num_drafts = block_width - 1
+        num_drafts = int(tokens.shape[1]) - 1
         depth = num_drafts if self.accept_depth is None else self.accept_depth
-        verified = tokens.clone().to(torch.int32)
-        for j in range(num_drafts):
-            accepted_here = min(depth, int(num_valid_drafts.min()))
-            if j >= accepted_here:
-                verified[:, 1 + j] = (tokens[:, 1 + j].to(torch.int64) + 1) % (
-                    self.vocab_size
-                )
+        cap = torch.clamp(num_valid_drafts.to(torch.int64), max=depth)
+        drafted = tokens[:, 1:].to(torch.int64)
+        columns = torch.arange(num_drafts, dtype=torch.int64)
+        diverge = columns.unsqueeze(0) >= cap.unsqueeze(1)
+        verified = tokens.clone().to(torch.int64)
+        verified[:, 1:] = torch.where(diverge, (drafted + 1) % self.vocab_size, drafted)
         return verified.to(torch.int32)
 
 
@@ -263,11 +298,29 @@ def make_fake_spec_model(**knobs) -> type[FakeSpecModel]:
     A subclass rather than a mutated class, because ``spec_plan`` is a
     classmethod and a mutated attribute would leak into every later test.
     """
-    unknown = sorted(set(knobs) - set(vars(FakeSpecModel)))
+    settable = _settable_knobs()
+    unknown = sorted(set(knobs) - set(settable))
     if unknown:
-        settable = sorted(k for k in vars(FakeSpecModel) if not k.startswith("_"))
         raise ValueError(
             f"make_fake_spec_model got unknown knobs {unknown}; "
             f"settable knobs are {settable}"
         )
     return type("ConfiguredFakeSpecModel", (FakeSpecModel,), dict(knobs))
+
+
+# A classmethod object is not callable on every supported interpreter, so the
+# descriptor types are named rather than filtered with callable().
+_NON_KNOB_TYPES = (types.FunctionType, classmethod, staticmethod, property)
+
+
+def _settable_knobs() -> list[str]:
+    """Class attributes a caller may override, excluding the contract methods.
+
+    Overriding a method name would replace a primitive with a plain value and
+    fail at the call site instead of here.
+    """
+    return sorted(
+        name
+        for name, value in vars(FakeSpecModel).items()
+        if not name.startswith("_") and not isinstance(value, _NON_KNOB_TYPES)
+    )

--- a/tests/spec/fake_spec_model.py
+++ b/tests/spec/fake_spec_model.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+"""A host model class that implements the speculative-decoding contract.
+
+No tt-metal model implements the runner-model contract yet, so the runner side
+has nothing to be driven against. This stand-in implements it in host torch
+with deterministic arithmetic, which makes it two things at once: a driver for
+the runner-side work, and a check on the contract itself, because it raises on
+every input the contract forbids rather than tolerating it.
+
+Two deliberate departures from what the first tt-metal model will ship. Both
+accept modes are served, not just the one that lands first, because the mode
+dispatch is the part of the runner most likely to be wrong and a second mode
+costs nothing here. And ``fused_sample`` is refused, because no hardware can
+run it: a stand-in that served it would produce a passing test for a path that
+cannot execute.
+"""
+
+import torch
+
+from vllm_tt_plugin.spec_decode import (
+    ACCEPT_MODE_ARGMAX_IDS,
+    ACCEPT_MODE_LOGITS,
+    DRAFTER_STATE_INTERNAL,
+    HIDDEN_HANDOFF_ON_DEVICE,
+    SPEC_REQUIREMENT_DEVICE_PROPOSE,
+    SPEC_REQUIREMENT_HIDDEN_FEED,
+    DraftOutput,
+    SpecPlan,
+    SpecReject,
+    VerifyOutput,
+)
+
+# Small enough to build dense logits for in a test, wide enough that a drafted
+# id and a verified id do not collide by accident.
+FAKE_VOCAB_SIZE = 512
+
+
+class FakeSpecModel:
+    """Contract-conformant stand-in for a resolved TT model class.
+
+    Knobs are class attributes because ``spec_plan`` is a classmethod that the
+    runner calls at config time, before any instance exists. Build a configured
+    variant with :func:`make_fake_spec_model` rather than mutating these, so
+    one test cannot configure the next.
+    """
+
+    model_capabilities = {
+        "supports_spec_decode": True,
+        "spec_requirements": [
+            SPEC_REQUIREMENT_DEVICE_PROPOSE,
+            SPEC_REQUIREMENT_HIDDEN_FEED,
+        ],
+        "spec_hidden_handoff": [HIDDEN_HANDOFF_ON_DEVICE],
+    }
+
+    supported_k: tuple[int, ...] = (3, 7, 11)
+    max_supported_num_seqs: int = 1
+    accept_modes: tuple[str, ...] = (ACCEPT_MODE_ARGMAX_IDS, ACCEPT_MODE_LOGITS)
+    drafter_state: str = DRAFTER_STATE_INTERNAL
+    extra_bytes_per_seq: int = 36 << 20
+    extra_bytes_per_token: int = 1 << 10
+    vocab_size: int = FAKE_VOCAB_SIZE
+    # How many of the K drafts the verify agrees with. The rest diverge, so a
+    # test can predict the accepted count exactly. None accepts every draft.
+    accept_depth: int | None = None
+
+    def __init__(self) -> None:
+        self.propose_calls: list[dict] = []
+        self.verify_calls: list[dict] = []
+
+    # ---- config time -----------------------------------------------------
+
+    @classmethod
+    def spec_plan(cls, vllm_config, max_num_seqs: int, requested_k: int):
+        del vllm_config  # the stand-in's feasibility does not depend on it
+        if max_num_seqs > cls.max_supported_num_seqs:
+            return SpecReject(
+                reason=(
+                    f"speculation needs max_num_seqs <= {cls.max_supported_num_seqs}, "
+                    f"got {max_num_seqs}"
+                ),
+                supported_k=(),
+            )
+        usable = tuple(k for k in sorted(cls.supported_k) if k <= requested_k)
+        if not usable:
+            return SpecReject(
+                reason=(
+                    f"requested_k {requested_k} is below every supported draft "
+                    f"length {sorted(cls.supported_k)}"
+                ),
+                supported_k=tuple(sorted(cls.supported_k)),
+            )
+        effective_k = usable[-1]
+        return SpecPlan(
+            effective_k=effective_k,
+            lanes_per_request=effective_k + 1,
+            extra_bytes_per_seq=cls.extra_bytes_per_seq,
+            extra_bytes_per_token=cls.extra_bytes_per_token,
+            accept_modes=cls.accept_modes,
+            drafter_state=cls.drafter_state,
+            supports_narrow_decode=False,
+        )
+
+    # ---- the primitives --------------------------------------------------
+
+    def propose_draft_tokens(
+        self,
+        num_drafts: int,
+        committed_tokens,
+        committed_positions,
+        accepted_counts,
+        hidden=None,
+    ) -> DraftOutput:
+        block_width = 1 + num_drafts
+        rows = self._check_block(
+            "propose", committed_tokens, committed_positions, block_width
+        )
+        self._check_accepted_counts(accepted_counts, rows, num_drafts)
+        self.propose_calls.append(
+            {
+                "num_drafts": num_drafts,
+                "rows": rows,
+                "accepted_counts": accepted_counts.clone(),
+                "hidden_was_none": hidden is None,
+            }
+        )
+        # Deterministic and derived only from the last committed token per row,
+        # so a test can predict both the drafts and the accepted count.
+        last = self._last_committed(committed_tokens, accepted_counts)
+        offsets = torch.arange(1, num_drafts + 1, dtype=torch.int32)
+        drafts = (last.unsqueeze(1) + offsets.unsqueeze(0)) % self.vocab_size
+        return DraftOutput(draft_token_ids=drafts.to(torch.int32))
+
+    def decode_forward(
+        self,
+        tokens,
+        positions,
+        num_valid_drafts,
+        accepted_counts,
+        page_table=None,
+        slot_mapping=None,
+        sampling_params=None,
+        spec_mode: str = ACCEPT_MODE_ARGMAX_IDS,
+    ) -> VerifyOutput:
+        del page_table, slot_mapping, sampling_params
+        if spec_mode not in self.accept_modes:
+            raise ValueError(
+                f"FakeSpecModel serves {list(self.accept_modes)}, "
+                f"asked for {spec_mode!r}"
+            )
+        rows, block_width = tokens.shape
+        self._check_block("verify", tokens, positions, block_width)
+        num_drafts = block_width - 1
+        self._check_accepted_counts(accepted_counts, rows, num_drafts)
+        if num_valid_drafts.shape != (rows,):
+            raise ValueError(
+                f"verify num_valid_drafts must be [{rows}], got "
+                f"{tuple(num_valid_drafts.shape)}"
+            )
+        out_of_range = num_valid_drafts[
+            (num_valid_drafts < 0) | (num_valid_drafts > num_drafts)
+        ]
+        if out_of_range.numel():
+            raise ValueError(
+                f"verify num_valid_drafts entries must lie in [0, {num_drafts}], "
+                f"got {out_of_range.tolist()}"
+            )
+        self.verify_calls.append(
+            {
+                "rows": rows,
+                "block_width": block_width,
+                "spec_mode": spec_mode,
+                "num_valid_drafts": num_valid_drafts.clone(),
+                "accepted_counts": accepted_counts.clone(),
+            }
+        )
+
+        verified = self._verified_ids(tokens, num_valid_drafts)
+        if spec_mode == ACCEPT_MODE_ARGMAX_IDS:
+            return VerifyOutput(spec_mode=spec_mode, argmax_ids=verified, hidden=None)
+        # The two modes must agree, or a test of one proves nothing about the
+        # other: the logits argmax is the ids the other mode returns.
+        logits = torch.zeros(rows, block_width, self.vocab_size)
+        logits.scatter_(2, verified.to(torch.int64).unsqueeze(2), 1.0)
+        return VerifyOutput(spec_mode=spec_mode, logits=logits, hidden=None)
+
+    # ---- contract checks -------------------------------------------------
+
+    def _check_block(self, call: str, tokens, positions, block_width: int) -> int:
+        if tokens.dim() != 2 or positions.dim() != 2:
+            raise ValueError(
+                f"{call} tokens and positions must both be 2-D [B, 1+K], got "
+                f"{tuple(tokens.shape)} and {tuple(positions.shape)}"
+            )
+        if tokens.shape != positions.shape:
+            raise ValueError(
+                f"{call} tokens {tuple(tokens.shape)} and positions "
+                f"{tuple(positions.shape)} must have the same shape"
+            )
+        if tokens.shape[1] != block_width:
+            raise ValueError(
+                f"{call} expects the uniform width 1+K = {block_width}, got "
+                f"{tokens.shape[1]}"
+            )
+        return int(tokens.shape[0])
+
+    def _check_accepted_counts(self, accepted_counts, rows: int, num_drafts: int):
+        if accepted_counts is None:
+            raise ValueError(
+                "accepted_counts may be None only after a fused_sample step, "
+                "which FakeSpecModel does not serve"
+            )
+        if accepted_counts.shape != (rows,):
+            raise ValueError(
+                f"accepted_counts must be [{rows}], got {tuple(accepted_counts.shape)}"
+            )
+        if accepted_counts.dtype != torch.int32:
+            raise ValueError(
+                f"accepted_counts must be int32, got {accepted_counts.dtype}"
+            )
+        low, high = 1, 1 + num_drafts
+        out_of_range = accepted_counts[
+            (accepted_counts < low) | (accepted_counts > high)
+        ]
+        if out_of_range.numel():
+            raise ValueError(
+                f"accepted_counts entries must lie in [{low}, {high}]; a count "
+                f"of 0 is never valid, got {out_of_range.tolist()}"
+            )
+
+    # ---- deterministic arithmetic ---------------------------------------
+
+    @staticmethod
+    def _last_committed(committed_tokens, accepted_counts):
+        index = (accepted_counts.to(torch.int64) - 1).unsqueeze(1)
+        return committed_tokens.to(torch.int64).gather(1, index).squeeze(1)
+
+    def _verified_ids(self, tokens, num_valid_drafts):
+        """Ids the verify claims, agreeing with the drafts up to accept_depth.
+
+        Column 0 always repeats the input token, which is already committed.
+        Column ``1+j`` agrees with drafted column ``1+j`` while ``j`` is below
+        the depth this stand-in accepts, and otherwise returns an id no drafter
+        of this stand-in can produce, so the accept walk stops there.
+        """
+        rows, block_width = tokens.shape
+        num_drafts = block_width - 1
+        depth = num_drafts if self.accept_depth is None else self.accept_depth
+        verified = tokens.clone().to(torch.int32)
+        for j in range(num_drafts):
+            accepted_here = min(depth, int(num_valid_drafts.min()))
+            if j >= accepted_here:
+                verified[:, 1 + j] = (tokens[:, 1 + j].to(torch.int64) + 1) % (
+                    self.vocab_size
+                )
+        return verified.to(torch.int32)
+
+
+def make_fake_spec_model(**knobs) -> type[FakeSpecModel]:
+    """Return a fresh :class:`FakeSpecModel` subclass with ``knobs`` applied.
+
+    A subclass rather than a mutated class, because ``spec_plan`` is a
+    classmethod and a mutated attribute would leak into every later test.
+    """
+    unknown = sorted(set(knobs) - set(vars(FakeSpecModel)))
+    if unknown:
+        settable = sorted(k for k in vars(FakeSpecModel) if not k.startswith("_"))
+        raise ValueError(
+            f"make_fake_spec_model got unknown knobs {unknown}; "
+            f"settable knobs are {settable}"
+        )
+    return type("ConfiguredFakeSpecModel", (FakeSpecModel,), dict(knobs))

--- a/tests/spec/test_contract_conformance.py
+++ b/tests/spec/test_contract_conformance.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+"""The speculative-decoding contract enforces its own shapes and modes.
+
+These tests exercise the two mechanisms the contract types own: the inclusive
+domain of ``accepted_counts``, and the pairing between a ``spec_mode`` and the
+verify-return fields it requires. They also drive ``FakeSpecModel`` through the
+inputs the contract forbids, so a later change to the runner that builds a
+ragged block, a zero count or a mismatched width fails here rather than inside
+an accept walk.
+"""
+
+import pytest
+import torch
+
+# vLLM's own bootstrap resolves the platform plugin, which imports plugin
+# modules. Letting a plugin import trigger that bootstrap deadlocks the cycle
+# on a half-built module, so let vLLM finish importing itself first.
+import vllm  # noqa: F401
+
+from tests.spec.fake_spec_model import (
+    FAKE_VOCAB_SIZE,
+    FakeSpecModel,
+    make_fake_spec_model,
+)
+from vllm_tt_plugin.spec_decode import (
+    ACCEPT_MODE_ARGMAX_IDS,
+    ACCEPT_MODE_FUSED_SAMPLE,
+    ACCEPT_MODE_LOGITS,
+    ACCEPT_MODES,
+    DRAFTER_STATE_INTERNAL,
+    HIDDEN_HANDOFFS,
+    SPEC_REQUIREMENTS,
+    SpecPlan,
+    SpecReject,
+    VerifyOutput,
+    normalize_declared_values,
+)
+
+
+def _plan(**overrides) -> SpecPlan:
+    fields = {
+        "effective_k": 3,
+        "lanes_per_request": 4,
+        "extra_bytes_per_seq": 0,
+        "extra_bytes_per_token": 0,
+        "accept_modes": (ACCEPT_MODE_ARGMAX_IDS,),
+        "drafter_state": DRAFTER_STATE_INTERNAL,
+    }
+    fields.update(overrides)
+    return SpecPlan(**fields)
+
+
+def _block(rows: int, block_width: int, base: int = 10):
+    tokens = (
+        torch.arange(rows * block_width, dtype=torch.int32).reshape(rows, block_width)
+        + base
+    )
+    positions = torch.arange(rows * block_width, dtype=torch.int32).reshape(
+        rows, block_width
+    )
+    return tokens, positions
+
+
+def _counts(rows: int, value: int):
+    return torch.full((rows,), value, dtype=torch.int32)
+
+
+# --- the contract's derived quantities ------------------------------------
+
+
+@pytest.mark.parametrize("effective_k", [1, 3, 7, 11])
+def test_accepted_counts_range_is_one_based_and_never_zero(effective_k):
+    plan = _plan(effective_k=effective_k, lanes_per_request=effective_k + 1)
+    assert plan.accepted_counts_range == (1, 1 + effective_k)
+    assert plan.block_width == 1 + effective_k
+
+
+# --- SpecPlan rejects what the runner cannot budget with ------------------
+
+
+@pytest.mark.parametrize(
+    "overrides, offending",
+    [
+        ({"effective_k": 0}, "0"),
+        ({"effective_k": -1}, "-1"),
+        ({"lanes_per_request": 0}, "0"),
+        ({"extra_bytes_per_seq": -1}, "-1"),
+        ({"extra_bytes_per_token": -8}, "-8"),
+        ({"accept_modes": ()}, "mode"),
+        ({"accept_modes": ("nonsense",)}, "nonsense"),
+        (
+            {"accept_modes": (ACCEPT_MODE_LOGITS, ACCEPT_MODE_LOGITS)},
+            ACCEPT_MODE_LOGITS,
+        ),
+        ({"drafter_state": "elsewhere"}, "elsewhere"),
+    ],
+)
+def test_spec_plan_raises_and_names_the_offending_value(overrides, offending):
+    with pytest.raises(ValueError) as excinfo:
+        _plan(**overrides)
+    assert offending in str(excinfo.value)
+
+
+def test_spec_plan_normalizes_accept_modes_to_a_tuple():
+    # A list field on a frozen value object would be shared mutable state.
+    declared = [ACCEPT_MODE_ARGMAX_IDS, ACCEPT_MODE_LOGITS]
+    plan = _plan(accept_modes=declared)
+    declared.append(ACCEPT_MODE_FUSED_SAMPLE)
+    assert plan.accept_modes == (ACCEPT_MODE_ARGMAX_IDS, ACCEPT_MODE_LOGITS)
+
+
+def test_spec_plan_accepts_fused_sample_because_admission_owns_that_policy():
+    # The type is the contract surface. Refusing a mode no model implements is
+    # a config-time decision, not a property of the value object.
+    plan = _plan(accept_modes=(ACCEPT_MODE_FUSED_SAMPLE,))
+    assert plan.accept_modes == (ACCEPT_MODE_FUSED_SAMPLE,)
+
+
+# --- SpecReject carries a usable refusal ----------------------------------
+
+
+def test_spec_reject_requires_a_reason():
+    with pytest.raises(ValueError):
+        SpecReject(reason="   ")
+
+
+@pytest.mark.parametrize("supported_k", [(0,), (-2,), (3, 3)])
+def test_spec_reject_rejects_an_unusable_supported_set(supported_k):
+    with pytest.raises(ValueError):
+        SpecReject(reason="no", supported_k=supported_k)
+
+
+def test_spec_reject_normalizes_supported_k_to_a_tuple():
+    assert SpecReject(reason="no", supported_k=[3, 7]).supported_k == (3, 7)
+
+
+# --- the mode-to-return pairing -------------------------------------------
+
+
+def test_every_accept_mode_has_a_declared_return_shape():
+    # A mode with no required fields would construct empty and fail later.
+    for mode in ACCEPT_MODES:
+        with pytest.raises(ValueError):
+            VerifyOutput(spec_mode=mode)
+
+
+def test_verify_output_accepts_each_mode_with_its_own_fields():
+    ids = torch.zeros(2, 4, dtype=torch.int32)
+    logits = torch.zeros(2, 4, FAKE_VOCAB_SIZE)
+    counts = _counts(2, 1)
+    assert (
+        VerifyOutput(spec_mode=ACCEPT_MODE_ARGMAX_IDS, argmax_ids=ids).argmax_ids is ids
+    )
+    assert VerifyOutput(spec_mode=ACCEPT_MODE_LOGITS, logits=logits).logits is logits
+    fused = VerifyOutput(
+        spec_mode=ACCEPT_MODE_FUSED_SAMPLE,
+        accepted_token_ids=ids,
+        accepted_counts=counts,
+    )
+    assert fused.accepted_counts is counts
+
+
+def test_verify_output_rejects_a_mode_carrying_the_wrong_field():
+    with pytest.raises(ValueError):
+        VerifyOutput(
+            spec_mode=ACCEPT_MODE_LOGITS,
+            argmax_ids=torch.zeros(2, 4, dtype=torch.int32),
+        )
+    with pytest.raises(ValueError):
+        VerifyOutput(
+            spec_mode=ACCEPT_MODE_FUSED_SAMPLE,
+            accepted_token_ids=torch.zeros(2, 4, dtype=torch.int32),
+        )
+
+
+def test_verify_output_rejects_an_unknown_mode():
+    with pytest.raises(ValueError) as excinfo:
+        VerifyOutput(spec_mode="device")
+    assert "device" in str(excinfo.value)
+
+
+def test_hidden_handle_stays_opaque():
+    # The runner holds it and passes it back without interpreting it, so any
+    # object must survive the round trip, including None for on-device retention.
+    sentinel = object()
+    ids = torch.zeros(1, 2, dtype=torch.int32)
+    assert (
+        VerifyOutput(
+            spec_mode=ACCEPT_MODE_ARGMAX_IDS, argmax_ids=ids, hidden=sentinel
+        ).hidden
+        is sentinel
+    )
+    assert VerifyOutput(spec_mode=ACCEPT_MODE_ARGMAX_IDS, argmax_ids=ids).hidden is None
+
+
+# --- declared capability lists --------------------------------------------
+
+
+def test_absent_declaration_is_empty_not_an_error():
+    assert normalize_declared_values(None, SPEC_REQUIREMENTS, "spec_requirements") == ()
+
+
+def test_declared_capability_typo_raises_rather_than_disabling_silently():
+    with pytest.raises(ValueError) as excinfo:
+        normalize_declared_values(
+            ["devise_propose"], SPEC_REQUIREMENTS, "spec_requirements"
+        )
+    assert "devise_propose" in str(excinfo.value)
+
+
+def test_declared_capability_duplicate_raises():
+    with pytest.raises(ValueError):
+        normalize_declared_values(
+            ["on_device", "on_device"], HIDDEN_HANDOFFS, "spec_hidden_handoff"
+        )
+
+
+# --- the stand-in model conforms and declares well-formed capabilities ----
+
+
+def test_fake_model_capabilities_use_known_values():
+    capabilities = FakeSpecModel.model_capabilities
+    assert capabilities["supports_spec_decode"] is True
+    assert normalize_declared_values(
+        capabilities["spec_requirements"], SPEC_REQUIREMENTS, "spec_requirements"
+    )
+    assert normalize_declared_values(
+        capabilities["spec_hidden_handoff"], HIDDEN_HANDOFFS, "spec_hidden_handoff"
+    )
+
+
+def test_spec_plan_reduces_an_over_large_requested_k():
+    plan = FakeSpecModel.spec_plan(None, max_num_seqs=1, requested_k=9)
+    assert isinstance(plan, SpecPlan)
+    assert plan.effective_k == 7
+    assert plan.lanes_per_request == plan.block_width
+
+
+def test_spec_plan_refuses_a_draft_length_below_every_supported_one():
+    reject = FakeSpecModel.spec_plan(None, max_num_seqs=1, requested_k=2)
+    assert isinstance(reject, SpecReject)
+    assert reject.supported_k == (3, 7, 11)
+
+
+def test_spec_plan_refuses_a_concurrency_the_model_cannot_serve():
+    reject = FakeSpecModel.spec_plan(None, max_num_seqs=8, requested_k=3)
+    assert isinstance(reject, SpecReject)
+    assert "8" in reject.reason
+
+
+def test_configured_variant_does_not_leak_into_the_base_class():
+    variant = make_fake_spec_model(max_supported_num_seqs=4, supported_k=(1,))
+    assert isinstance(variant.spec_plan(None, max_num_seqs=4, requested_k=1), SpecPlan)
+    assert isinstance(
+        FakeSpecModel.spec_plan(None, max_num_seqs=4, requested_k=1), SpecReject
+    )
+
+
+def test_unknown_knob_raises_rather_than_being_ignored():
+    with pytest.raises(ValueError) as excinfo:
+        make_fake_spec_model(effective_k=3)
+    assert "effective_k" in str(excinfo.value)
+
+
+# --- both accept modes agree ----------------------------------------------
+
+
+def test_the_two_accept_modes_return_the_same_token_ids():
+    # A test of one mode proves nothing about the other unless they agree.
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    valid = torch.full((rows,), num_drafts, dtype=torch.int32)
+    counts = _counts(rows, 1)
+    ids = model.decode_forward(
+        tokens, positions, valid, counts, spec_mode=ACCEPT_MODE_ARGMAX_IDS
+    ).argmax_ids
+    logits = model.decode_forward(
+        tokens, positions, valid, counts, spec_mode=ACCEPT_MODE_LOGITS
+    ).logits
+    assert torch.equal(logits.argmax(dim=-1).to(torch.int32), ids)
+
+
+def test_fused_sample_is_refused_because_no_hardware_runs_it():
+    model = FakeSpecModel()
+    tokens, positions = _block(1, 4)
+    with pytest.raises(ValueError):
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((1,), 3, dtype=torch.int32),
+            _counts(1, 1),
+            spec_mode=ACCEPT_MODE_FUSED_SAMPLE,
+        )
+
+
+# --- the stand-in refuses every input the contract forbids ----------------
+
+
+def test_propose_and_verify_take_the_same_padded_width():
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    counts = _counts(rows, 1)
+    model.propose_draft_tokens(num_drafts, tokens, positions, counts)
+    model.decode_forward(
+        tokens, positions, torch.full((rows,), num_drafts, dtype=torch.int32), counts
+    )
+    assert model.propose_calls[0]["rows"] == model.verify_calls[0]["rows"]
+    assert model.verify_calls[0]["block_width"] == 1 + num_drafts
+
+
+def test_propose_refuses_a_ragged_committed_block():
+    model = FakeSpecModel()
+    tokens, positions = _block(2, 4)
+    with pytest.raises(ValueError):
+        model.propose_draft_tokens(3, tokens[:, :3], positions, _counts(2, 1))
+
+
+def test_propose_refuses_a_block_narrower_than_one_plus_k():
+    model = FakeSpecModel()
+    tokens, positions = _block(2, 3)
+    with pytest.raises(ValueError):
+        model.propose_draft_tokens(3, tokens, positions, _counts(2, 1))
+
+
+@pytest.mark.parametrize("count", [0, 5])
+def test_verify_refuses_an_accepted_count_outside_the_inclusive_domain(count):
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    with pytest.raises(ValueError) as excinfo:
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((rows,), num_drafts, dtype=torch.int32),
+            _counts(rows, count),
+        )
+    assert str(count) in str(excinfo.value)
+
+
+def test_verify_accepts_the_lower_bound_that_follows_a_prefill():
+    # 1 means only the input token stood, which is also the value after a
+    # prefill and after a non-speculating step.
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    out = model.decode_forward(
+        tokens,
+        positions,
+        torch.zeros(rows, dtype=torch.int32),
+        _counts(rows, 1),
+    )
+    assert out.argmax_ids.shape == (rows, 1 + num_drafts)
+
+
+def test_verify_refuses_a_non_int32_accepted_counts():
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    with pytest.raises(ValueError):
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((rows,), num_drafts, dtype=torch.int32),
+            torch.ones(rows, dtype=torch.int64),
+        )
+
+
+def test_verify_refuses_a_none_accepted_counts_without_a_fused_previous_step():
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    with pytest.raises(ValueError):
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((rows,), num_drafts, dtype=torch.int32),
+            None,
+        )
+
+
+@pytest.mark.parametrize("valid", [-1, 4])
+def test_verify_refuses_a_per_row_draft_count_outside_zero_to_k(valid):
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    with pytest.raises(ValueError):
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((rows,), valid, dtype=torch.int32),
+            _counts(rows, 1),
+        )
+
+
+def test_verify_refuses_a_mis_sized_per_row_draft_count():
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    with pytest.raises(ValueError):
+        model.decode_forward(
+            tokens,
+            positions,
+            torch.full((rows + 1,), num_drafts, dtype=torch.int32),
+            _counts(rows, 1),
+        )

--- a/tests/spec/test_contract_conformance.py
+++ b/tests/spec/test_contract_conformance.py
@@ -2,21 +2,17 @@
 # SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 """The speculative-decoding contract enforces its own shapes and modes.
 
-These tests exercise the two mechanisms the contract types own: the inclusive
-domain of ``accepted_counts``, and the pairing between a ``spec_mode`` and the
-verify-return fields it requires. They also drive ``FakeSpecModel`` through the
-inputs the contract forbids, so a later change to the runner that builds a
-ragged block, a zero count or a mismatched width fails here rather than inside
-an accept walk.
+These tests exercise the mechanisms the contract types own: the inclusive
+domain of ``accepted_counts``, the pairing between a ``spec_mode`` and the
+verify-return fields it requires, and the completeness of that pairing. They
+also drive ``FakeSpecModel`` through the inputs the contract forbids, so a
+later change to the runner that builds a ragged block, a zero count, a
+mismatched width or a batch-wide draft count fails here rather than inside an
+accept walk.
 """
 
 import pytest
 import torch
-
-# vLLM's own bootstrap resolves the platform plugin, which imports plugin
-# modules. Letting a plugin import trigger that bootstrap deadlocks the cycle
-# on a half-built module, so let vLLM finish importing itself first.
-import vllm  # noqa: F401
 
 from tests.spec.fake_spec_model import (
     FAKE_VOCAB_SIZE,
@@ -30,6 +26,7 @@ from vllm_tt_plugin.spec_decode import (
     ACCEPT_MODES,
     DRAFTER_STATE_INTERNAL,
     HIDDEN_HANDOFFS,
+    MODE_REQUIRED_FIELDS,
     SPEC_REQUIREMENTS,
     SpecPlan,
     SpecReject,
@@ -62,8 +59,18 @@ def _block(rows: int, block_width: int, base: int = 10):
     return tokens, positions
 
 
-def _counts(rows: int, value: int):
+def _per_row(rows: int, value: int):
+    """One int32 entry per row, for accepted_counts and num_valid_drafts."""
     return torch.full((rows,), value, dtype=torch.int32)
+
+
+def _verify(model, tokens, positions, valid, counts, mode=ACCEPT_MODE_ARGMAX_IDS):
+    """Call the verify primitive with a mode always supplied.
+
+    The primitive itself has no default, so that a runner cannot silently get
+    greedy ids; a default here only keeps the input-validation tests short.
+    """
+    return model.decode_forward(tokens, positions, valid, counts, spec_mode=mode)
 
 
 # --- the contract's derived quantities ------------------------------------
@@ -138,17 +145,25 @@ def test_spec_reject_normalizes_supported_k_to_a_tuple():
 # --- the mode-to-return pairing -------------------------------------------
 
 
-def test_every_accept_mode_has_a_declared_return_shape():
-    # A mode with no required fields would construct empty and fail later.
-    for mode in ACCEPT_MODES:
-        with pytest.raises(ValueError):
-            VerifyOutput(spec_mode=mode)
+def test_every_accept_mode_declares_its_required_fields():
+    # Pinned directly: a mode missing from the mapping would otherwise be
+    # caught by the unknown-mode branch, which proves nothing about the
+    # mapping's completeness.
+    assert set(MODE_REQUIRED_FIELDS) == set(ACCEPT_MODES)
+    assert all(fields for fields in MODE_REQUIRED_FIELDS.values())
+
+
+@pytest.mark.parametrize("mode", sorted(ACCEPT_MODES))
+def test_verify_output_requires_the_fields_its_mode_declares(mode):
+    with pytest.raises(ValueError) as excinfo:
+        VerifyOutput(spec_mode=mode)
+    assert mode in str(excinfo.value)
 
 
 def test_verify_output_accepts_each_mode_with_its_own_fields():
     ids = torch.zeros(2, 4, dtype=torch.int32)
     logits = torch.zeros(2, 4, FAKE_VOCAB_SIZE)
-    counts = _counts(2, 1)
+    counts = _per_row(2, 1)
     assert (
         VerifyOutput(spec_mode=ACCEPT_MODE_ARGMAX_IDS, argmax_ids=ids).argmax_ids is ids
     )
@@ -161,17 +176,24 @@ def test_verify_output_accepts_each_mode_with_its_own_fields():
     assert fused.accepted_counts is counts
 
 
-def test_verify_output_rejects_a_mode_carrying_the_wrong_field():
+def test_verify_output_rejects_a_mode_missing_a_required_field():
+    ids = torch.zeros(2, 4, dtype=torch.int32)
+    # argmax_ids is not what "logits" mode declares, so the required field is
+    # still missing however many other fields are set.
     with pytest.raises(ValueError):
-        VerifyOutput(
-            spec_mode=ACCEPT_MODE_LOGITS,
-            argmax_ids=torch.zeros(2, 4, dtype=torch.int32),
-        )
+        VerifyOutput(spec_mode=ACCEPT_MODE_LOGITS, argmax_ids=ids)
     with pytest.raises(ValueError):
-        VerifyOutput(
-            spec_mode=ACCEPT_MODE_FUSED_SAMPLE,
-            accepted_token_ids=torch.zeros(2, 4, dtype=torch.int32),
-        )
+        VerifyOutput(spec_mode=ACCEPT_MODE_FUSED_SAMPLE, accepted_token_ids=ids)
+
+
+def test_verify_output_tolerates_a_field_another_mode_uses():
+    # Only the declared fields are required; a model that fills more is not
+    # wrong, so the runner reads by mode rather than by presence.
+    ids = torch.zeros(2, 4, dtype=torch.int32)
+    logits = torch.zeros(2, 4, FAKE_VOCAB_SIZE)
+    out = VerifyOutput(spec_mode=ACCEPT_MODE_ARGMAX_IDS, argmax_ids=ids, logits=logits)
+    assert out.spec_mode == ACCEPT_MODE_ARGMAX_IDS
+    assert out.logits is logits
 
 
 def test_verify_output_rejects_an_unknown_mode():
@@ -182,7 +204,8 @@ def test_verify_output_rejects_an_unknown_mode():
 
 def test_hidden_handle_stays_opaque():
     # The runner holds it and passes it back without interpreting it, so any
-    # object must survive the round trip, including None for on-device retention.
+    # object must survive the round trip, including None for on-device
+    # retention.
     sentinel = object()
     ids = torch.zeros(1, 2, dtype=torch.int32)
     assert (
@@ -263,6 +286,17 @@ def test_unknown_knob_raises_rather_than_being_ignored():
     assert "effective_k" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "method", ["spec_plan", "propose_draft_tokens", "decode_forward"]
+)
+def test_a_contract_method_is_not_a_settable_knob(method):
+    # Overriding one would replace a primitive with a plain value and fail at
+    # the call site instead of here.
+    with pytest.raises(ValueError) as excinfo:
+        make_fake_spec_model(**{method: None})
+    assert method in str(excinfo.value)
+
+
 # --- both accept modes agree ----------------------------------------------
 
 
@@ -271,58 +305,138 @@ def test_the_two_accept_modes_return_the_same_token_ids():
     model = FakeSpecModel()
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
-    valid = torch.full((rows,), num_drafts, dtype=torch.int32)
-    counts = _counts(rows, 1)
-    ids = model.decode_forward(
-        tokens, positions, valid, counts, spec_mode=ACCEPT_MODE_ARGMAX_IDS
-    ).argmax_ids
-    logits = model.decode_forward(
-        tokens, positions, valid, counts, spec_mode=ACCEPT_MODE_LOGITS
+    valid = _per_row(rows, num_drafts)
+    counts = _per_row(rows, 1)
+    ids = _verify(model, tokens, positions, valid, counts).argmax_ids
+    logits = _verify(
+        model, tokens, positions, valid, counts, mode=ACCEPT_MODE_LOGITS
     ).logits
     assert torch.equal(logits.argmax(dim=-1).to(torch.int32), ids)
 
 
-def test_fused_sample_is_refused_because_no_hardware_runs_it():
+def test_fused_sample_is_refused_because_no_implementation_serves_it():
     model = FakeSpecModel()
     tokens, positions = _block(1, 4)
     with pytest.raises(ValueError):
-        model.decode_forward(
+        _verify(
+            model,
             tokens,
             positions,
-            torch.full((1,), 3, dtype=torch.int32),
-            _counts(1, 1),
-            spec_mode=ACCEPT_MODE_FUSED_SAMPLE,
+            _per_row(1, 3),
+            _per_row(1, 1),
+            mode=ACCEPT_MODE_FUSED_SAMPLE,
         )
+
+
+def test_verify_requires_an_explicit_spec_mode():
+    # A runner that forgets the mode must fail, not receive greedy ids.
+    model = FakeSpecModel()
+    tokens, positions = _block(1, 4)
+    with pytest.raises(TypeError):
+        model.decode_forward(tokens, positions, _per_row(1, 3), _per_row(1, 1))
+
+
+# --- acceptance is per row, never reduced across the batch ----------------
+
+
+def test_each_row_accepts_to_its_own_valid_draft_count():
+    # A batch-wide count would let one grammar-truncated request destroy every
+    # other request's speculation, which the contract forbids.
+    model = FakeSpecModel()
+    tokens, positions = _block(2, 4)
+    ids = _verify(
+        model,
+        tokens,
+        positions,
+        torch.tensor([3, 0], dtype=torch.int32),
+        _per_row(2, 1),
+    ).argmax_ids
+    assert torch.equal(ids[0], tokens[0])
+    assert int(ids[1][1]) != int(tokens[1][1])
+
+
+def test_a_row_with_fewer_valid_drafts_diverges_only_past_its_own_count():
+    model = FakeSpecModel()
+    tokens, positions = _block(2, 4)
+    ids = _verify(
+        model,
+        tokens,
+        positions,
+        torch.tensor([1, 3], dtype=torch.int32),
+        _per_row(2, 1),
+    ).argmax_ids
+    assert int(ids[0][1]) == int(tokens[0][1])
+    assert int(ids[0][2]) != int(tokens[0][2])
+    assert torch.equal(ids[1], tokens[1])
+
+
+def test_accept_depth_caps_a_row_without_reducing_across_the_batch():
+    model = make_fake_spec_model(accept_depth=1)()
+    tokens, positions = _block(2, 4)
+    ids = _verify(model, tokens, positions, _per_row(2, 3), _per_row(2, 1)).argmax_ids
+    for row in range(2):
+        assert int(ids[row][1]) == int(tokens[row][1])
+        assert int(ids[row][2]) != int(tokens[row][2])
 
 
 # --- the stand-in refuses every input the contract forbids ----------------
 
 
-def test_propose_and_verify_take_the_same_padded_width():
+def test_verify_then_propose_take_the_same_padded_width():
+    # The contract's per-step order: verify first, then propose from that
+    # step's hidden state.
     model = FakeSpecModel()
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
-    counts = _counts(rows, 1)
+    counts = _per_row(rows, 1)
+    _verify(model, tokens, positions, _per_row(rows, num_drafts), counts)
     model.propose_draft_tokens(num_drafts, tokens, positions, counts)
-    model.decode_forward(
-        tokens, positions, torch.full((rows,), num_drafts, dtype=torch.int32), counts
-    )
-    assert model.propose_calls[0]["rows"] == model.verify_calls[0]["rows"]
+    assert model.verify_calls[0]["rows"] == model.propose_calls[0]["rows"]
     assert model.verify_calls[0]["block_width"] == 1 + num_drafts
 
 
-def test_propose_refuses_a_ragged_committed_block():
+@pytest.mark.parametrize(
+    "tokens, positions, offender",
+    [
+        (torch.zeros(4, dtype=torch.int32), torch.zeros(4, dtype=torch.int32), "2-D"),
+        (
+            torch.zeros(2, 4, dtype=torch.int32),
+            torch.zeros(3, 4, dtype=torch.int32),
+            "same shape",
+        ),
+        (
+            torch.zeros(2, 3, dtype=torch.int32),
+            torch.zeros(2, 3, dtype=torch.int32),
+            "uniform width",
+        ),
+        (
+            torch.zeros(0, 4, dtype=torch.int32),
+            torch.zeros(0, 4, dtype=torch.int32),
+            "at least one row",
+        ),
+    ],
+)
+def test_each_structural_violation_trips_its_own_guard(tokens, positions, offender):
+    # Each input is invalid in exactly one way, so a removed guard cannot hide
+    # behind a later one.
     model = FakeSpecModel()
-    tokens, positions = _block(2, 4)
-    with pytest.raises(ValueError):
-        model.propose_draft_tokens(3, tokens[:, :3], positions, _counts(2, 1))
+    with pytest.raises(ValueError) as excinfo:
+        model.propose_draft_tokens(3, tokens, positions, _per_row(2, 1))
+    assert offender in str(excinfo.value)
 
 
-def test_propose_refuses_a_block_narrower_than_one_plus_k():
+def test_verify_refuses_an_empty_batch():
     model = FakeSpecModel()
-    tokens, positions = _block(2, 3)
-    with pytest.raises(ValueError):
-        model.propose_draft_tokens(3, tokens, positions, _counts(2, 1))
+    empty = torch.zeros(0, 4, dtype=torch.int32)
+    with pytest.raises(ValueError) as excinfo:
+        _verify(
+            model,
+            empty,
+            empty,
+            torch.zeros(0, dtype=torch.int32),
+            torch.zeros(0, dtype=torch.int32),
+        )
+    assert "at least one row" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("count", [0, 5])
@@ -331,11 +445,8 @@ def test_verify_refuses_an_accepted_count_outside_the_inclusive_domain(count):
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
     with pytest.raises(ValueError) as excinfo:
-        model.decode_forward(
-            tokens,
-            positions,
-            torch.full((rows,), num_drafts, dtype=torch.int32),
-            _counts(rows, count),
+        _verify(
+            model, tokens, positions, _per_row(rows, num_drafts), _per_row(rows, count)
         )
     assert str(count) in str(excinfo.value)
 
@@ -346,24 +457,35 @@ def test_verify_accepts_the_lower_bound_that_follows_a_prefill():
     model = FakeSpecModel()
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
-    out = model.decode_forward(
-        tokens,
-        positions,
-        torch.zeros(rows, dtype=torch.int32),
-        _counts(rows, 1),
-    )
+    out = _verify(model, tokens, positions, _per_row(rows, 0), _per_row(rows, 1))
     assert out.argmax_ids.shape == (rows, 1 + num_drafts)
 
 
-def test_verify_refuses_a_non_int32_accepted_counts():
+def test_both_primitives_accept_the_inclusive_upper_bound():
+    # 1+K is full acceptance, the common speculative success, and it is the
+    # exact value an exclusive upper bound would reject.
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    full = _per_row(rows, 1 + num_drafts)
+    out = _verify(model, tokens, positions, _per_row(rows, num_drafts), full)
+    assert out.argmax_ids.shape == (rows, 1 + num_drafts)
+    drafts = model.propose_draft_tokens(
+        num_drafts, tokens, positions, full
+    ).draft_token_ids
+    assert drafts.shape == (rows, num_drafts)
+
+
+def test_verify_refuses_a_non_int32_accepted_per_row():
     model = FakeSpecModel()
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
     with pytest.raises(ValueError):
-        model.decode_forward(
+        _verify(
+            model,
             tokens,
             positions,
-            torch.full((rows,), num_drafts, dtype=torch.int32),
+            _per_row(rows, num_drafts),
             torch.ones(rows, dtype=torch.int64),
         )
 
@@ -373,12 +495,7 @@ def test_verify_refuses_a_none_accepted_counts_without_a_fused_previous_step():
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
     with pytest.raises(ValueError):
-        model.decode_forward(
-            tokens,
-            positions,
-            torch.full((rows,), num_drafts, dtype=torch.int32),
-            None,
-        )
+        _verify(model, tokens, positions, _per_row(rows, num_drafts), None)
 
 
 @pytest.mark.parametrize("valid", [-1, 4])
@@ -387,12 +504,7 @@ def test_verify_refuses_a_per_row_draft_count_outside_zero_to_k(valid):
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
     with pytest.raises(ValueError):
-        model.decode_forward(
-            tokens,
-            positions,
-            torch.full((rows,), valid, dtype=torch.int32),
-            _counts(rows, 1),
-        )
+        _verify(model, tokens, positions, _per_row(rows, valid), _per_row(rows, 1))
 
 
 def test_verify_refuses_a_mis_sized_per_row_draft_count():
@@ -400,9 +512,25 @@ def test_verify_refuses_a_mis_sized_per_row_draft_count():
     rows, num_drafts = 2, 3
     tokens, positions = _block(rows, 1 + num_drafts)
     with pytest.raises(ValueError):
-        model.decode_forward(
-            tokens,
-            positions,
-            torch.full((rows + 1,), num_drafts, dtype=torch.int32),
-            _counts(rows, 1),
+        _verify(
+            model, tokens, positions, _per_row(rows + 1, num_drafts), _per_row(rows, 1)
         )
+
+
+def test_propose_records_the_hidden_handoff_and_returns_no_scores():
+    # On-device retention hands propose no tensor, and this stand-in declares
+    # no drafter scores, so an accept rule needing them must not assume they
+    # are there.
+    model = FakeSpecModel()
+    rows, num_drafts = 2, 3
+    tokens, positions = _block(rows, 1 + num_drafts)
+    out = model.propose_draft_tokens(
+        num_drafts, tokens, positions, _per_row(rows, 1), hidden=None
+    )
+    assert out.draft_scores is None
+    assert model.propose_calls[0]["hidden_was_none"] is True
+    sentinel = object()
+    model.propose_draft_tokens(
+        num_drafts, tokens, positions, _per_row(rows, 1), hidden=sentinel
+    )
+    assert model.propose_calls[1]["hidden_was_none"] is False


### PR DESCRIPTION
## TL;DR

Adds the speculative-decoding contract types (`SpecPlan`, `SpecReject`, `DraftOutput`, `VerifyOutput`) and a host stand-in model class that implements the contract in torch. Nothing in the plugin consumes them yet: this is the surface the runner-side work is built against, landing ahead of its consumer on purpose.

## Details

The plugin rejects every speculative request today (`platform.py`, `_apply_check_and_update_config`). The runner-side work needed to lift that is almost entirely host logic: config admission, `[B, 1+K]` input construction, scheduler bookkeeping, the accept walk, output emission. None of it needs a device to exercise, but all of it needs a model that implements the contract, and no tt-metal model does yet.

So this PR adds that model as a test double, and the contract types it returns.

`src/vllm_tt_plugin/spec_decode.py` holds the wire surface and the validation of the values that cross it. It reads no `model_capabilities` key and admits no configuration, which keeps it inside the section 6 rule in `AGENTS.md`: a plugin change that consumes a new capability needs the matching tt-metal declaration in the same pair of PRs. Nothing here consumes one. `normalize_declared_values` validates a declaration a caller has already read, and lives here next to the constant sets it validates.

Two contract properties are enforced by the types rather than left to each caller, because leaving either to a caller invites an error that only surfaces inside an accept walk:

- `SpecPlan.accepted_counts_range` is the inclusive `[1, 1+K]` domain of `accepted_counts`. It is a count of committed tokens and never zero, so a model selecting a per-candidate state slot selects slot `accepted_counts - 1`. This matches upstream's `num_accepted_tokens` convention, which fills with 1 for new and unused rows (`vllm/v1/worker/gpu_model_runner.py`, `vllm/v1/worker/gpu_input_batch.py`) and reads slot `n_acc - 1` in its recurrent kernels (`vllm/model_executor/layers/fla/ops/fused_recurrent.py`).
- `VerifyOutput.__post_init__` enforces the pairing between a `spec_mode` and the fields its return must carry. `MODE_REQUIRED_FIELDS` is public because it is contract information, so a caller can check a return it did not build.
- `SpecPlan` refuses `drafter_target_cache_requires` on a `drafter_state` that reserves bytes. The two cost-bearing states describe what the runner must budget; `"shared_with_target"` describes a drafter that reserves nothing and instead constrains how the target's caches are organised. A requirement on a cost-bearing state is a contradiction, not extra information, and the failure mode it guards against is reading the wrong cache positions rather than failing to allocate.
- `PLACEHOLDER_TOKEN_ID` names the tail marker for a fixed-width block that committed fewer tokens than its width. A real token identifier cannot serve as the pad, including the end-of-sequence identifier, because it is indistinguishable from a committed token and silently turns a short commit into a stop.

`tests/spec/fake_spec_model.py` is the stand-in. Its value is that it refuses every input the contract forbids rather than tolerating it: a ragged committed block, a mis-ranked tensor, an empty batch, a width other than `1+K`, a non-int32 or out-of-domain `accepted_counts`, a per-row draft count outside `[0, K]`, and a `None` count outside the one case that permits it. That makes the follow-up runner work fail here rather than in a debugger.

Acceptance in the stand-in is per row, capped at `min(accept_depth, num_valid_drafts[i])`, and never reduced across the batch. A batch-wide cap would let one grammar-truncated request destroy every other request's speculation, which the contract forbids, and a stand-in that did so could not drive the mixed-row case the runner has to get right.

Both `argmax_ids` and `logits` are served, not just the mode a first model would land, because the mode dispatch is the runner code most likely to be wrong and a second mode costs nothing in a stand-in. A test asserts the two return the same ids, so a test of one is evidence about the other. `fused_sample` is refused, because no implementation serves it today on either side; the contract keeps the mode for a model that will, and a stand-in that served it would give a passing test for a path nothing can run. `SpecPlan` still accepts the mode, because refusing a mode no model implements is a config-time policy and not a property of a value object.

`spec_plan` is a classmethod, since the runner calls it before an instance exists. `make_fake_spec_model(**knobs)` returns a configured subclass rather than mutating class attributes, so one test cannot configure the next, and it refuses a knob naming a contract method rather than replacing a primitive with a plain value. `decode_forward` takes `spec_mode` with no default, so a caller that forgets it fails instead of silently receiving greedy ids.

## Related Artifacts

Contract: tenstorrent/vllm-tt-plugin#110. Model-side feature request: tenstorrent/vllm#442. First tt-metal implementation: tenstorrent/tt-metal#55548.

This is step 1 of a plugin-side plan whose later steps consume these types: config admission, the `[B, 1+K]` input build, an ngram drafter with a greedy accept walk, a torch accept walk for sampled requests, and structured output over drafts.

No paired tt-metal change is needed, because this PR consumes no capability.

## Validation

Host-only, no Tenstorrent hardware, using the `AGENTS.md` recipe.

```text
$ PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/spec -q
71 passed in 3.12s

$ PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/ --ignore=tests/tt -q
456 passed, 14 warnings in 3.65s

baseline on origin/main, excluding tests/spec:
$ PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/ --ignore=tests/tt --ignore=tests/spec -q
385 passed, 14 warnings in 3.64s
```

`pre-commit run` over the four files:

```text
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
```

The conformance tests were mutation-checked, so they are known to bite rather than to pass trivially. Each mutation breaks one property the suite claims to pin:

```text
per-row cap -> batch-wide minimum:            2 failed, 61 passed
block shape-equality guard removed:           1 failed, 62 passed
block rank guard removed:                     1 failed, 62 passed
accepted_counts upper bound made exclusive:   1 failed, 62 passed
empty-batch guard removed:                    2 failed, 61 passed
a mode dropped from MODE_REQUIRED_FIELDS:     3 failed, 60 passed
all mutations reverted:                      63 passed
```

The third commit tracks three contract changes and adds three more mutations:

```text
cost-vs-constraint contradiction check dropped:   1 failed, 70 passed
shared_with_target dropped from DRAFTER_STATES:   2 failed, 69 passed
PLACEHOLDER_TOKEN_ID set to a real token id:      1 failed, 70 passed
all mutations reverted:                          71 passed
```

The first four of those mutations survived the suite as originally pushed, and the last two properties were unpinned entirely. The second commit fixes the per-row defect they exposed and closes all six gaps, so the mutation table above is also the review record.

No device validation applies: this PR adds no device-reaching code, and `ci/host-stubs/ttnn/` would fail loudly if it did.

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [ ] I updated documentation where applicable.

