### PR TITLE
Retarget TTTv1 generator imports to models.ttt_compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,7 @@ Two more contracts are methods, not dict keys: hybrid KV opt-in is
 `release_persistent_capture`.
 
 The model classes and their capability declarations live in **tt-metal**, under
-`models.tt_transformers.tt.generator_vllm` and the per-demo generators such as
+`models.ttt_compat.tt.generator_vllm` and the per-demo generators such as
 `models.demos.llama3_70b_galaxy.tt.generator_vllm`.
 
 Consequence: a plugin change that consumes a new capability needs a matching

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ login()
 
 For the target model, follow any setup instructions in the corresponding
 tt-metal demo. For Llama 3.1, Llama 3.2, and Qwen 2.5 models, follow the
-[tt-transformers demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers)
+[tt-transformers demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/ttt_compat)
 for weights and environment variables.
 
 ## Running The Offline Inference Example
@@ -569,7 +569,7 @@ a 6x reduction in KV cache memory.
 
 To enable hybrid KV cache support for a TT model:
 
-1. Inherit from `models.tt_transformers.tt.generator_vllm.HybridAttentionForCausalLM`
+1. Inherit from `models.ttt_compat.tt.generator_vllm.HybridAttentionForCausalLM`
    instead of `Generator`. The base class provides a default
    `get_kv_cache_spec` classmethod that builds per-layer specs from
    `hf_config.text_config.layer_types`.

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -1049,7 +1049,7 @@ def register_tt_models(register_test_models=False) -> None:
 
     llama_text_version = os.getenv("TT_LLAMA_TEXT_VER", "tt_transformers")
     if llama_text_version == "tt_transformers":
-        path_llama_text = "models.tt_transformers.tt.generator_vllm:LlamaForCausalLM"
+        path_llama_text = "models.ttt_compat.tt.generator_vllm:LlamaForCausalLM"
     elif llama_text_version == "llama3_70b_galaxy":
         path_llama_text = (
             "models.demos.llama3_70b_galaxy.tt.generator_vllm:LlamaForCausalLM"
@@ -1071,17 +1071,17 @@ def register_tt_models(register_test_models=False) -> None:
     _register_model_if_missing(
         ModelRegistry,
         "TTMllamaForConditionalGeneration",
-        "models.tt_transformers.tt.generator_vllm:MllamaForConditionalGeneration",
+        "models.ttt_compat.tt.generator_vllm:MllamaForConditionalGeneration",
     )
 
     # Qwen2.5 - Text
-    path_qwen_text = "models.tt_transformers.tt.generator_vllm:QwenForCausalLM"
+    path_qwen_text = "models.ttt_compat.tt.generator_vllm:QwenForCausalLM"
     _register_model_if_missing(ModelRegistry, "TTQwen2ForCausalLM", path_qwen_text)
 
     # Qwen3 - Text
     qwen3_text_version = os.getenv("TT_QWEN3_TEXT_VER", "tt_transformers")
     if qwen3_text_version == "tt_transformers":
-        path_qwen3_text = "models.tt_transformers.tt.generator_vllm:QwenForCausalLM"
+        path_qwen3_text = "models.ttt_compat.tt.generator_vllm:QwenForCausalLM"
     elif qwen3_text_version == "qwen3_32b_galaxy":
         path_qwen3_text = (
             "models.demos.llama3_70b_galaxy.tt.generator_vllm:QwenForCausalLM"
@@ -1128,21 +1128,21 @@ def register_tt_models(register_test_models=False) -> None:
     _register_model_if_missing(
         ModelRegistry,
         "TTMistralForCausalLM",
-        "models.tt_transformers.tt.generator_vllm:MistralForCausalLM",
+        "models.ttt_compat.tt.generator_vllm:MistralForCausalLM",
     )
 
     # Mistral 3 - Multimodal (Vision + Text)
     _register_model_if_missing(
         ModelRegistry,
         "TTMistral3ForConditionalGeneration",
-        "models.tt_transformers.tt.generator_vllm:Mistral3ForConditionalGeneration",
+        "models.ttt_compat.tt.generator_vllm:Mistral3ForConditionalGeneration",
     )
 
     # Gemma3
     _register_model_if_missing(
         ModelRegistry,
         "TTGemma3ForConditionalGeneration",
-        "models.tt_transformers.tt.generator_vllm:Gemma3ForConditionalGeneration",
+        "models.ttt_compat.tt.generator_vllm:Gemma3ForConditionalGeneration",
     )
 
     # Gemma4 — text-only TT bridge.
@@ -1201,7 +1201,7 @@ def register_tt_models(register_test_models=False) -> None:
     _register_model_if_missing(
         ModelRegistry,
         "TTGptOssForCausalLM",
-        "models.tt_transformers.tt.generator_vllm:GptOssForCausalLM",
+        "models.ttt_compat.tt.generator_vllm:GptOssForCausalLM",
     )
 
     # Optionally register test models if explicitly enabled

--- a/src/vllm_tt_plugin/utils/dp_discovery.py
+++ b/src/vllm_tt_plugin/utils/dp_discovery.py
@@ -188,7 +188,7 @@ def _discover_standard_dp_visible_device_groups(
     [("0,1,2,3,4,5,6,7", (1, 8)), ...]
     """
     import ttnn
-    from models.tt_transformers.tt.generator import create_submeshes
+    from models.ttt_compat.tt.generator import create_submeshes
 
     mesh_device = None
     submeshes = []

--- a/tests/test_dp_modes.py
+++ b/tests/test_dp_modes.py
@@ -28,7 +28,7 @@ class TestDPModes:
         return type(
             "DummyModel",
             (),
-            {"__module__": "models.tt_transformers.tt.generator_vllm"},
+            {"__module__": "models.ttt_compat.tt.generator_vllm"},
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Pair with tt-metal #55977: `models/tt_transformers` is now `models/ttt_compat` (hard rename, no shim).
- Rewrite the seven builtin `platform.py` registry strings plus `create_submeshes` / dummy-model `__module__` / docs to `models.ttt_compat.tt.generator_vllm`.
- Leave `TT_LLAMA_TEXT_VER=tt_transformers` / `TT_QWEN3_TEXT_VER=tt_transformers` alone — version selector, not a path.

**Do not merge this onto a tt-metal pin that still has `models.tt_transformers`.** Serving will ImportError the other way.

## Test plan
- [ ] `TT_LLAMA_TEXT_VER=tt_transformers` still selects the TTT text bridge (now `models.ttt_compat.tt.generator_vllm:LlamaForCausalLM`)
- [ ] Llama / Qwen2 / Qwen3 / Mistral / Mistral3 / Gemma3 / GptOss / Mllama registry targets import
- [ ] DP discovery still imports `models.ttt_compat.tt.generator.create_submeshes`
- [ ] `tests/test_dp_modes.py` dummy `__module__` matches the new package


Made with [Cursor](https://cursor.com)