### PR TITLE
[bug] Capture the decode trace before prefill in warmup Phase 2

### DIFF
--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -2645,8 +2645,14 @@ class TTModelRunner:
         if hasattr(self.model, "already_warmed_up_prefill"):
             self.model.already_warmed_up_prefill = False
 
-        # Phase 2: capture traces (all ops already compiled)
-        if trace_prefill_mode:
-            self.model.warmup_model_prefill(enable_trace=True, **prefill_kwargs)
+        # Phase 2: capture traces (all ops already compiled). Capture decode
+        # before prefill: the decode trace's persistent input buffers (token,
+        # position, page table) are staged with copy_host_to_device while no
+        # trace is live, so they cannot be placed inside a prefill trace's
+        # scratch. Capturing prefill first leaves those buffers allocated while
+        # a prefill trace is live, and every later prefill replay then rewrites
+        # them (observed as a zeroed decode token buffer on decode).
         if trace_decode_mode:
             self.model.warmup_model_decode(enable_trace=True, **decode_kwargs)
+        if trace_prefill_mode:
+            self.model.warmup_model_prefill(enable_trace=True, **prefill_kwargs)


### PR DESCRIPTION
## TL;DR

Fix a decode token corruption bug (one wrong sampled token per concurrent split prefill) by capturing the decode trace before any prefill trace in warmup Phase 2, so the decode trace's persistent input buffers are staged while no trace is live.

## Details

**Symptom.** With the decode-interleave policy (decode steps between prefill chunks, #119), a long prefill that is split into chunks produces exactly one wrong sampled token per concurrent split prefill. The wrong token is at the position right after the last prefill chunk, and the sampled token equals the token at sequence position 0 of the corrupted request.

**Root cause.** `TTModelRunner.warmup_model` runs a two-phase warmup: Phase 1 compiles all ops (`enable_trace=False`), Phase 2 captures the traces (`enable_trace=True`). Phase 2 captured prefill before decode. The decode trace's persistent input buffers (token, position, page table) are staged via `copy_host_to_device` during `warmup_model_decode`. With a prefill trace already live, the trace allocator placed these long-lived decode input buffers inside the live prefill trace's scratch region. Every later prefill trace replay zeroes that scratch region, so the device token buffer is zeroed (`dev_toks[i] == 0`) while the device position buffer still matches the host. The keep block in `models/tt_transformers/tt/generator.py` (`use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)`) then wrongly trusts the zeroed device token, producing one corrupted sampled token.

This is the decode-warmup instance of the allocation-ordering invariant documented in tenstorrent/tt-metal#54441 ("prefill warmup prepares traces while other traces are live"): no device memory may be allocated while another trace is live, because a buffer handed out afterwards can land inside a live trace's scratch and be clobbered on replay. #54441 covers the prefill-warmup instance (bucket N+1 prepared while bucket N is live); this PR fixes the decode-warmup instance (decode inputs staged while a prefill trace is live).

**Fix.** In Phase 2, capture the decode trace before the prefill traces. The decode trace's persistent input buffers are then staged while no trace is live, so the allocator cannot place them inside a prefill trace's scratch region. The plugin owns the decode page-table sizing (`decode_kwargs` includes `num_blocks=self.max_num_blocks_per_req`, which depends on vLLM KV-cache profiling invisible to the generator), so the reorder lives in the plugin rather than in the generator's warmup machinery.

## Related Artifacts

- Exposed by #119 (the decode-interleave feature; issue #109).
- Related: tenstorrent/tt-metal#54441 (the same allocation-ordering invariant, prefill-warmup instance; pre-existing and unchanged by this PR).
- Follow-up: tenstorrent/tt-metal#56215 (architectural fix: give the warmup path a prepare-only phase that stages all trace inputs before any capture). This PR is the interim fix - it reorders capture so the decode token buffer is staged while no trace is live, but does not decouple input staging from capture.

## Validation

CI: https://github.com/tenstorrent/tt-metal/actions/runs/34576046860

Host (this repo):

```text
$ pre-commit run
... passes on the changed files (ruff 0.14.0)

$ PYTHONPATH=ci/host-stubs .venv/bin/python -m pytest tests/ --ignore=tests/tt -q
385 passed
```

Device (wh-lb-77, T3K 8xWormhole, meta-llama/Llama-3.1-8B-Instruct, on top of #119):

```text
# Server:
python3 examples/server_example_tt.py --model meta-llama/Llama-3.1-8B-Instruct \
  --max_num_seqs 32 --block_size 64 --max_model_len 32768 --async-scheduling \
  --no-enable-prefix-caching --enable-chunked-prefill --max-num-batched-tokens 2048 \
  --additional-config '{"tt":{"fabric_config":"FABRIC_1D","sample_on_device_mode":"all","trace_region_size":85000000}}'

# Test:
pytest tests/tt/test_chunked_prefill.py -q -k prefills_sharing \
  --tt-server-url=http://localhost:8000 \
  --tt-model-name=meta-llama/Llama-3.1-8B-Instruct --tt-chunked-prefill-budget=2048

# Without this fix the interleave test passes roughly 1 in 22 runs (the
# corruption is timing-dependent). With this fix, 12/12 runs pass (two
# independent 6/6 runs).
# With TT_METAL_TRACE_ALLOC_TRACKING=1, the decode token buffer is no longer
# flagged as overlapping a live trace. The tracker now flags only
# prefill-vs-prefill buffers at a _prefill_forward_trace replay, which is the
# pre-existing #54441 instance (those I/O buffers are rewritten before each
# use, so it is benign) and is unchanged by this PR.
```

AI assistance was used in preparing this change.

## Checklist

- [x] This PR is focused on a single logical change.
- [ ] I added or updated tests where applicable. (No host test added; this is a warmup-ordering change validated on device - see Validation.)
- [x] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
