### PR TITLE
[feat] Enable on-device grammar sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ vllm_cache/
 *.tensorbin
 tracy/
 profiler/
+
+# Locally generated runtime/build artifacts (fabric, inspector, watcher, etc.)
+generated/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,7 @@ Keys currently consumed by `src/vllm_tt_plugin/platform.py`:
 | `supports_prefix_caching` | `False` | Whether the vLLM prefix cache may be used |
 | `output_tokens_per_step` | `1` | Committed output width per step. `1` is token-at-a-time; `>1` is block-output width |
 | `supports_sample_on_device` | `False` | Opt-in for on-device sampling. A requested `sample_on_device_mode` is rejected when `False` |
+| `supports_device_grammar` | `False` | Whether decode sampling can accept vLLM's packed grammar bitmask after forward. Requires `supports_sample_on_device`; structured prefill remains host-sampled |
 | `supports_async_decode` | `False` | Whether async scheduling may stay on. When `False`, the platform warns and clears `async_scheduling` |
 
 Absent keys default via `.get`. That is the live contract. Do not add

--- a/README.md
+++ b/README.md
@@ -280,7 +280,11 @@ curl http://localhost:8000/v1/completions \
   }'
 ```
 
-Requests that cannot use TT on-device sampling automatically fall back to vLLM’s host-side sampling path. This fallback is selected per batch and requires no user configuration.
+Before a forward is submitted, TT selects one sampling path for the whole
+submitted batch. If any request or batch feature cannot use on-device
+sampling, the batch uses vLLM's host-side path. A failure after deferred device
+sampling has begun is terminal rather than retried on host, because the device
+decode and sampler state may already have advanced.
 
 For vision models, start the server with the correct `--model`, then send a chat
 completion request with image content. Qwen 2.5-VL models can use either a
@@ -314,6 +318,28 @@ Common options:
 | `always_compat_sampling` | Use vLLM's LogitProcessor and sampler path even when not required by the batch. Default: `false`. |
 | `optimizations` | Select model/runtime optimization profile, such as `accuracy` or `performance`. |
 | `register_test_models` | Register non-production TT test models for infrastructure tests. Default: `false`. |
+
+Structured-output sampling is capability-gated independently from ordinary
+device sampling:
+
+| Step | Sampling path |
+| --- | --- |
+| Structured prefill | Host sampling |
+| Eligible structured decode | TT device sampling after the sample-time grammar mask arrives |
+| Structured decode with logprobs, another host-only sampling option, or no effective device-grammar support | Host sampling |
+
+Eligibility requires an operator-selected `sample_on_device_mode`, the static
+`supports_device_grammar` capability, a compatible runtime sampler (not
+row-sharded), model warmup when tracing, and no logprobs (including
+`logprobs=0`) or other host-only sampling option. It also requires
+`--no-async-scheduling`; with upstream batch-queue overlap enabled, structured
+requests retain host sampling. Block-output models reject structured outputs
+rather than falling back.
+
+Fallback is selected before forward submission. Once an eligible decode is
+submitted with deferred device sampling, its sample-time grammar mask must be
+present and valid. A missing mask or a device-sampling failure is terminal for
+that runner and requires recovery/restart; it is not retried on host.
 
 ### `max_model_len` And KV Cache Capacity
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -352,6 +352,24 @@ Overlap is disabled and pending async work is drained when correctness would oth
 - logprobs, including an explicit `logprobs=0`, or other features that force a
   more synchronous path
 
+When device sampling is operator-enabled, a model declares
+`supports_device_grammar`, its loaded sampler reports compatible runtime
+support, and the submitted batch has no logprobs or other host-only option, a
+structured decode keeps logits on device until `sample_tokens()` supplies and
+remaps the packed grammar mask. Sampling-path eligibility is batch-wide: one
+ineligible request moves the whole submitted TT batch to host sampling. The
+runner drains pending async work before that forward and completes device
+sampling synchronously after the mask arrives. This initial path also requires
+`async_scheduling=False`, because upstream's batch queue can otherwise submit
+another forward before the current grammar arrives. Structured prefill and
+ineligible structured decode retain host sampling. Block-output models reject
+structured outputs.
+
+That choice is made before forward submission. A deferred decode that later
+receives no mask, an incomplete request-to-mask mapping, or a device-sampling
+failure invalidates the runner; it cannot safely retry the already-submitted
+step on host.
+
 So the TT async path is best understood as a fast path for steady decode, not as a universal async execution model.
 
 The effective `async_scheduling` setting controls this engine and device

--- a/src/vllm_tt_plugin/async_decode.py
+++ b/src/vllm_tt_plugin/async_decode.py
@@ -36,6 +36,8 @@ class TTDecodeSubmission:
     batch_size_per_dp: list[int]
     sampling_params: Any
     perform_device_sampling: bool
+    device_sampling_params: Any | None = None
+    deferred_device_sampling: bool = False
     reload_plan: TTDecodeReloadPlan | None = None
 
 
@@ -206,6 +208,7 @@ class TTAsyncDecodeController:
         self._previous_device_sampling: bool | None = None
         self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
         self._legacy_contract_warning_emitted = False
+        self.device_grammar_sample_count = 0
 
     @staticmethod
     def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
@@ -446,7 +449,7 @@ class TTAsyncDecodeController:
             return False
         if model_input.decode_layout_changed:
             return False
-        if model_input.grammar_bitmask[0] is not None:
+        if getattr(model_input, "defer_device_sampling", False):
             return False
         if (
             model_input.prompt_tokens is not None
@@ -773,7 +776,24 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
+        deferred_device_sampling = bool(
+            getattr(model_input, "defer_device_sampling", False)
+        )
         contract_version = self.decode_input_update_contract_version()
+        if deferred_device_sampling and (
+            not perform_device_sampling or model_input.prompt_lens is not None
+        ):
+            raise ValueError(
+                "defer_device_sampling requires a device-sampled decode step; "
+                f"perform_device_sampling={perform_device_sampling}, "
+                f"is_decode={model_input.prompt_lens is None}"
+            )
+        if deferred_device_sampling and (read_from_device or async_read):
+            raise ValueError(
+                "deferred device sampling must retain device logits and cannot "
+                f"read them during submission; read_from_device={read_from_device}, "
+                f"async_read={async_read}"
+            )
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,
@@ -781,6 +801,7 @@ class TTAsyncDecodeController:
                 batch_size_per_dp=batch_size_per_dp,
                 sampling_params=sampling_params,
                 perform_device_sampling=perform_device_sampling,
+                deferred_device_sampling=deferred_device_sampling,
                 reload_plan=None,
             )
 
@@ -797,6 +818,7 @@ class TTAsyncDecodeController:
         # kwarg.
         if model_input.block_tables_per_layer is not None:
             kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
+        device_sampling_params = None
         if perform_device_sampling:
             sampling_param_dict = {
                 field.name: (
@@ -810,7 +832,11 @@ class TTAsyncDecodeController:
                 None if s == SEED_NONE_SENTINEL else s
                 for s in sampling_param_dict["seed"]
             ]
-            kwargs["sampling_params"] = type(sampling_params)(**sampling_param_dict)
+            device_sampling_params = type(sampling_params)(**sampling_param_dict)
+            if deferred_device_sampling:
+                kwargs["defer_device_sampling"] = True
+            else:
+                kwargs["sampling_params"] = device_sampling_params
             if model_input.prompt_tokens is not None:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
@@ -901,8 +927,76 @@ class TTAsyncDecodeController:
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
+            device_sampling_params=device_sampling_params,
+            deferred_device_sampling=deferred_device_sampling,
             reload_plan=reload_plan,
         )
+
+    def complete_deferred_device_sampling(
+        self,
+        submission: TTDecodeSubmission,
+        model_input: TTModelInput,
+    ) -> TTFinalizedDecode:
+        """Apply sample-time grammar on device, then finalize sampled tokens."""
+
+        def fail_deferred() -> None:
+            self._decode_chain_valid = False
+            self._submitted_page_tables = None
+            self.runner._poison_device_grammar()
+
+        if not submission.deferred_device_sampling:
+            raise ValueError(
+                "decode submission is not awaiting deferred device sampling"
+            )
+        if submission.tt_out is None or submission.device_sampling_params is None:
+            raise RuntimeError(
+                "deferred device sampling is missing device logits or "
+                "sampling parameters"
+            )
+        if len(model_input.grammar_bitmask) != 1:
+            raise ValueError(
+                "deferred device grammar expects one merged mask payload, got "
+                f"{len(model_input.grammar_bitmask)}"
+            )
+        grammar_bitmask = model_input.grammar_bitmask[0]
+        if grammar_bitmask is None:
+            fail_deferred()
+            raise RuntimeError(
+                "structured decode reached deferred device sampling without "
+                "a sample-time grammar bitmask"
+            )
+
+        sample_decode = getattr(self.runner.model, "sample_decode_on_device", None)
+        if not callable(sample_decode):
+            fail_deferred()
+            raise AttributeError(
+                "TT model declares device grammar support but does not implement "
+                "sample_decode_on_device()"
+            )
+        try:
+            sampled = sample_decode(
+                submission.tt_out,
+                sampling_params=submission.device_sampling_params,
+                grammar_bitmask=grammar_bitmask,
+            )
+            completed_submission = replace(
+                submission,
+                tt_out=sampled,
+                read_events=None,
+                deferred_device_sampling=False,
+            )
+            finalized = self.finalize_decode(completed_submission)
+            if finalized is None:
+                raise RuntimeError("deferred device sampling produced no output")
+        except Exception:
+            fail_deferred()
+            raise
+        self.device_grammar_sample_count += 1
+        logger.info(
+            "TT device grammar sampling active count=%d",
+            self.device_grammar_sample_count,
+        )
+        return finalized
 
     def finalize_decode(
         self,
@@ -911,6 +1005,10 @@ class TTAsyncDecodeController:
         runner = self.runner
         if submission.tt_out is None:
             return None
+        if submission.deferred_device_sampling:
+            raise RuntimeError(
+                "cannot finalize decode logits before deferred device sampling"
+            )
 
         if submission.read_events is not None:
             for read_event in submission.read_events:

--- a/src/vllm_tt_plugin/config.py
+++ b/src/vllm_tt_plugin/config.py
@@ -39,6 +39,7 @@ def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
 # get_tt_data_parallel_size.
 _RESOLVED_LANE_COUNT_KEY = "_tt_resolved_lane_count"
 _OUTPUT_TOKENS_PER_STEP_KEY = "_tt_output_tokens_per_step"
+_SUPPORTS_DEVICE_GRAMMAR_KEY = "_tt_supports_device_grammar"
 
 
 def get_tt_data_parallel_size(vllm_config: "VllmConfig") -> int:
@@ -120,6 +121,43 @@ def store_tt_output_tokens_per_step(
         additional = {}
         vllm_config.additional_config = additional
     additional[_OUTPUT_TOKENS_PER_STEP_KEY] = output_tokens_per_step
+
+
+def get_tt_supports_device_grammar(vllm_config: "VllmConfig") -> bool:
+    """Return the resolved model-side device grammar capability."""
+    additional = getattr(vllm_config, "additional_config", None) or {}
+    return bool(additional.get(_SUPPORTS_DEVICE_GRAMMAR_KEY, False))
+
+
+def is_tt_device_grammar_preload_eligible(
+    vllm_config: "VllmConfig",
+    *,
+    trace_mode: str,
+    enable_model_warmup: bool,
+) -> bool:
+    """Whether config-time state permits loading device grammar support.
+
+    Grammar-on sampling traces must be compiled before traced execution starts.
+    The loaded runner separately checks sampler/API and mesh-layout support.
+    """
+    return get_tt_supports_device_grammar(vllm_config) and (
+        trace_mode == "none" or enable_model_warmup
+    )
+
+
+def store_tt_supports_device_grammar(
+    vllm_config: "VllmConfig", supported: bool
+) -> None:
+    """Store device grammar support on the serializable vLLM config."""
+    if not isinstance(supported, bool):
+        raise ValueError(
+            f"resolved TT supports_device_grammar must be a boolean, got {supported!r}"
+        )
+    additional = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional, dict):
+        additional = {}
+        vllm_config.additional_config = additional
+    additional[_SUPPORTS_DEVICE_GRAMMAR_KEY] = supported
 
 
 def get_tt_max_batch_size(vllm_config: "VllmConfig") -> int:

--- a/src/vllm_tt_plugin/input_batch.py
+++ b/src/vllm_tt_plugin/input_batch.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -29,8 +30,10 @@ from vllm_tt_plugin.model_input import (
     slice_tt_sampling_params,
 )
 from vllm_tt_plugin.structured_output import (
+    capture_structured_decode_request_ids,
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
+    scheduled_structured_output_request_ids,
 )
 
 if TYPE_CHECKING:
@@ -1124,7 +1127,10 @@ class TTLaneInputBatch(InputBatch):
         )
 
     def slot_grammar_bitmask(
-        self, grammar_output: "GrammarOutput | None", batch_length: int
+        self,
+        grammar_output: "GrammarOutput | None",
+        batch_length: int,
+        expected_structured_output_request_ids: Collection[str] | None = None,
     ) -> torch.Tensor | None:
         """Reorder the scheduler grammar bitmask into a full slot-batch tensor.
 
@@ -1140,6 +1146,9 @@ class TTLaneInputBatch(InputBatch):
             structured_output_request_ids=grammar_output.structured_output_request_ids,
             row_req_ids=self.req_ids[:batch_length],
             batch_length=batch_length,
+            expected_structured_output_request_ids=(
+                expected_structured_output_request_ids
+            ),
         )
 
     # ------------------------------------------------------------------
@@ -1200,9 +1209,20 @@ class TTLaneInputBatch(InputBatch):
         has_structured = has_structured_outputs(
             runner.requests, scheduler_output, bitmask
         )
+        scheduled_structured_req_ids = scheduled_structured_output_request_ids(
+            runner.requests,
+            scheduler_output,
+        )
+        has_scheduled_structured = bool(scheduled_structured_req_ids)
+        structured_output_req_ids = capture_structured_decode_request_ids(
+            scheduled_structured_req_ids,
+            lane_batch.req_ids[:total],
+        )
         perform_device_sampling = runner.check_perform_device_sampling(
             is_decode=True, has_structured_outputs=has_structured
         )
+        if has_structured and not has_scheduled_structured:
+            perform_device_sampling = False
 
         # The prompt/output token tensors feed device-side penalties only. Host
         # sampling rebuilds them itself in ``build_merged_sampling_metadata``, so
@@ -1241,6 +1261,11 @@ class TTLaneInputBatch(InputBatch):
             logitsprocs_list=[None],
             generators_list=[{}],
             prefill_empty_slots=None,
+            defer_device_sampling=(
+                perform_device_sampling and has_scheduled_structured
+            ),
+            structured_output_req_ids=structured_output_req_ids,
+            grammar_row_req_ids=tuple(lane_batch.req_ids[:total]),
         )
 
     def _build_prefill_input(
@@ -1288,6 +1313,17 @@ class TTLaneInputBatch(InputBatch):
         bitmask = lane_batch.slot_grammar_bitmask(
             grammar_output, lane_batch.max_num_reqs
         )
+        scheduled_structured_req_ids = scheduled_structured_output_request_ids(
+            runner.requests,
+            scheduler_output,
+        )
+        structured_output_req_ids = frozenset(
+            lane_batch.req_ids[row]
+            for local_row, row in enumerate(rows)
+            if lane_batch.req_ids[row] in scheduled_structured_req_ids
+            and not bool(intermediate_prefill_mask[local_row])
+        )
+        prefill_rows = set(rows)
         has_structured = has_structured_outputs(
             runner.requests, scheduler_output, bitmask
         )
@@ -1343,6 +1379,12 @@ class TTLaneInputBatch(InputBatch):
                 else None
             ),
             intermediate_prefill_mask=intermediate_prefill_mask,
+            defer_device_sampling=False,
+            structured_output_req_ids=structured_output_req_ids,
+            grammar_row_req_ids=tuple(
+                lane_batch.req_ids[row] if row in prefill_rows else None
+                for row in range(lane_batch.max_num_reqs)
+            ),
         )
 
     def extract_output(

--- a/src/vllm_tt_plugin/model_input.py
+++ b/src/vllm_tt_plugin/model_input.py
@@ -175,3 +175,16 @@ class TTModelInput:
     # must resolve rows through this. ``None`` for lane builds, whose rows are
     # the persistent slots.
     row_req_ids: list[str] | None = None
+
+    # Decode-only: retain device logits until sample_tokens supplies the grammar,
+    # then invoke the model's device sampler. Structured prefills stay on host.
+    defer_device_sampling: bool = False
+
+    # Requests in this forward that must receive a sample-time grammar row.
+    # Captured with the forward so a partial GrammarOutput cannot silently leave
+    # a structured row all-allowed after the persistent batch changes.
+    structured_output_req_ids: frozenset[str] = frozenset()
+
+    # Immutable row identity used for sample-time grammar remapping. Includes
+    # padding/gap rows as None and is never reconstructed from a mutable batch.
+    grammar_row_req_ids: tuple[str | None, ...] = ()

--- a/src/vllm_tt_plugin/model_runner.py
+++ b/src/vllm_tt_plugin/model_runner.py
@@ -38,13 +38,16 @@ from vllm_tt_plugin.async_decode import (
     DeferredDecodeOutput,
     SubmittedStepContext,
     TTAsyncDecodeController,
+    TTDecodeSubmission,
 )
 from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_max_batch_size,
     get_tt_output_tokens_per_step,
     get_tt_per_lane_max_num_seqs,
+    get_tt_supports_device_grammar,
     is_tt_block_output_model,
+    is_tt_device_grammar_preload_eligible,
 )
 from vllm_tt_plugin.input_batch import (
     SEED_NONE_SENTINEL,
@@ -67,8 +70,10 @@ from vllm_tt_plugin.model_input import (
 from vllm_tt_plugin.platform import TTPlatform
 from vllm_tt_plugin.scheduler import get_tt_forced_reset_discard_counts
 from vllm_tt_plugin.structured_output import (
+    capture_structured_decode_request_ids,
     has_structured_outputs,
     reorder_grammar_bitmask_for_tt_batch,
+    scheduled_structured_output_request_ids,
 )
 
 if TYPE_CHECKING:
@@ -117,6 +122,7 @@ class _SyncForward:
     batch_size_per_dp: list[int]
     perform_device_sampling: bool
     is_decode: bool
+    decode_submission: TTDecodeSubmission | None = None
 
 
 def _coerce_output_block(
@@ -164,6 +170,7 @@ class TTModelRunner:
         self._output_tokens_per_step = get_tt_output_tokens_per_step(vllm_config)
         self._is_block_output_model = is_tt_block_output_model(vllm_config)
         self._persistent_capture_released = False
+        self._device_grammar_poisoned = False
 
         if self.model_config.is_encoder_decoder:
             raise ValueError("Encoder-decoder models aren't yet supported for TT")
@@ -177,11 +184,39 @@ class TTModelRunner:
         self.mesh_device = mesh_device
         self.trace_mode = trace_mode
         self.enable_model_warmup = enable_model_warmup
+        self.supports_device_grammar = is_tt_device_grammar_preload_eligible(
+            vllm_config,
+            trace_mode=self.trace_mode,
+            enable_model_warmup=self.enable_model_warmup,
+        )
+        if (
+            not self.supports_device_grammar
+            and get_tt_supports_device_grammar(vllm_config)
+            and self.trace_mode != "none"
+            and not self.enable_model_warmup
+        ):
+            logger.warning(
+                "TT device grammar sampling requires model warmup before "
+                "traced execution; retaining host grammar sampling because "
+                "enable_model_warmup is false"
+            )
+            self.supports_device_grammar = False
         # Runtime-discovered physical device count, supplied by the worker.
         self.num_devices = num_devices
         # Whether to sample on device
         self.sample_on_device_mode = getattr(TTPlatform, "sample_on_device_mode", None)
         assert self.sample_on_device_mode in (None, "all", "decode_only")
+        if self.supports_device_grammar and (
+            self.sample_on_device_mode is None or self.scheduler_config.async_scheduling
+        ):
+            logger.info(
+                "TT device grammar runtime activation is disabled "
+                "(sample_on_device_mode=%s, async_scheduling=%s); retaining "
+                "host grammar sampling",
+                self.sample_on_device_mode,
+                self.scheduler_config.async_scheduling,
+            )
+            self.supports_device_grammar = False
         # Whether the model supports top-K logprobs on device.
         # Detected from model_type (available to all DP ranks without
         # requiring the model to be loaded). Models like gpt-oss-120b
@@ -316,6 +351,37 @@ class TTModelRunner:
         self.model = loader.load_model(
             vllm_config=self.vllm_config, model_config=self.model_config
         )
+        if self.supports_device_grammar:
+            activate = getattr(self.model, "enable_device_grammar", None)
+            if callable(activate):
+                activate()
+            runtime_support = bool(getattr(self.model, "device_grammar_enabled", False))
+            has_sample_api = callable(
+                getattr(self.model, "sample_decode_on_device", None)
+            )
+            if not runtime_support or not has_sample_api:
+                logger.warning(
+                    "TT model declares device grammar support but this runtime "
+                    "layout has no compatible sampler; retaining host grammar "
+                    "sampling (runtime_support=%s, sample_api=%s)",
+                    runtime_support,
+                    has_sample_api,
+                )
+                self.supports_device_grammar = False
+
+    def _poison_device_grammar(self) -> None:
+        """Reject all later runner work after a deferred decode becomes unsafe."""
+        self._device_grammar_poisoned = True
+        poison_model = getattr(self.model, "poison_deferred_device_sampling", None)
+        if callable(poison_model):
+            poison_model()
+
+    def _raise_if_device_grammar_poisoned(self) -> None:
+        if getattr(self, "_device_grammar_poisoned", False):
+            raise RuntimeError(
+                "TT device grammar sampling previously failed after decode "
+                "submission; reconstruct the model runner before continuing"
+            )
 
     def _uses_async_scheduler(self) -> bool:
         """Whether upstream publishes outputs through placeholder accounting.
@@ -1281,6 +1347,26 @@ class TTModelRunner:
         has_structured = has_structured_outputs(
             self.requests, scheduler_output, bitmask
         )
+        scheduled_structured_req_ids = scheduled_structured_output_request_ids(
+            self.requests,
+            scheduler_output,
+        )
+        has_scheduled_structured = bool(scheduled_structured_req_ids)
+        if is_prompt:
+            structured_output_req_ids = frozenset(
+                req_id
+                for row, req_id in enumerate(row_req_ids)
+                if req_id in scheduled_structured_req_ids
+                and (
+                    intermediate_prefill_mask is None
+                    or not bool(intermediate_prefill_mask[row])
+                )
+            )
+        else:
+            structured_output_req_ids = capture_structured_decode_request_ids(
+                scheduled_structured_req_ids,
+                row_req_ids,
+            )
         if bitmask is not None:
             # Using torch tensor instead of numpy array for consistency
             # because we need it as tensor for gather.
@@ -1301,17 +1387,23 @@ class TTModelRunner:
                 structured_output_request_ids=structured_output_request_ids,
                 row_req_ids=row_req_ids,
                 batch_length=batch_length,
+                expected_structured_output_request_ids=structured_output_req_ids,
             )
 
         perform_device_sampling = self.check_perform_device_sampling(
             is_decode=not is_prompt,
             has_structured_outputs=has_structured,
         )
+        if has_structured and not has_scheduled_structured:
+            perform_device_sampling = False
         if intermediate_prefill_mask is not None and intermediate_prefill_mask.any():
             # Device sampling advances device RNG state for every row it reads,
             # which an intermediate chunk must not do. Host sampling can hand
             # those rows a generator clone instead.
             perform_device_sampling = False
+        defer_device_sampling = (
+            perform_device_sampling and has_scheduled_structured and not is_prompt
+        )
 
         # Populate prompt_tokens and output_tokens if penalties are needed
         # (decode only).
@@ -1434,6 +1526,10 @@ class TTModelRunner:
             # state. Stateless models ignore it.
             prefill_empty_slots=prefill_empty_slots,
             intermediate_prefill_mask=intermediate_prefill_mask,
+            defer_device_sampling=defer_device_sampling,
+            structured_output_req_ids=structured_output_req_ids,
+            grammar_row_req_ids=tuple(row_req_ids)
+            + (None,) * (input_tokens.shape[0] - len(row_req_ids)),
         )
 
     def build_model_input(
@@ -1555,8 +1651,17 @@ class TTModelRunner:
         if plan.is_decode:
             # ``slot_grammar_bitmask`` reorders against the full decode capacity.
             lane_total = plan.capacity
-            if self.async_decode_scheduling:
-                req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
+            if model_input.defer_device_sampling:
+                self.async_decode.wait_for_all_pending_async_steps()
+            if self.async_decode_scheduling and not model_input.defer_device_sampling:
+                req_ids = [
+                    model_input.grammar_row_req_ids[row] for row in scheduled_rows
+                ]
+                if any(req_id is None for req_id in req_ids):
+                    raise RuntimeError(
+                        "submitted lane row identity is missing scheduled request IDs: "
+                        f"scheduled_rows={scheduled_rows}, row_req_ids={req_ids}"
+                    )
                 context = self.async_decode.capture_submitted_step_context(req_ids)
                 wrapper = self.async_decode.submit_async_lane_decode(
                     model_input, context, scheduled_rows
@@ -1571,14 +1676,21 @@ class TTModelRunner:
                 )
                 return None
             submission = self.async_decode.submit_decode(
-                model_input, read_from_device=True, async_read=False
+                model_input,
+                read_from_device=not model_input.defer_device_sampling,
+                async_read=False,
             )
-            finalized = self.async_decode.finalize_decode(submission)
-            assert finalized is not None
-            tt_out = finalized.tt_out
-            tt_log_probs = finalized.tt_log_probs
+            if model_input.defer_device_sampling:
+                tt_out = submission.tt_out
+                tt_log_probs = None
+            else:
+                finalized = self.async_decode.finalize_decode(submission)
+                assert finalized is not None
+                tt_out = finalized.tt_out
+                tt_log_probs = finalized.tt_log_probs
             is_decode = True
         else:
+            submission = None
             # Prefill reorders against the per-lane request capacity.
             lane_total = lane_batch.max_num_reqs
             tt_out = self.submit_prefill(model_input, model_input.unpadded_batch_size)
@@ -1608,6 +1720,7 @@ class TTModelRunner:
                 scheduled_rows=scheduled_rows,
                 is_decode=is_decode,
                 lane_total=lane_total,
+                decode_submission=submission,
             )
         )
         return None
@@ -1622,17 +1735,83 @@ class TTModelRunner:
         scheduled_rows: list[int],
         is_decode: bool,
         lane_total: int,
+        decode_submission: TTDecodeSubmission | None = None,
+    ) -> ModelRunnerOutput:
+        deferred = bool(getattr(model_input, "defer_device_sampling", False))
+        try:
+            return TTModelRunner._finish_lane_sync_impl(
+                self,
+                grammar_output,
+                tt_out=tt_out,
+                tt_log_probs=tt_log_probs,
+                model_input=model_input,
+                scheduled_rows=scheduled_rows,
+                is_decode=is_decode,
+                lane_total=lane_total,
+                decode_submission=decode_submission,
+            )
+        except Exception:
+            if deferred:
+                self._poison_device_grammar()
+            raise
+
+    def _finish_lane_sync_impl(
+        self,
+        grammar_output: GrammarOutput | None,
+        *,
+        tt_out: Any,
+        tt_log_probs: Any,
+        model_input: TTModelInput,
+        scheduled_rows: list[int],
+        is_decode: bool,
+        lane_total: int,
+        decode_submission: TTDecodeSubmission | None = None,
     ) -> ModelRunnerOutput:
         """Sample and build the runner output for a deferred lane forward."""
         model_input = self._apply_grammar_to_input(
             model_input, grammar_output, lane_total=lane_total
         )
+        if getattr(model_input, "defer_device_sampling", False):
+            if decode_submission is None:
+                raise RuntimeError(
+                    "deferred lane decode is missing its device submission"
+                )
+            finalized = self.async_decode.complete_deferred_device_sampling(
+                decode_submission,
+                model_input,
+            )
+            tt_out = finalized.tt_out
+            tt_log_probs = finalized.tt_log_probs
+            model_input = replace(
+                model_input,
+                grammar_bitmask=[None],
+                defer_device_sampling=False,
+            )
         sampled, logprobs = self.lane_batch.extract_output(
             self, tt_out, tt_log_probs, model_input, scheduled_rows, is_decode=is_decode
         )
         # ``scheduled_rows`` are persistent slots; their req_ids in row order are
         # the canonical merged output order.
-        req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
+        submitted_row_ids = getattr(model_input, "grammar_row_req_ids", ())
+        snapshot_covers_rows = bool(submitted_row_ids) and (
+            not scheduled_rows or max(scheduled_rows) < len(submitted_row_ids)
+        )
+        if isinstance(model_input, TTModelInput) and not snapshot_covers_rows:
+            raise RuntimeError(
+                "submitted lane row identity does not cover scheduled rows: "
+                f"scheduled_rows={scheduled_rows}, "
+                f"row_identity_size={len(submitted_row_ids)}"
+            )
+        req_ids = (
+            [submitted_row_ids[row] for row in scheduled_rows]
+            if snapshot_covers_rows
+            else [self.lane_batch.req_ids[row] for row in scheduled_rows]
+        )
+        if any(req_id is None for req_id in req_ids):
+            raise RuntimeError(
+                "submitted lane row identity is missing scheduled request IDs: "
+                f"scheduled_rows={scheduled_rows}, row_req_ids={req_ids}"
+            )
 
         if not is_decode and model_input.prompt_lens is not None:
             lane_batch = self.lane_batch
@@ -1670,6 +1849,8 @@ class TTModelRunner:
         nothing was scheduled (no sampler is enqueued). Standard multi-process
         DP reaches this entrypoint once per rank, each over its own mesh.
         """
+        TTModelRunner._raise_if_device_grammar_poisoned(self)
+
         # Single-process lane-DP: the lane scheduler attaches a per-step plan to
         # the scheduler output. When present, the step runs over the merged lane
         # batch (``TTLaneInputBatch`` owns all the lane-specific input/output
@@ -1695,7 +1876,13 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         is_decode = model_input.prompt_lens is None
-        if self.async_decode_scheduling and is_decode:
+        if model_input.defer_device_sampling:
+            self.async_decode.wait_for_all_pending_async_steps()
+        if (
+            self.async_decode_scheduling
+            and is_decode
+            and not model_input.defer_device_sampling
+        ):
             steady_decode_fast_path = self.async_decode.can_use_steady_decode_fast_path(
                 model_input
             )
@@ -1725,22 +1912,31 @@ class TTModelRunner:
         model_input: TTModelInput,
         *,
         lane_total: int | None,
+        require_complete: bool = True,
     ) -> torch.Tensor | None:
         """Reorder a scheduler grammar bitmask into TT batch layout, or ``None``."""
         if grammar_output is None or grammar_output.grammar_bitmask is None:
+            if require_complete and model_input.structured_output_req_ids:
+                raise RuntimeError(
+                    "sample-time grammar output is absent for TT batch request IDs: "
+                    f"{sorted(model_input.structured_output_req_ids)}"
+                )
             return None
 
-        if lane_total is not None:
-            return self.lane_batch.slot_grammar_bitmask(grammar_output, lane_total)
-
-        assert model_input.row_req_ids is not None
-
         bitmask = torch.from_numpy(grammar_output.grammar_bitmask)
+        row_req_ids = model_input.grammar_row_req_ids
+        if not row_req_ids:
+            raise RuntimeError(
+                "sample-time grammar remapping is missing the submitted TT row identity"
+            )
         return reorder_grammar_bitmask_for_tt_batch(
             bitmask=bitmask,
             structured_output_request_ids=grammar_output.structured_output_request_ids,
-            row_req_ids=model_input.row_req_ids,
-            batch_length=model_input.input_tokens.shape[0],
+            row_req_ids=row_req_ids,
+            batch_length=len(row_req_ids),
+            expected_structured_output_request_ids=(
+                model_input.structured_output_req_ids if require_complete else None
+            ),
         )
 
     def _apply_grammar_to_input(
@@ -1769,16 +1965,37 @@ class TTModelRunner:
         """Attach the sample-time grammar bitmask to a deferred async decode.
 
         The reorder happens here on the engine thread (layout still matches the
-        forward); the wrapper applies the bitmask when its read completes.
+        forward); the wrapper applies the bitmask when its read completes. A
+        row finished by the preceding queued result may be absent from the new
+        grammar output; it stays unrestricted here and late-output suppression
+        discards its sampled token.
         """
         bitmask = self._reorder_grammar_bitmask(
-            grammar_output, model_input, lane_total=lane_total
+            grammar_output,
+            model_input,
+            lane_total=lane_total,
+            require_complete=False,
         )
         if bitmask is not None:
             wrapper.set_grammar_bitmask(bitmask)
         return wrapper
 
     def _finish_front_packed_sync(
+        self, grammar_output: GrammarOutput | None, *, fwd: _SyncForward | None
+    ) -> ModelRunnerOutput:
+        deferred = bool(fwd is not None and fwd.model_input.defer_device_sampling)
+        try:
+            return TTModelRunner._finish_front_packed_sync_impl(
+                self,
+                grammar_output,
+                fwd=fwd,
+            )
+        except Exception:
+            if deferred:
+                self._poison_device_grammar()
+            raise
+
+    def _finish_front_packed_sync_impl(
         self, grammar_output: GrammarOutput | None, *, fwd: _SyncForward | None
     ) -> ModelRunnerOutput:
         """Sample and build output for a deferred front-packed forward."""
@@ -1912,6 +2129,7 @@ class TTModelRunner:
         ``EngineCore``'s ``if model_output is None`` path), so the true cause
         surfaces instead of being masked by the empty-popleft error.
         """
+        TTModelRunner._raise_if_device_grammar_poisoned(self)
         if not self._pending_samples:
             return None
         finish = self._pending_samples.popleft()
@@ -1942,9 +2160,17 @@ class TTModelRunner:
         if has_always_host_only_sampling_params:
             return False
 
-        # Structured outputs are not supported on device yet
-        # https://github.com/tenstorrent/vllm/issues/277
-        if has_structured_outputs:
+        # The initial model contract covers decode only. Prefill keeps the
+        # established host path so its first token remains grammar-safe.
+        # Upstream async scheduling can queue another forward before the
+        # current sample-time grammar arrives; the traced TT logits buffer is
+        # single-owner, so structured decode stays on host until that overlap
+        # has a dedicated multi-buffer contract.
+        if has_structured_outputs and (
+            not is_decode
+            or not self.supports_device_grammar
+            or self.scheduler_config.async_scheduling
+        ):
             return False
 
         # Logprobs on device require multi-device setups (num_devices in {8,32}).
@@ -1957,6 +2183,11 @@ class TTModelRunner:
         # return the sampled token's logprob, so max_lp > 0 falls back to
         # host sampling to compute full top-N from logits.
         max_lp = input_batch.max_num_logprobs
+        if has_structured_outputs and max_lp is not None:
+            # Grammar-aware device logprob parity is not part of the initial
+            # contract. Keep vLLM's host path rather than publish incomplete
+            # or force-argmax placeholder metadata.
+            return False
         if max_lp is not None:
             if num_devices not in (8, 32):
                 return False
@@ -2052,6 +2283,7 @@ class TTModelRunner:
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
         tt_log_probs = None
+        decode_submission = None
 
         # Execute model
         if not is_decode:
@@ -2068,17 +2300,20 @@ class TTModelRunner:
             elif isinstance(tt_out, tuple):
                 tt_out, _ = tt_out
         else:
-            submission = self.async_decode.submit_decode(
+            decode_submission = self.async_decode.submit_decode(
                 model_input, read_from_device=False, async_read=False
             )
-            finalized = self.async_decode.finalize_decode(submission)
-            assert finalized is not None
-            # ``finalize_decode`` already unpacked ``(tt_out, tt_log_probs)``.
-            tt_out = finalized.tt_out
-            tt_log_probs = finalized.tt_log_probs
-            batch_size_per_dp = submission.batch_size_per_dp
-            sampling_params = submission.sampling_params
-            perform_device_sampling = submission.perform_device_sampling
+            if model_input.defer_device_sampling:
+                tt_out = decode_submission.tt_out
+            else:
+                finalized = self.async_decode.finalize_decode(decode_submission)
+                assert finalized is not None
+                # ``finalize_decode`` already unpacked ``(tt_out, tt_log_probs)``.
+                tt_out = finalized.tt_out
+                tt_log_probs = finalized.tt_log_probs
+            batch_size_per_dp = decode_submission.batch_size_per_dp
+            sampling_params = decode_submission.sampling_params
+            perform_device_sampling = decode_submission.perform_device_sampling
 
         return _SyncForward(
             tt_out=tt_out,
@@ -2088,12 +2323,30 @@ class TTModelRunner:
             batch_size_per_dp=batch_size_per_dp,
             perform_device_sampling=perform_device_sampling,
             is_decode=is_decode,
+            decode_submission=decode_submission,
         )
 
     def _sample_sync_forward(
         self, fwd: _SyncForward
     ) -> tuple[list[torch.Tensor], list[LogprobsTensors | None]]:
         """Sample a forward produced by ``_forward_with_model_input``."""
+        if getattr(fwd.model_input, "defer_device_sampling", False):
+            if fwd.decode_submission is None:
+                raise RuntimeError("deferred decode is missing its device submission")
+            finalized = self.async_decode.complete_deferred_device_sampling(
+                fwd.decode_submission,
+                fwd.model_input,
+            )
+            fwd = replace(
+                fwd,
+                tt_out=finalized.tt_out,
+                tt_log_probs=finalized.tt_log_probs,
+                model_input=replace(
+                    fwd.model_input,
+                    grammar_bitmask=[None],
+                    defer_device_sampling=False,
+                ),
+            )
         return self._get_output_tokens(
             tt_out=fwd.tt_out,
             tt_log_probs=fwd.tt_log_probs,
@@ -2636,6 +2889,8 @@ class TTModelRunner:
             num_blocks=self.max_num_blocks_per_req,
             can_sample_on_device=sample_on_device_mode in ("all", "decode_only"),
         )
+        if self.supports_device_grammar:
+            decode_kwargs["can_sample_device_grammar"] = True
 
         # Phase 1: compile all code paths (no trace capture)
         self.model.warmup_model_prefill(enable_trace=False, **prefill_kwargs)
@@ -2645,8 +2900,52 @@ class TTModelRunner:
         if hasattr(self.model, "already_warmed_up_prefill"):
             self.model.already_warmed_up_prefill = False
 
-        # Phase 2: capture traces (all ops already compiled)
+        decode_trace_prepared = False
+        if trace_prefill_mode and trace_decode_mode and self.supports_device_grammar:
+            prepare_decode = getattr(
+                self.model,
+                "prepare_device_grammar_decode_trace_warmup",
+                None,
+            )
+            if callable(prepare_decode):
+                decode_trace_prepared = bool(
+                    prepare_decode(
+                        kv_cache=self.kv_caches,
+                        max_batch_size=self.tt_max_batch_size,
+                        num_blocks=self.max_num_blocks_per_req,
+                    )
+                )
+            if not decode_trace_prepared:
+                logger.warning(
+                    "TT device grammar decode buffers could not be prepared "
+                    "before prefill trace capture; retaining host grammar "
+                    "sampling for trace_mode='all'"
+                )
+                self.supports_device_grammar = False
+                decode_kwargs.pop("can_sample_device_grammar", None)
+
+        # Phase 2 captures the compiled variants. For trace_mode="all", the
+        # grammar hook has also prepared both decode input families before
+        # prefill capture.
         if trace_prefill_mode:
             self.model.warmup_model_prefill(enable_trace=True, **prefill_kwargs)
+        if decode_trace_prepared:
+            capture_decode = getattr(
+                self.model,
+                "capture_prepared_device_grammar_decode_trace",
+                None,
+            )
+            if not callable(capture_decode):
+                raise RuntimeError(
+                    "TT model prepared a device grammar decode trace but does "
+                    "not expose its capture method"
+                )
+            capture_decode()
         if trace_decode_mode:
-            self.model.warmup_model_decode(enable_trace=True, **decode_kwargs)
+            traced_decode_kwargs = dict(decode_kwargs)
+            if decode_trace_prepared:
+                traced_decode_kwargs["sampling_trace_variants_prepared"] = True
+            self.model.warmup_model_decode(
+                enable_trace=True,
+                **traced_decode_kwargs,
+            )

--- a/src/vllm_tt_plugin/platform.py
+++ b/src/vllm_tt_plugin/platform.py
@@ -21,6 +21,7 @@ from vllm_tt_plugin.config import (
     require_tt_output_tokens_per_step,
     store_tt_lane_count,
     store_tt_output_tokens_per_step,
+    store_tt_supports_device_grammar,
     uses_tt_lane_coordinator,
     validate_tt_lane_config,
 )
@@ -1570,6 +1571,39 @@ class TTPlatform(Platform):
         output_tokens_per_step = cls._resolve_output_tokens_per_step(model_class)
         store_tt_output_tokens_per_step(vllm_config, output_tokens_per_step)
         is_block_output_model = is_tt_block_output_model(vllm_config)
+        supports_device_grammar = (
+            model_capabilities.get("supports_device_grammar", False)
+            if model_capabilities
+            else False
+        )
+        if not isinstance(supports_device_grammar, bool):
+            raise ValueError(
+                f"Model {model_class.__module__}.{model_class.__name__} "
+                "must declare model_capabilities['supports_device_grammar'] "
+                f"as a boolean, got {supports_device_grammar!r}"
+            )
+        supports_sample_on_device = (
+            model_capabilities.get("supports_sample_on_device", False)
+            if model_capabilities
+            else False
+        )
+        if supports_device_grammar and not supports_sample_on_device:
+            raise ValueError(
+                f"Model {model_class.__module__}.{model_class.__name__} "
+                "declares model_capabilities['supports_device_grammar']=True "
+                "without model_capabilities['supports_sample_on_device']=True"
+            )
+        if is_block_output_model and supports_device_grammar:
+            raise ValueError(
+                f"Model {model_class.__module__}.{model_class.__name__} "
+                "declares model_capabilities['supports_device_grammar']=True, "
+                "but block-output models own a multi-token sampler and do not "
+                "support vLLM grammar masks"
+            )
+        store_tt_supports_device_grammar(
+            vllm_config,
+            supports_device_grammar,
+        )
         if is_diffusion_gemma and not is_block_output_model:
             raise ValueError(
                 "DiffusionGemma must declare output_tokens_per_step > 1 "
@@ -1753,11 +1787,6 @@ class TTPlatform(Platform):
         # A model either supports the full on-device sampling pipeline or it
         # doesn't — there is no greedy-only mode. Models opt in by setting
         # `supports_sample_on_device` in their `model_capabilities` dict.
-        supports_sample_on_device = (
-            model_capabilities.get("supports_sample_on_device", False)
-            if model_capabilities
-            else False
-        )
         if sample_on_device_mode is not None and not supports_sample_on_device:
             raise ValueError(
                 f"sample_on_device_mode={sample_on_device_mode!r} was requested, "

--- a/src/vllm_tt_plugin/structured_output.py
+++ b/src/vllm_tt_plugin/structured_output.py
@@ -3,22 +3,41 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections import Counter
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import torch
-
-from vllm_tt_plugin.logger import init_tt_logger
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
 
-logger = init_tt_logger(__name__)
+def scheduled_structured_output_request_ids(
+    requests: Mapping[str, CachedRequestState],
+    scheduler_output: SchedulerOutput,
+) -> frozenset[str]:
+    """Scheduled requests carrying structured-output parameters.
 
-# Track missing request IDs we've already warned about, so each ID logs once.
-_warned_missing_request_ids: set[str] = set()
+    Decode callers require rows for all returned IDs. Prefill callers can
+    exclude intermediate chunks, which must not sample a token.
+    """
+    return frozenset(
+        req_id
+        for req_id in scheduler_output.num_scheduled_tokens
+        if (req := requests.get(req_id)) is not None
+        and req.sampling_params is not None
+        and req.sampling_params.structured_outputs is not None
+    )
+
+
+def has_scheduled_structured_outputs(
+    requests: Mapping[str, CachedRequestState],
+    scheduler_output: SchedulerOutput,
+) -> bool:
+    """Whether a request scheduled this step carries structured parameters."""
+    return bool(scheduled_structured_output_request_ids(requests, scheduler_output))
 
 
 def has_structured_outputs(
@@ -31,12 +50,23 @@ def has_structured_outputs(
     scheduled request carrying ``structured_outputs`` sampling params."""
     if bitmask is not None or scheduler_output.pending_structured_output_tokens:
         return True
-    return any(
-        (req := requests.get(req_id)) is not None
-        and req.sampling_params is not None
-        and req.sampling_params.structured_outputs is not None
-        for req_id in scheduler_output.num_scheduled_tokens
-    )
+    return has_scheduled_structured_outputs(requests, scheduler_output)
+
+
+def capture_structured_decode_request_ids(
+    scheduled_request_ids: Collection[str],
+    row_req_ids: Sequence[str | None],
+) -> frozenset[str]:
+    """Capture every scheduled structured decode row before submission."""
+    captured_ids = frozenset(scheduled_request_ids)
+    local_row_ids = {req_id for req_id in row_req_ids if req_id is not None}
+    missing_ids = sorted(captured_ids - local_row_ids)
+    if missing_ids:
+        raise RuntimeError(
+            "scheduled structured requests are absent from the submitted TT "
+            f"decode rows: {missing_ids}"
+        )
+    return captured_ids
 
 
 def reorder_grammar_bitmask_for_tt_batch(
@@ -45,11 +75,67 @@ def reorder_grammar_bitmask_for_tt_batch(
     structured_output_request_ids: Sequence[str],
     row_req_ids: Sequence[str | None],
     batch_length: int,
+    expected_structured_output_request_ids: Collection[str] | None = None,
 ) -> torch.Tensor:
-    """Reorder scheduler bitmask rows into the TT batch layout.
+    """Reorder scheduler bitmask rows into TT row order.
 
-    Warn once per process for each request ID that is missing a remapped row.
+    Supplying ``expected_structured_output_request_ids`` enables strict mode
+    and requires complete source and destination coverage. With ``None``, only
+    source IDs present in the submitted rows are mapped; other rows remain
+    all-allowed for stale async outputs that will be discarded.
     """
+    if bitmask.ndim != 2:
+        raise ValueError(
+            f"grammar bitmask must be rank 2, got shape={tuple(bitmask.shape)}"
+        )
+    if bitmask.shape[0] != len(structured_output_request_ids):
+        raise ValueError(
+            "grammar bitmask row count must match request IDs, got "
+            f"rows={bitmask.shape[0]}, request_ids={len(structured_output_request_ids)}"
+        )
+    duplicate_source_ids = sorted(
+        req_id
+        for req_id, count in Counter(structured_output_request_ids).items()
+        if count > 1
+    )
+    if duplicate_source_ids:
+        raise ValueError(
+            f"grammar output contains duplicate request IDs: {duplicate_source_ids}"
+        )
+
+    strict_identity = expected_structured_output_request_ids is not None
+    local_rows = list(row_req_ids[:batch_length])
+    if strict_identity and len(local_rows) != batch_length:
+        raise ValueError(
+            "grammar row identity must cover the full TT batch, got "
+            f"rows={len(local_rows)}, batch_length={batch_length}"
+        )
+    local_rows.extend([None] * (batch_length - len(local_rows)))
+    local_row_ids = {req_id for req_id in local_rows if req_id is not None}
+    expected_local_ids = (
+        set(expected_structured_output_request_ids)
+        if strict_identity
+        else set(structured_output_request_ids) & local_row_ids
+    )
+    absent_expected_ids = sorted(expected_local_ids - local_row_ids)
+    if absent_expected_ids:
+        raise RuntimeError(
+            "captured structured request IDs are absent from the submitted TT "
+            f"row identity: {absent_expected_ids}"
+        )
+    duplicate_expected_rows = sorted(
+        req_id
+        for req_id, count in Counter(
+            req_id for req_id in local_rows if req_id in expected_local_ids
+        ).items()
+        if count > 1
+    )
+    if duplicate_expected_rows:
+        raise RuntimeError(
+            "structured requests appear more than once in the TT batch: "
+            f"{duplicate_expected_rows}"
+        )
+
     # region Reorder rows
     grammar_bitmask_length = bitmask.shape[1]
     reordered_bitmask = torch.full(
@@ -62,39 +148,18 @@ def reorder_grammar_bitmask_for_tt_batch(
     req_id_to_bitmask_row: dict[str, int] = {
         req_id: i for i, req_id in enumerate(structured_output_request_ids)
     }
+    missing_ids = sorted(expected_local_ids - req_id_to_bitmask_row.keys())
+    if missing_ids:
+        raise RuntimeError(
+            f"sample-time grammar output is missing TT batch request IDs: {missing_ids}"
+        )
 
-    # Collect placeable and placed IDs to log missing IDs if left.
-    placeable_ids = {
-        req_id
-        for req_id in row_req_ids[:batch_length]
-        if req_id is not None and req_id in req_id_to_bitmask_row
-    }
-    placed_ids: set[str] = set()
-
-    for local_row, req_id in enumerate(row_req_ids[:batch_length]):
+    for local_row, req_id in enumerate(local_rows):
+        if req_id not in expected_local_ids:
+            continue
         scheduler_bitmask_row = req_id_to_bitmask_row.get(req_id)
         if scheduler_bitmask_row is not None:
             reordered_bitmask[local_row, :] = bitmask[scheduler_bitmask_row, :]
-            placed_ids.add(req_id)
-    # endregion
-
-    # region Log missing request IDs
-    missing_ids = placeable_ids - placed_ids
-    new_missing_ids = sorted(
-        req_id for req_id in missing_ids if req_id not in _warned_missing_request_ids
-    )
-    if new_missing_ids:
-        _warned_missing_request_ids.update(new_missing_ids)
-        msg = (
-            "Structured-output bitmask remap shortfall: %d new missing "
-            "request ID%s did not receive a bitmask row:\n%s"
-        )
-        args = [
-            len(new_missing_ids),
-            "" if len(new_missing_ids) == 1 else "s",
-            new_missing_ids,
-        ]
-        logger.warning(msg, *args)
     # endregion
 
     return reordered_bitmask

--- a/tests/test_block_request_validation.py
+++ b/tests/test_block_request_validation.py
@@ -14,6 +14,7 @@ from vllm.sampling_params import (
 
 from vllm_tt_plugin.config import (
     get_tt_output_tokens_per_step,
+    get_tt_supports_device_grammar,
     store_tt_output_tokens_per_step,
 )
 from vllm_tt_plugin.platform import (
@@ -288,6 +289,21 @@ class ARModel:
     }
 
 
+class ARDeviceGrammarModel(ARModel):
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_device_grammar": True,
+    }
+
+
+class InvalidDeviceGrammarModel(ARModel):
+    model_capabilities = {
+        **ARModel.model_capabilities,
+        "supports_sample_on_device": False,
+        "supports_device_grammar": True,
+    }
+
+
 class _WeakrefableConfig(SimpleNamespace):
     """SimpleNamespace itself cannot be weak-referenced; VllmConfig can."""
 
@@ -333,6 +349,23 @@ def test_startup_stores_block_capability_and_enforces_contract(monkeypatch):
     assert config.diffusion_config is None
     assert not hasattr(config.model_config.hf_config, "canvas_length")
     assert config.model_config.is_diffusion is False
+
+
+def test_startup_stores_device_grammar_capability(monkeypatch):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, ARDeviceGrammarModel)
+
+    TTPlatform.check_and_update_config(config)
+
+    assert get_tt_supports_device_grammar(config)
+
+
+def test_device_grammar_requires_device_sampling_capability(monkeypatch):
+    config = _ar_config()
+    _patch_model_resolution(monkeypatch, InvalidDeviceGrammarModel)
+
+    with pytest.raises(ValueError, match="supports_sample_on_device"):
+        TTPlatform.check_and_update_config(config)
 
 
 def _switch_resolution(monkeypatch, model_class):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -132,3 +133,47 @@ def test_required_output_tokens_per_step_rejects_missing_setup_state():
 def test_output_tokens_per_step_rejects_invalid_values(invalid):
     with pytest.raises(ValueError, match="integer >= 1"):
         tt_config.store_tt_output_tokens_per_step(_vllm_config(), invalid)
+
+
+def test_supports_device_grammar_defaults_false_and_round_trips():
+    config = _vllm_config()
+
+    assert not tt_config.get_tt_supports_device_grammar(config)
+
+    tt_config.store_tt_supports_device_grammar(config, True)
+
+    assert tt_config.get_tt_supports_device_grammar(config)
+    assert config.additional_config[tt_config._SUPPORTS_DEVICE_GRAMMAR_KEY] is True
+    assert tt_config.get_tt_supports_device_grammar(pickle.loads(pickle.dumps(config)))
+
+
+@pytest.mark.parametrize(
+    ("trace_mode", "enable_model_warmup", "expected"),
+    [
+        ("all", True, True),
+        ("decode_only", False, False),
+        ("none", False, True),
+    ],
+)
+def test_device_grammar_runtime_requires_warmup_only_for_tracing(
+    trace_mode,
+    enable_model_warmup,
+    expected,
+):
+    config = _vllm_config()
+    tt_config.store_tt_supports_device_grammar(config, True)
+
+    assert (
+        tt_config.is_tt_device_grammar_preload_eligible(
+            config,
+            trace_mode=trace_mode,
+            enable_model_warmup=enable_model_warmup,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize("invalid", [1, "true", None])
+def test_supports_device_grammar_rejects_non_boolean(invalid):
+    with pytest.raises(ValueError, match="must be a boolean"):
+        tt_config.store_tt_supports_device_grammar(_vllm_config(), invalid)

--- a/tests/test_lane_input_batch.py
+++ b/tests/test_lane_input_batch.py
@@ -18,10 +18,12 @@ No device / ttnn execution required.
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils import torch_utils
+from vllm.v1.core.sched.output import GrammarOutput
 from vllm.v1.sample import sampler as sampler_module
 from vllm.v1.sample.logits_processor import AdapterLogitsProcessor, build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -31,6 +33,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
 import vllm_tt_plugin  # noqa: F401  (activates tt platform / ttnn import)
 from vllm_tt_plugin.input_batch import InputBatch, TTLaneInputBatch
+from vllm_tt_plugin.model_runner import TTModelRunner
 
 VOCAB = 64
 BLOCK = 16
@@ -319,6 +322,148 @@ def test_lane_prefill_input_ends_at_scheduled_chunk_boundary():
     assert model_input.intermediate_prefill_mask.tolist() == [True]
     # An intermediate chunk must not advance device RNG state.
     assert model_input.perform_device_sampling is False
+
+
+def test_lane_structured_decode_captures_expected_grammar_request_ids():
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    batch = _lane_batch(num_lanes=1, per_lane=2, with_custom=False)
+    request = _make_req(
+        "request",
+        [1, 2],
+        [3],
+        {
+            "temperature": 0.0,
+            "structured_outputs": StructuredOutputsParams(json_object=True),
+        },
+    )
+    row = _add_to_lane(batch, request, lane=0)
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"request": 1}
+    scheduler_output.total_num_scheduled_tokens = 1
+    plan = _plan({"request": row}, is_decode=True, capacity=2)
+    runner = SimpleNamespace(
+        max_num_blocks_per_req=MAX_MODEL_LEN // BLOCK,
+        _block_tables_per_layer=lambda _: None,
+        check_perform_device_sampling=lambda **_: True,
+        _decode_layout_changed_since_last_decode=False,
+        model_config=SimpleNamespace(is_multimodal_model=False),
+        requests={"request": request},
+    )
+
+    model_input = batch.build_model_input(runner, scheduler_output, None, plan)
+
+    assert model_input.grammar_bitmask == [None]
+    assert model_input.structured_output_req_ids == frozenset({"request"})
+    assert model_input.defer_device_sampling is True
+
+
+def test_slot_grammar_bitmask_default_preserves_non_strict_mapping():
+    batch = _lane_batch(num_lanes=1, per_lane=2, with_custom=False)
+    request = _make_req(
+        "request",
+        [1, 2],
+        [3],
+        {"temperature": 0.0},
+    )
+    _add_to_lane(batch, request, lane=0)
+    grammar = GrammarOutput(
+        structured_output_request_ids=["request"],
+        grammar_bitmask=np.array([[10, 11]], dtype=np.int32),
+    )
+
+    reordered = batch.slot_grammar_bitmask(grammar, batch_length=2)
+
+    assert reordered.tolist() == [[10, 11], [-1, -1]]
+
+
+def test_sparse_two_lane_grammar_uses_submitted_row_snapshot():
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    batch = _lane_batch(num_lanes=2, per_lane=2, with_custom=False)
+    structured_a = _make_req(
+        "structured-a",
+        [1, 2],
+        [3],
+        {
+            "temperature": 0.0,
+            "structured_outputs": StructuredOutputsParams(json_object=True),
+        },
+    )
+    plain = _make_req("plain", [4, 5], [6], {"temperature": 0.0})
+    structured_b = _make_req(
+        "structured-b",
+        [7, 8],
+        [9],
+        {
+            "temperature": 0.0,
+            "structured_outputs": StructuredOutputsParams(json_object=True),
+        },
+    )
+    batch.add_request_to_row(structured_a, 1)
+    batch.add_request_to_row(plain, 2)
+    batch.add_request_to_row(structured_b, 3)
+    requests = {
+        request.req_id: request for request in (structured_a, plain, structured_b)
+    }
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {
+        "structured-a": 1,
+        "plain": 1,
+        "structured-b": 1,
+    }
+    scheduler_output.total_num_scheduled_tokens = 3
+    plan = _plan(
+        {"structured-a": 1, "plain": 2, "structured-b": 3},
+        is_decode=True,
+        capacity=4,
+        num_lanes=2,
+    )
+    runner = SimpleNamespace(
+        max_num_blocks_per_req=MAX_MODEL_LEN // BLOCK,
+        _block_tables_per_layer=lambda _: None,
+        check_perform_device_sampling=lambda **_: True,
+        _decode_layout_changed_since_last_decode=False,
+        model_config=SimpleNamespace(is_multimodal_model=False),
+        requests=requests,
+    )
+
+    model_input = batch.build_model_input(runner, scheduler_output, None, plan)
+    grammar = GrammarOutput(
+        structured_output_request_ids=["structured-b", "structured-a"],
+        grammar_bitmask=np.array([[30, 31], [10, 11]], dtype=np.int32),
+    )
+    reordered = TTModelRunner._reorder_grammar_bitmask(
+        SimpleNamespace(),
+        grammar,
+        model_input,
+        lane_total=4,
+    )
+
+    assert model_input.grammar_row_req_ids == (
+        None,
+        "structured-a",
+        "plain",
+        "structured-b",
+    )
+    assert reordered.tolist() == [
+        [-1, -1],
+        [10, 11],
+        [-1, -1],
+        [30, 31],
+    ]
+
+    missing = GrammarOutput(
+        structured_output_request_ids=["structured-a"],
+        grammar_bitmask=np.array([[10, 11]], dtype=np.int32),
+    )
+    with pytest.raises(RuntimeError, match="structured-b"):
+        TTModelRunner._reorder_grammar_bitmask(
+            SimpleNamespace(),
+            missing,
+            model_input,
+            lane_total=4,
+        )
 
 
 def test_apply_step_plan_preempted_request_frees_its_row_and_keeps_its_state():

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -5,7 +5,7 @@
 from types import SimpleNamespace
 
 import pytest
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
@@ -29,6 +29,7 @@ def _batch_with_one_request(
     prompt_len: int,
     output_len: int,
     num_computed_tokens: int,
+    sampling_params: SamplingParams | None = None,
 ) -> tuple[InputBatch, CachedRequestState]:
     """Creates a batch with a single request, for testing purposes."""
     batch = InputBatch(
@@ -43,7 +44,11 @@ def _batch_with_one_request(
         req_id="r",
         prompt_token_ids=list(range(prompt_len)),
         mm_features=None,
-        sampling_params=SamplingParams(temperature=0.0),
+        sampling_params=(
+            sampling_params
+            if sampling_params is not None
+            else SamplingParams(temperature=0.0)
+        ),
         generator=None,
         block_ids=([0],),
         num_computed_tokens=num_computed_tokens,
@@ -215,6 +220,33 @@ def test_completed_cached_request_builds_decode_input(output_len: int):
     )
     assert model_input.input_tokens.shape == (MAX_NUM_SEQS, 1)
     assert model_input.input_tokens[0, 0] == batch.token_ids_cpu[0, num_tokens - 1]
+
+
+def test_structured_decode_build_captures_expected_grammar_request_ids():
+    prompt_len = 8
+    output_len = 1
+    num_computed_tokens = prompt_len
+    batch, request = _batch_with_one_request(
+        prompt_len=prompt_len,
+        output_len=output_len,
+        num_computed_tokens=num_computed_tokens,
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            structured_outputs=StructuredOutputsParams(json_object=True),
+        ),
+    )
+    runner = _fake_runner(batch, request)
+    runner.check_perform_device_sampling = lambda **_: True
+
+    model_input = _prepare(
+        runner,
+        ("r", 1, num_computed_tokens, output_len),
+    )
+
+    assert model_input.prompt_lens is None
+    assert model_input.grammar_bitmask == [None]
+    assert model_input.structured_output_req_ids == frozenset({"r"})
+    assert model_input.defer_device_sampling is True
 
 
 def test_final_one_token_prompt_chunk_stays_prefill():

--- a/tests/test_sample_time_grammar.py
+++ b/tests/test_sample_time_grammar.py
@@ -12,16 +12,20 @@ Requires the ttnn-enabled environment because importing the plugin modules pulls
 in ttnn.
 """
 
+from collections import deque
 from dataclasses import replace
 from functools import partial
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from vllm.v1.core.sched.output import GrammarOutput
 
+from vllm_tt_plugin.async_decode import TTAsyncDecodeController, TTDecodeSubmission
 from vllm_tt_plugin.model_input import TTModelInput
 from vllm_tt_plugin.model_runner import TTModelRunner, _SyncForward
+from vllm_tt_plugin.platform import TTPlatform
 
 VOCAB_WORDS = 2  # int32 words per grammar bitmask row
 
@@ -48,6 +52,12 @@ def _model_input(**overrides) -> TTModelInput:
         row_req_ids=["req-0"],
     )
     base.update(overrides)
+    if "grammar_row_req_ids" not in overrides:
+        row_req_ids = base["row_req_ids"] or []
+        batch_length = base["input_tokens"].shape[0]
+        base["grammar_row_req_ids"] = tuple(row_req_ids) + (None,) * (
+            batch_length - len(row_req_ids)
+        )
     return TTModelInput(**base)
 
 
@@ -57,6 +67,26 @@ def _grammar(num_structured: int) -> GrammarOutput:
     )
     req_ids = [f"req-{i}" for i in range(num_structured)]
     return GrammarOutput(structured_output_request_ids=req_ids, grammar_bitmask=bitmask)
+
+
+def _device_sampling_runner(*, supports_device_grammar: bool):
+    return SimpleNamespace(
+        sample_on_device_mode="all",
+        supports_device_grammar=supports_device_grammar,
+        num_devices=8,
+        tt_data_parallel_size=1,
+        supports_topk_logprobs=False,
+        scheduler_config=SimpleNamespace(async_scheduling=False),
+        input_batch=SimpleNamespace(
+            no_allowed_token_ids=True,
+            sampling=SimpleNamespace(
+                bad_words_token_ids={},
+                has_active_logitsprocs=lambda: False,
+            ),
+            max_num_logprobs=None,
+        ),
+        model_config=SimpleNamespace(logits_processors=[]),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -87,6 +117,284 @@ def test_sample_tokens_pops_fifo_and_passes_grammar_through():
     assert len(runner._pending_samples) == 0
 
 
+def test_execute_model_defers_structured_device_sampling_until_sample_tokens():
+    events: list[str] = []
+    model_input = _model_input(
+        perform_device_sampling=True,
+        defer_device_sampling=True,
+    )
+    submission = object()
+    fwd = replace(
+        _sync_forward(model_input),
+        perform_device_sampling=True,
+        decode_submission=submission,
+    )
+
+    def build_model_input(_scheduler_output, grammar_output):
+        assert grammar_output is None
+        events.append("build-without-grammar")
+        return model_input
+
+    def forward(received_input):
+        assert received_input.grammar_bitmask == [None]
+        events.append("forward")
+        return fwd
+
+    def sample_sync(received_fwd):
+        bitmask = received_fwd.model_input.grammar_bitmask[0]
+        assert bitmask is not None
+        events.append("device-sample")
+        return [torch.tensor([[42]], dtype=torch.int32)], [None]
+
+    async_decode = SimpleNamespace(
+        can_attempt_steady_decode_from_scheduler=lambda _output: False,
+        must_drain_pending_async_steps=lambda *_args: False,
+        wait_for_all_pending_async_steps=lambda: events.append("drain"),
+        submit_async_decode=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("structured device sampling must not use async overlap")
+        ),
+    )
+    runner = SimpleNamespace(
+        async_decode=async_decode,
+        async_decode_scheduling=True,
+        scheduler_config=SimpleNamespace(async_scheduling=False),
+        _pending_samples=deque(),
+        build_model_input=build_model_input,
+        _forward_with_model_input=forward,
+        _sample_sync_forward=sample_sync,
+        apply_and_build_runner_output=lambda sampled, _logprobs, **_kwargs: sampled,
+    )
+    runner._reorder_grammar_bitmask = partial(
+        TTModelRunner._reorder_grammar_bitmask,
+        runner,
+    )
+    runner._apply_grammar_to_input = partial(
+        TTModelRunner._apply_grammar_to_input,
+        runner,
+    )
+    runner._finish_front_packed_sync = partial(
+        TTModelRunner._finish_front_packed_sync,
+        runner,
+    )
+
+    assert TTModelRunner.execute_model(runner, SimpleNamespace()) is None
+    assert events == ["build-without-grammar", "drain", "forward"]
+
+    output = TTModelRunner.sample_tokens(runner, _grammar(1))
+
+    assert events == [
+        "build-without-grammar",
+        "drain",
+        "forward",
+        "device-sample",
+    ]
+    assert output.tolist() == [[42]]
+
+
+def test_device_grammar_sampling_is_capability_gated_for_decode():
+    unsupported = _device_sampling_runner(supports_device_grammar=False)
+    supported = _device_sampling_runner(supports_device_grammar=True)
+
+    assert not TTModelRunner.check_perform_device_sampling(
+        unsupported,
+        is_decode=True,
+        has_structured_outputs=True,
+    )
+    assert TTModelRunner.check_perform_device_sampling(
+        supported,
+        is_decode=True,
+        has_structured_outputs=True,
+    )
+
+
+def test_structured_prefill_remains_host_sampled_with_device_grammar_capability():
+    runner = _device_sampling_runner(supports_device_grammar=True)
+
+    assert not TTModelRunner.check_perform_device_sampling(
+        runner,
+        is_decode=False,
+        has_structured_outputs=True,
+    )
+
+
+def test_structured_decode_remains_host_sampled_with_async_scheduling():
+    runner = _device_sampling_runner(supports_device_grammar=True)
+    runner.scheduler_config.async_scheduling = True
+
+    assert not TTModelRunner.check_perform_device_sampling(
+        runner,
+        is_decode=True,
+        has_structured_outputs=True,
+    )
+
+
+def test_structured_device_logprobs_remain_host_sampled():
+    runner = _device_sampling_runner(supports_device_grammar=True)
+    runner.input_batch.max_num_logprobs = 0
+
+    assert not TTModelRunner.check_perform_device_sampling(
+        runner,
+        is_decode=True,
+        has_structured_outputs=True,
+    )
+
+
+def test_model_load_downgrades_device_grammar_for_incompatible_runtime(
+    monkeypatch,
+):
+    class Loader:
+        def __init__(self, _load_config):
+            pass
+
+        def load_model(self, **_kwargs):
+            return SimpleNamespace(
+                device_grammar_enabled=False,
+                sample_decode_on_device=lambda *_args, **_kwargs: None,
+            )
+
+    monkeypatch.setattr(
+        "vllm_tt_plugin.model_runner.TTModelLoader",
+        Loader,
+    )
+    runner = SimpleNamespace(
+        load_config=object(),
+        vllm_config=object(),
+        model_config=object(),
+        supports_device_grammar=True,
+    )
+
+    TTModelRunner.load_model(runner)
+
+    assert runner.supports_device_grammar is False
+
+
+def test_model_load_activates_device_grammar_runtime(monkeypatch):
+    events = []
+
+    class Model:
+        device_grammar_enabled = False
+
+        def enable_device_grammar(self):
+            events.append("activate")
+            self.device_grammar_enabled = True
+
+        def sample_decode_on_device(self, *_args, **_kwargs):
+            return None
+
+    class Loader:
+        def __init__(self, _load_config):
+            pass
+
+        def load_model(self, **_kwargs):
+            return Model()
+
+    monkeypatch.setattr(
+        "vllm_tt_plugin.model_runner.TTModelLoader",
+        Loader,
+    )
+    runner = SimpleNamespace(
+        load_config=object(),
+        vllm_config=object(),
+        model_config=object(),
+        supports_device_grammar=True,
+    )
+
+    TTModelRunner.load_model(runner)
+
+    assert events == ["activate"]
+    assert runner.supports_device_grammar is True
+
+
+def test_runner_poison_rejects_all_later_work():
+    model_poisoned = []
+    runner = SimpleNamespace(
+        model=SimpleNamespace(
+            poison_deferred_device_sampling=lambda: model_poisoned.append(True)
+        ),
+        _device_grammar_poisoned=False,
+    )
+
+    TTModelRunner._poison_device_grammar(runner)
+
+    assert runner._device_grammar_poisoned is True
+    assert model_poisoned == [True]
+    with pytest.raises(RuntimeError, match="reconstruct the model runner"):
+        TTModelRunner._raise_if_device_grammar_poisoned(runner)
+
+
+def test_front_packed_grammar_remap_failure_poisons_runner():
+    poisoned = []
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("missing grammar row")
+        ),
+        _poison_device_grammar=lambda: poisoned.append(True),
+    )
+    fwd = _sync_forward(
+        _model_input(
+            perform_device_sampling=True,
+            defer_device_sampling=True,
+            structured_output_req_ids=frozenset({"req-0"}),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="missing grammar row"):
+        TTModelRunner._finish_front_packed_sync(
+            runner,
+            _grammar(1),
+            fwd=fwd,
+        )
+
+    assert poisoned == [True]
+
+
+def test_trace_all_warmup_prepares_decode_before_prefill_capture(monkeypatch):
+    events = []
+
+    class Model:
+        already_warmed_up_prefill = True
+
+        def warmup_model_prefill(self, *, enable_trace, **_kwargs):
+            events.append(("prefill", enable_trace))
+
+        def warmup_model_decode(self, *, enable_trace, **kwargs):
+            events.append(
+                (
+                    "decode",
+                    enable_trace,
+                    kwargs.get("sampling_trace_variants_prepared", False),
+                )
+            )
+
+        def prepare_device_grammar_decode_trace_warmup(self, **_kwargs):
+            events.append(("prepare-decode",))
+            return True
+
+        def capture_prepared_device_grammar_decode_trace(self):
+            events.append(("capture-decode",))
+
+    monkeypatch.setattr(TTPlatform, "sample_on_device_mode", "decode_only")
+    runner = SimpleNamespace(
+        trace_mode="all",
+        supports_device_grammar=True,
+        model=Model(),
+        kv_caches=object(),
+        tt_max_batch_size=4,
+        max_num_blocks_per_req=8,
+    )
+
+    TTModelRunner.warmup_model(runner)
+
+    assert events == [
+        ("prefill", False),
+        ("decode", False, False),
+        ("prepare-decode",),
+        ("prefill", True),
+        ("capture-decode",),
+        ("decode", True, True),
+    ]
+
+
 # --------------------------------------------------------------------------
 # _reorder_grammar_bitmask dispatch (lane vs non-DP vs none)
 # --------------------------------------------------------------------------
@@ -100,26 +408,46 @@ def test_reorder_grammar_bitmask_none_returns_none():
     assert result is None
 
 
-def test_reorder_grammar_bitmask_lane_path_delegates_to_slot_reorder():
-    """``lane_total`` selects the full-slot lane reorder, not the non-DP one."""
-    calls: list[tuple] = []
-    sentinel = torch.tensor([[7, 7]], dtype=torch.int32)
+def test_reorder_grammar_bitmask_requires_mask_for_structured_forward():
+    runner = SimpleNamespace()
+    model_input = _model_input(structured_output_req_ids=frozenset({"req-0"}))
 
-    def slot_grammar_bitmask(grammar_output, batch_length):
-        calls.append((grammar_output, batch_length))
-        return sentinel
+    with pytest.raises(RuntimeError, match="grammar output is absent.*req-0"):
+        TTModelRunner._reorder_grammar_bitmask(
+            runner,
+            None,
+            model_input,
+            lane_total=None,
+        )
 
+
+def test_reorder_grammar_bitmask_lane_path_uses_submitted_row_snapshot():
     runner = SimpleNamespace(
-        lane_batch=SimpleNamespace(slot_grammar_bitmask=slot_grammar_bitmask)
+        lane_batch=SimpleNamespace(
+            slot_grammar_bitmask=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("sample-time mapping must not read mutable lane state")
+            )
+        )
     )
-    grammar = _grammar(1)
+    grammar = GrammarOutput(
+        structured_output_request_ids=["req-1"],
+        grammar_bitmask=np.array([[7, 8]], dtype=np.int32),
+    )
+    model_input = _model_input(
+        input_tokens=torch.zeros((3, 1), dtype=torch.int32),
+        row_req_ids=None,
+        grammar_row_req_ids=("req-0", None, "req-1"),
+        structured_output_req_ids=frozenset({"req-1"}),
+    )
 
     result = TTModelRunner._reorder_grammar_bitmask(
-        runner, grammar, _model_input(), lane_total=32
+        runner,
+        grammar,
+        model_input,
+        lane_total=3,
     )
 
-    assert result is sentinel
-    assert calls == [(grammar, 32)]
+    assert result.tolist() == [[-1, -1], [-1, -1], [7, 8]]
 
 
 def test_reorder_grammar_bitmask_non_dp_path_uses_front_packed_reorder():
@@ -133,6 +461,7 @@ def test_reorder_grammar_bitmask_non_dp_path_uses_front_packed_reorder():
     model_input = _model_input(
         input_tokens=torch.zeros((2, 1), dtype=torch.int32),
         row_req_ids=["req-0", "req-1"],
+        structured_output_req_ids=frozenset({"req-1"}),
     )
 
     result = TTModelRunner._reorder_grammar_bitmask(
@@ -160,6 +489,7 @@ def test_reorder_grammar_bitmask_non_dp_path_ignores_filtered_rows():
     model_input = _model_input(
         input_tokens=torch.zeros((2, 8), dtype=torch.int32),
         row_req_ids=["req-0", "req-2"],
+        structured_output_req_ids=frozenset({"req-2"}),
     )
 
     result = TTModelRunner._reorder_grammar_bitmask(
@@ -234,6 +564,61 @@ def test_finish_async_decode_sets_bitmask_when_grammar_present():
     assert len(calls) == 1 and torch.equal(calls[0], bitmask)
 
 
+def test_finish_async_decode_allows_missing_stale_grammar_rows():
+    calls: list[torch.Tensor] = []
+    wrapper = SimpleNamespace(set_grammar_bitmask=lambda bm: calls.append(bm))
+    runner = SimpleNamespace()
+    runner._reorder_grammar_bitmask = partial(
+        TTModelRunner._reorder_grammar_bitmask,
+        runner,
+    )
+    model_input = _model_input(
+        input_tokens=torch.zeros((2, 1), dtype=torch.int32),
+        row_req_ids=["stale", "active"],
+        grammar_row_req_ids=("stale", "active"),
+        structured_output_req_ids=frozenset({"stale", "active"}),
+    )
+    grammar = GrammarOutput(
+        structured_output_request_ids=["active"],
+        grammar_bitmask=np.array([[7, 8]], dtype=np.int32),
+    )
+
+    result = TTModelRunner._finish_async_decode(
+        runner,
+        grammar,
+        wrapper=wrapper,
+        model_input=model_input,
+        lane_total=None,
+    )
+
+    assert result is wrapper
+    assert calls[0].tolist() == [[-1, -1], [7, 8]]
+
+
+def test_finish_async_decode_allows_all_structured_rows_to_be_stale():
+    calls: list = []
+    wrapper = SimpleNamespace(set_grammar_bitmask=lambda bm: calls.append(bm))
+    runner = SimpleNamespace()
+    runner._reorder_grammar_bitmask = partial(
+        TTModelRunner._reorder_grammar_bitmask,
+        runner,
+    )
+    model_input = _model_input(
+        structured_output_req_ids=frozenset({"stale"}),
+    )
+
+    result = TTModelRunner._finish_async_decode(
+        runner,
+        None,
+        wrapper=wrapper,
+        model_input=model_input,
+        lane_total=None,
+    )
+
+    assert result is wrapper
+    assert calls == []
+
+
 # --------------------------------------------------------------------------
 # _finish_front_packed_sync / _finish_lane_sync (grammar before sampling)
 # --------------------------------------------------------------------------
@@ -249,6 +634,159 @@ def _sync_forward(model_input: TTModelInput) -> _SyncForward:
         perform_device_sampling=False,
         is_decode=True,
     )
+
+
+def test_sample_sync_forward_consumes_deferred_grammar_before_extraction():
+    bitmask = torch.tensor([[3, 4]], dtype=torch.int32)
+    model_input = _model_input(
+        perform_device_sampling=True,
+        grammar_bitmask=[bitmask],
+        defer_device_sampling=True,
+    )
+    submission = object()
+    seen: dict = {}
+
+    def complete_deferred(received_submission, received_input):
+        seen["submission"] = received_submission
+        seen["bitmask"] = received_input.grammar_bitmask[0]
+        return SimpleNamespace(tt_out=torch.tensor([[42]]), tt_log_probs=None)
+
+    def get_output_tokens(**kwargs):
+        seen["extraction_input"] = kwargs["model_input"]
+        return [kwargs["tt_out"]], [None]
+
+    runner = SimpleNamespace(
+        async_decode=SimpleNamespace(
+            complete_deferred_device_sampling=complete_deferred
+        ),
+        _get_output_tokens=get_output_tokens,
+    )
+    fwd = replace(
+        _sync_forward(model_input),
+        perform_device_sampling=True,
+        decode_submission=submission,
+    )
+
+    sampled, _ = TTModelRunner._sample_sync_forward(runner, fwd)
+
+    assert seen["submission"] is submission
+    assert seen["bitmask"] is bitmask
+    assert seen["extraction_input"].grammar_bitmask == [None]
+    assert seen["extraction_input"].defer_device_sampling is False
+    assert sampled[0].tolist() == [[42]]
+
+
+def test_deferred_device_sampling_transports_sample_time_grammar():
+    calls: list[tuple] = []
+    device_params = object()
+    raw_logits = object()
+    sampled = torch.tensor([[17]], dtype=torch.int32)
+
+    def sample_decode_on_device(tt_out, *, sampling_params, grammar_bitmask):
+        calls.append((tt_out, sampling_params, grammar_bitmask))
+        return sampled
+
+    runner = SimpleNamespace(
+        model=SimpleNamespace(sample_decode_on_device=sample_decode_on_device)
+    )
+    controller = TTAsyncDecodeController(runner)
+    sampling_params = SimpleNamespace(enable_log_probs=torch.tensor([False]))
+    submission = TTDecodeSubmission(
+        tt_out=raw_logits,
+        read_events=None,
+        batch_size_per_dp=[1],
+        sampling_params=sampling_params,
+        perform_device_sampling=True,
+        device_sampling_params=device_params,
+        deferred_device_sampling=True,
+    )
+    bitmask = torch.tensor([[5, 6]], dtype=torch.int32)
+    model_input = _model_input(
+        perform_device_sampling=True,
+        grammar_bitmask=[bitmask],
+        defer_device_sampling=True,
+    )
+
+    finalized = controller.complete_deferred_device_sampling(
+        submission,
+        model_input,
+    )
+
+    assert calls == [(raw_logits, device_params, bitmask)]
+    assert finalized.tt_out is sampled
+    assert controller.device_grammar_sample_count == 1
+
+
+def test_deferred_device_sampling_rejects_missing_sample_time_grammar():
+    poisoned = []
+    runner = SimpleNamespace(
+        model=SimpleNamespace(
+            sample_decode_on_device=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("device sampler must not run without grammar")
+            )
+        ),
+        _poison_device_grammar=lambda: poisoned.append(True),
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller._decode_chain_valid = True
+    controller._submitted_page_tables = (torch.zeros((1, 1)),)
+    submission = TTDecodeSubmission(
+        tt_out=object(),
+        read_events=None,
+        batch_size_per_dp=[1],
+        sampling_params=SimpleNamespace(enable_log_probs=torch.tensor([False])),
+        perform_device_sampling=True,
+        device_sampling_params=object(),
+        deferred_device_sampling=True,
+    )
+
+    with pytest.raises(RuntimeError, match="without a sample-time grammar"):
+        controller.complete_deferred_device_sampling(
+            submission,
+            _model_input(
+                perform_device_sampling=True,
+                grammar_bitmask=[None],
+                defer_device_sampling=True,
+            ),
+        )
+
+    assert controller._decode_chain_valid is False
+    assert controller._submitted_page_tables is None
+    assert poisoned == [True]
+
+
+def test_deferred_device_sampling_no_output_invalidates_decode_chain():
+    poisoned = []
+    runner = SimpleNamespace(
+        model=SimpleNamespace(sample_decode_on_device=lambda *_args, **_kwargs: None),
+        _poison_device_grammar=lambda: poisoned.append(True),
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller._decode_chain_valid = True
+    controller._submitted_page_tables = (torch.zeros((1, 1)),)
+    submission = TTDecodeSubmission(
+        tt_out=object(),
+        read_events=None,
+        batch_size_per_dp=[1],
+        sampling_params=SimpleNamespace(enable_log_probs=torch.tensor([False])),
+        perform_device_sampling=True,
+        device_sampling_params=object(),
+        deferred_device_sampling=True,
+    )
+
+    with pytest.raises(RuntimeError, match="produced no output"):
+        controller.complete_deferred_device_sampling(
+            submission,
+            _model_input(
+                perform_device_sampling=True,
+                grammar_bitmask=[torch.full((1, VOCAB_WORDS), -1, dtype=torch.int32)],
+                defer_device_sampling=True,
+            ),
+        )
+
+    assert controller._decode_chain_valid is False
+    assert controller._submitted_page_tables is None
+    assert poisoned == [True]
 
 
 def test_finish_front_packed_sync_applies_grammar_before_sampling():
@@ -371,7 +909,9 @@ def test_finish_lane_sync_builds_req_ids_in_scheduled_row_order():
         _grammar(1),
         tt_out=object(),
         tt_log_probs=None,
-        model_input=_model_input(),
+        model_input=_model_input(
+            grammar_row_req_ids=(None, "req-a", None, None, "req-d"),
+        ),
         scheduled_rows=[4, 1],
         is_decode=True,
         lane_total=32,
@@ -381,3 +921,65 @@ def test_finish_lane_sync_builds_req_ids_in_scheduled_row_order():
     # req_ids follow scheduled_rows order, not slot order.
     assert captured["req_ids"] == ["req-d", "req-a"]
     assert output.sampled.tolist() == [[11], [12]]
+
+
+def test_finish_lane_sync_consumes_device_grammar_before_slot_extraction():
+    bitmask = torch.tensor([[3, 4], [5, 6]], dtype=torch.int32)
+    submission = object()
+    seen: dict = {}
+
+    def complete_deferred(received_submission, received_input):
+        seen["submission"] = received_submission
+        seen["bitmask"] = received_input.grammar_bitmask[0]
+        return SimpleNamespace(
+            tt_out=torch.tensor([11, 12], dtype=torch.int32),
+            tt_log_probs=None,
+        )
+
+    def extract_output(
+        _runner,
+        tt_out,
+        _tt_log_probs,
+        model_input,
+        _scheduled_rows,
+        *,
+        is_decode,
+    ):
+        assert is_decode
+        assert model_input.grammar_bitmask == [None]
+        assert model_input.defer_device_sampling is False
+        return tt_out.reshape(2, 1), None
+
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=lambda model_input, _grammar_output, **_kwargs: (
+            replace(model_input, grammar_bitmask=[bitmask])
+        ),
+        async_decode=SimpleNamespace(
+            complete_deferred_device_sampling=complete_deferred
+        ),
+        lane_batch=SimpleNamespace(
+            extract_output=extract_output,
+            req_ids={0: "req-a", 1: "req-b"},
+        ),
+        apply_and_build_runner_output=lambda sampled, _logprobs, **_kwargs: sampled,
+    )
+
+    output = TTModelRunner._finish_lane_sync(
+        runner,
+        _grammar(2),
+        tt_out=object(),
+        tt_log_probs=None,
+        model_input=_model_input(
+            perform_device_sampling=True,
+            defer_device_sampling=True,
+            grammar_row_req_ids=("req-a", "req-b"),
+        ),
+        scheduled_rows=[0, 1],
+        is_decode=True,
+        lane_total=2,
+        decode_submission=submission,
+    )
+
+    assert seen["submission"] is submission
+    assert seen["bitmask"] is bitmask
+    assert output.tolist() == [[11], [12]]

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -1,9 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 Tenstorrent USA, Inc.
 
+import pytest
 import torch
 
-from vllm_tt_plugin.structured_output import reorder_grammar_bitmask_for_tt_batch
+from vllm_tt_plugin.structured_output import (
+    capture_structured_decode_request_ids,
+    reorder_grammar_bitmask_for_tt_batch,
+)
+
+
+def test_capture_structured_decode_request_ids_requires_every_submitted_row():
+    with pytest.raises(RuntimeError, match="absent.*req-1"):
+        capture_structured_decode_request_ids(
+            {"req-0", "req-1"},
+            ["req-0", None],
+        )
 
 
 def test_reorder_grammar_bitmask_uses_forward_row_order():
@@ -99,3 +111,42 @@ def test_reorder_grammar_bitmask_handles_forward_narrower_than_batch():
         reordered,
         torch.tensor([[-1, -1], [10, 11]], dtype=torch.int32),
     )
+
+
+def test_reorder_grammar_bitmask_rejects_missing_local_structured_row():
+    bitmask = torch.tensor([[10, 11]], dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="missing TT batch request IDs.*req-1"):
+        reorder_grammar_bitmask_for_tt_batch(
+            bitmask=bitmask,
+            structured_output_request_ids=["req-0"],
+            row_req_ids=["req-0", "req-1"],
+            batch_length=2,
+            expected_structured_output_request_ids={"req-0", "req-1"},
+        )
+
+
+def test_reorder_grammar_bitmask_rejects_duplicate_source_request_id():
+    bitmask = torch.tensor([[10, 11], [20, 21]], dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="duplicate request IDs.*req-0"):
+        reorder_grammar_bitmask_for_tt_batch(
+            bitmask=bitmask,
+            structured_output_request_ids=["req-0", "req-0"],
+            row_req_ids=["req-0"],
+            batch_length=1,
+            expected_structured_output_request_ids={"req-0"},
+        )
+
+
+def test_reorder_grammar_bitmask_rejects_expected_id_absent_from_snapshot():
+    bitmask = torch.tensor([[10, 11]], dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="absent from the submitted TT row"):
+        reorder_grammar_bitmask_for_tt_batch(
+            bitmask=bitmask,
+            structured_output_request_ids=["req-0"],
+            row_req_ids=["replacement", None],
+            batch_length=2,
+            expected_structured_output_request_ids={"req-0"},
+        )

--- a/tests/tt/test_structured_output_dp1.py
+++ b/tests/tt/test_structured_output_dp1.py
@@ -30,6 +30,7 @@ async def _send_choice_request(async_client, model: str, request_id: int) -> str
         ],
         max_completion_tokens=8,
         temperature=0,
+        presence_penalty=0.5,
         extra_body={"structured_outputs": {"choice": CHOICES}},
     )
     content = response.choices[0].message.content
@@ -101,11 +102,12 @@ async def _send_plain_request(async_client, model: str, request_id: int) -> str:
     return content
 
 
-def test_dp1_full_capacity_mixes_structured_and_plain_requests(
+def _run_mixed_request_wave(
     tt_server,
-    tt_model_name,
-    max_batch_size,
-):
+    tt_model_name: str,
+    max_batch_size: int,
+    wave: int,
+) -> None:
     async def _run() -> None:
         async_client = tt_server.get_async_client()
         request_count = min(max_batch_size, 32)
@@ -115,17 +117,33 @@ def test_dp1_full_capacity_mixes_structured_and_plain_requests(
             _send_json_request,
             _send_plain_request,
         ]
-
+        request_ids = range(wave * request_count, (wave + 1) * request_count)
         tasks = [
-            senders[request_id % len(senders)](
+            senders[(request_id + wave) % len(senders)](
                 async_client,
                 tt_model_name,
                 request_id,
             )
-            for request_id in range(request_count)
+            for request_id in request_ids
         ]
 
         results = await asyncio.gather(*tasks)
         assert len(results) == request_count
 
     asyncio.run(_run())
+
+
+def test_dp1_full_capacity_mixes_structured_and_plain_requests_first_wave(
+    tt_server,
+    tt_model_name,
+    max_batch_size,
+):
+    _run_mixed_request_wave(tt_server, tt_model_name, max_batch_size, wave=0)
+
+
+def test_dp1_full_capacity_reuses_slots_for_second_mixed_wave(
+    tt_server,
+    tt_model_name,
+    max_batch_size,
+):
+    _run_mixed_request_wave(tt_server, tt_model_name, max_batch_size, wave=1)


### PR DESCRIPTION
## TL;DR

Adds plugin-side support for TT on-device grammar (structured-output) decode sampling: deferred sampling so vLLM's grammar bitmask can be built after `execute_model()`, packed-mask plumbing into the TT sampler, and capability gating instead of a model-name allowlist. Pairs with tenstorrent/tt-metal#55892.

## Usage

Quick overview:

```bash
python examples/server_example_tt.py \
  --model Qwen/Qwen2.5-7B-Instruct \
  --max_num_seqs 32 \
  --block_size 64 \
  --guided-decoding-backend xgrammar \
  --max_model_len 4096 \
  --additional-config '{"tt": {"sample_on_device_mode": "decode_only"}}'

curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2.5-7B-Instruct",
    "messages": [{"role": "user", "content": "Return a JSON object with fields name and age."}],
    "temperature": 0.7,
    "top_p": 0.9,
    "top_k": 20,
    "max_tokens": 64,
    "guided_json": {
      "type": "object",
      "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
      "required": ["name", "age"]
    }
  }'
```

No request-shape changes are required from callers; when the active generator declares `supports_device_grammar` and the batch is decode-only/eligible, the grammar bitmask vLLM already builds for xgrammar is packed and forwarded to the device sampler instead of being applied on host.

## Details

vLLM produces the grammar bitmask only at sample time, after `execute_model()`/forward has already run, so this PR moves grammar-eligible batches to a deferred sampling model: the plugin runs forward first, then calls `sample_decode_on_device(...)` with the packed mask once it is available. Capability is read off the active generator's `model_capabilities` dict instead of an allowlist, so any future generator that implements the same deferred/trace contract is included for free. Host fallback stays the default path for anything not eligible (structured prefill, async scheduling, logprobs, unsupported generators, mixed-eligibility batches).

- **`src/vllm_tt_plugin/async_decode.py`** - Extends async decode-reload planning to account for deferred, grammar-aware sampling and its single-owner logits payload.
- **`src/vllm_tt_plugin/config.py`** - Adds configuration surface for enabling device-grammar sampling and its decode-only mode.
- **`src/vllm_tt_plugin/input_batch.py`** - Threads grammar bitmask state through the lane input batch alongside existing sampling-parameter tracking.
- **`src/vllm_tt_plugin/model_input.py`** - Carries the packed grammar bitmask through the model-input construction path.
- **`src/vllm_tt_plugin/model_runner.py`** - Wires deferred decode sampling into the runner: builds/validates the packed mask, calls `sample_decode_on_device`, and falls back to host sampling when the batch is ineligible.
- **`src/vllm_tt_plugin/platform.py`** - Exposes/validates the new device-grammar capability and configuration at the platform boundary.
- **`src/vllm_tt_plugin/structured_output.py`** - Detects grammar-eligible batches, packs vLLM's raw bitmask into the device format, and routes eligible/ineligible requests accordingly.
- **`docs/SCHEDULING.md`** - Documents the deferred sampling contract and its scheduling implications.
- **`README.md`**, **`AGENTS.md`** - Documents the feature and updates agent-facing repo guidance.
- **`.gitignore`** - Ignores locally generated runtime artifacts (`generated/`) produced by device/fabric tooling during local runs.
- **`tests/test_sample_time_grammar.py`** - New/expanded coverage for packed-mask construction, eligibility detection, and deferred-sampling routing (largest test addition).
- **`tests/test_lane_input_batch.py`**, **`tests/test_model_runner.py`**, **`tests/test_structured_output.py`**, **`tests/test_config.py`**, **`tests/test_block_request_validation.py`**, **`tests/tt/test_structured_output_dp1.py`** - Updated/added unit coverage for the touched runner, batch, config, and structured-output paths.

## Related Artifacts

Pairs with tenstorrent/tt-metal#55892 (device-side grammar-mask sampling, sampler, and trace support). This plugin PR depends on that PR's device-side contract (`sample_decode_on_device`, packed grammar-mask format, capability flag) but does not require it to merge first for host-only review; CI steps that depend on the paired plugin tests are temporarily disabled on the tt-metal side until this PR is published.

## Validation

Environment: `~/tt-metal/.venv` (tt-metal's real Python env, pinned `vllm==0.26.0`, plugin installed editable via `uv pip install --no-deps -e .`).

```text
$ ~/tt-metal/.venv/bin/python -m pytest tests/ --ignore=tests/tt -q
398 passed, 16 warnings in 13.76s
```

- [x] Full plugin host unit suite (excluding `tests/tt`, which requires a live vLLM server against real hardware): **398 passed, 0 failed**.
- [ ] vLLM Model Tests CI

## Checklist

- [x] This PR is focused on a single logical change.
- [x] I added or updated tests where applicable.
- [ ] I ran the relevant checks such as unit tests and Actions and recorded them above.
- [x] I updated documentation where applicable.
